### PR TITLE
Add optional connection_name attribute for AWS connections

### DIFF
--- a/docs/resources/megaport_aws_connection.md
+++ b/docs/resources/megaport_aws_connection.md
@@ -61,6 +61,7 @@ resource "megaport_aws_connection" "aws_vxc" {
     - `customer_ip` - (Optional) The internal tunnel IP for the Megaport end.
     - `amazon_ip` - (Optional) The internal tunnel IP for the Amazon end.
     - `hosted_connection` - (Optional) If set to true, an AWS Hosted Connection will be created with a dedicated Direct Connect. Otherwise, a Hosted VIF will be created.
+    - `connection_name` - (Optional) The label for the connection in AWS
 
 ## Attributes Reference
 - `uid` - The identifier of the Port.

--- a/resource_megaport/resource_megaport_aws_connection.go
+++ b/resource_megaport/resource_megaport_aws_connection.go
@@ -62,6 +62,7 @@ func resourceMegaportAWSConnectionCreate(d *schema.ResourceData, m interface{}) 
 			ConnectType:       connectType,
 			Type:              cspSettings["visibility"].(string),
 			OwnerAccount:      cspSettings["amazon_account"].(string),
+			ConnectionName:    cspSettings["connection_name"].(string),
 		},
 	}
 

--- a/schema_megaport/megaport_aws_connection.go
+++ b/schema_megaport/megaport_aws_connection.go
@@ -142,6 +142,12 @@ func ResourceAwsConnectionCspSettings() *schema.Schema {
 					Default:  false,
 					ForceNew: true,
 				},
+				"connection_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+					Default:  "",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Description

Add a connection_name attribute for AWS connection

Depends on megaport/megaportgo/pull/4

Fixes #17

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Contributor Agreement

I have read and accept the CLA