### PR TITLE
added requested_product_id to gcp_connection csp settings to allow se…

### DIFF
--- a/docs/data-sources/megaport_partner_port.md
+++ b/docs/data-sources/megaport_partner_port.md
@@ -29,6 +29,19 @@ data "megaport_partner_port" "aws_test_sydney_2" {
 }
 ```
 
+## Example Usage (Google Connection)
+```
+data megaport_location equinix_se2 {
+  name = "Equinix SE2"
+}
+
+data "megaport_partner_port" "google_test_seattle_us_1" {
+  company_name = "Google Inc"
+  product_name = "Seattle (sea-zone1-86)"
+  location_id = data.megaport_location.equinix_se2.id
+}
+```
+
 ## Argument Reference
  - `connect_type` - (Optional) The type of connection you will create. In the case of AWS, specify `AWS` for a Hosted VIF or `AWSHC` for a Hosted Connection).
  - `company_name` - (Optional) The company name to search for (from the company's Megaport Marketplace profile).

--- a/docs/resources/megaport_gcp_connection.md
+++ b/docs/resources/megaport_gcp_connection.md
@@ -2,8 +2,8 @@
 Adds a connection to Google Compute Cloud on a Port or an MCR. 
 
 To provision this connection, you need a partner key from the Google Cloud Console. You can get this key by adding a new VLAN attachment and selecting "Megaport" as the interconnect partner.
- 
-## Example Usage
+
+## Example Usage (Automatically Select Google Port Location)
 ```
 data megaport_location glb_switch_sydney {
   name = "Global Switch Sydney West"
@@ -30,6 +30,44 @@ resource megaport_gcp_connection test {
 }
 ```
 
+## Example Usage (Specify Google Port Location)
+```
+data megaport_location glb_switch_sydney {
+  name = "Global Switch Sydney West"
+}
+
+data megaport_location nextdc_s1 {
+  name = "NextDC S1"
+}
+
+data megaport_partner_port google_sydney_1 {
+  company_name = "Google Inc"
+  product_name = "Sydney (syd-zone1-1660)"
+  location_id = data.megaport_location.nextdc_s1.id
+}
+
+resource megaport_port my_port {
+    port_name       = "My Example Port"
+    port_speed      = 1000
+    location_id     = data.megaport_location.glb_switch_sydney.id
+}
+
+resource megaport_gcp_connection test {
+  vxc_name = "My Example Google Connection"
+  rate_limit = 1000
+
+  a_end {
+    requested_vlan = 191
+  }
+
+  csp_settings {
+    attached_to = megaport_port.my_port.id
+    pairing_key = "19f9d93e-05c8-4c18-81fc-095d679ff645/australia-southeast-1/1"
+    requested_product_id = data.megaport_partner_port.google_sydney_1.id
+  }
+}
+```
+
 ## Argument Reference
 - `vxc_name` - (Required) The name of the VXC.
 - `rate_limit` - (Required) The speed of the VXC in Mbps.
@@ -38,6 +76,7 @@ resource megaport_gcp_connection test {
 - `csp_settings`:
     - `attached_to` - (Required) The identifier of the product (Port/MCR) to attach the connection to.
     - `pairing_key` - (Required) The pairing key for the new GCP connection.
+    - `requested_product_id` - (Optional) The partner port location you want to connect to.
 
 ## Attributes Reference
 - `uid` - The identifier of the Port.

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,6 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.9.1
 	github.com/megaport/megaportgo v0.1.2-beta
 )
+
+// Will remove this and reference updated version once https://github.com/megaport/megaportgo/pull/2 is merged
+replace github.com/megaport/megaportgo => github.com/kdw174/megaportgo v0.1.3-beta

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,5 @@ go 1.13
 require (
 	github.com/engi-fyi/go-credentials v1.2.1
 	github.com/hashicorp/terraform-plugin-sdk v1.9.1
-	github.com/megaport/megaportgo v0.1.2-beta
+	github.com/megaport/megaportgo v0.1.3-beta
 )
-
-// Will remove this and reference updated version once https://github.com/megaport/megaportgo/pull/2 is merged
-replace github.com/megaport/megaportgo => github.com/kdw174/megaportgo v0.1.3-beta

--- a/resource_megaport/resource_megaport_azure_connection.go
+++ b/resource_megaport/resource_megaport_azure_connection.go
@@ -15,10 +15,11 @@
 package resource_megaport
 
 import (
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/megaport/megaportgo/vxc"
 	"github.com/megaport/terraform-provider-megaport/schema_megaport"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"time"
 )
 
 func MegaportAzureConnection() *schema.Resource {
@@ -58,11 +59,10 @@ func resourceMegaportAzureConnectionCreate(d *schema.ResourceData, m interface{}
 	}
 
 	peers := map[string]bool{
-		"private": private,
-		"public": public,
+		"private":   private,
+		"public":    public,
 		"microsoft": microsoft,
 	}
-
 
 	if aEndConfiguration, ok := d.GetOk("a_end"); ok {
 		if newVlan, aOk := aEndConfiguration.(*schema.Set).List()[0].(map[string]interface{})["requested_vlan"].(int); aOk {

--- a/schema_megaport/megaport_gcp_connection.go
+++ b/schema_megaport/megaport_gcp_connection.go
@@ -64,7 +64,7 @@ func ResourceGcpConnectionVXCSchema() map[string]*schema.Schema {
 		},
 		"csp_settings": ResourceGcpConnectionCspSettings(),
 		"vxc_internal_type": {
-			Type:	  schema.TypeString,
+			Type:     schema.TypeString,
 			Optional: true,
 			Default:  "gcp",
 		},
@@ -85,6 +85,11 @@ func ResourceGcpConnectionCspSettings() *schema.Schema {
 				"pairing_key": {
 					Type:     schema.TypeString,
 					Required: true,
+					ForceNew: true,
+				},
+				"requested_product_id": {
+					Type:     schema.TypeString,
+					Optional: true,
 					ForceNew: true,
 				},
 			},


### PR DESCRIPTION
…lecting the google b end location

## Description

Adds a new optional parameter, "requested_product_id", to megaport_gcp_connection csp settings that allows specifying the Google b end port location. This is a ProductUID and leverages the existing megaport_partner_port data source as a lookup. 

This PR is blocked by the dependency changes in megaportgo getting merged: https://github.com/megaport/megaportgo/pull/2

Fixes https://github.com/megaport/terraform-provider-megaport/issues/4

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# Contributor Agreement

Lodging this Pull Request (PR) indicates agreement with the project's 
(Contributor License Agreement)[https://github.com/megaport/terraform-provider-megaport/wiki/Megaport_Contributor_Licence_Agreement.md].

Please read the Contributor Licence Agreement (CLA) and affirm your acceptance here:

I have read and accept the CLA
