### PR TITLE
Add support for Port Diversity

### DIFF
--- a/data_megaport/data_megaport_port.go
+++ b/data_megaport/data_megaport_port.go
@@ -55,6 +55,7 @@ func dataMegaportPortRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("lag_id", portDetails.LAGID)
 	d.Set("locked", portDetails.Locked)
 	d.Set("admin_locked", portDetails.AdminLocked)
+	d.Set("diversity_zone", portDetails.DiversityZone)
 
 	return nil
 }

--- a/docs/data-sources/megaport_port.md
+++ b/docs/data-sources/megaport_port.md
@@ -31,3 +31,4 @@ The following arguments are supported:
  - `lag_id` - The LAG identifier.
  - `locked` - Indicates whether the resource has been locked by a user.
  - `admin_locked` - Indicates whether the resource has been locked by an administrator.
+ - `diversity_zone` - The Diversity Zone in which the port is deployed (`red` or `blue` or undefined for sites where zones aren't available).

--- a/docs/guides/example_single_zoned_port.md
+++ b/docs/guides/example_single_zoned_port.md
@@ -1,0 +1,42 @@
+---
+page_title: "Single Zoned Port"
+subcategory: "Examples"
+---
+
+# Single Port
+This will provision a single Megaport in the Blue Diversity Zone. 
+
+Replace the `username`, `password` and optional `mfa_otp_key` with your own credentials.
+
+```
+terraform {
+  required_providers {
+    megaport = {
+      source  = "megaport/megaport"
+      version = ">=0.2.11"
+    }
+  }
+}
+
+provider "megaport" {
+  username              = "my.test.user@example.org"
+  password              = "n0t@re4lPassw0rd"
+  mfa_otp_key           = "ABCDEFGHIJK01234"
+  accept_purchase_terms = true
+  delete_ports          = true
+  environment           = "staging"
+}
+
+data "megaport_location" "bne_nxt1" {
+  name    = "NextDC B1"
+  has_mcr = false
+}
+
+resource "megaport_port" "port" {
+  port_name   = "Terraform Example - Port"
+  port_speed  = 1000
+  location_id = data.megaport_location.bne_nxt1.id
+  term        = 1
+  diversity_zone = "blue"
+}
+```

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -22,6 +22,7 @@ provider "megaport" {
 
 Here's a description of each example:
 1. [single_port](example_single_port): Create a Single Megaport.
+1. [single_zoned_port](example_single_zoned_port): Create a Single Megaport in specified Zone.
 1. [two_ports_and_vxc](example_two_ports_and_vxc): Provision two Megaports in different locations linked by a VXC (Virtual Cross Connect)
 1. [lag_port](example_lag_port): Create a LAG Port.
 1. [multicloud_aws_azure](example_multicloud_aws_azure): Create a fully functional example network linking AWS & Azure 

--- a/docs/resources/megaport_port.md
+++ b/docs/resources/megaport_port.md
@@ -27,6 +27,25 @@ resource "megaport_port" "port" {
 This example results in the creation of a single Port located at NextDC Brisbane 1, under a 12 month term with a Port
 speed of 10 Gbps.
 
+## Example Usage (Single with Zone)
+```
+data "megaport_location" "bne_nxt1" {
+  name    = "NextDC B1"
+  has_mcr = false
+}
+
+resource "megaport_port" "port" {
+  port_name   = "Terraform Example - Port"
+  port_speed  = 10000
+  location_id = data.megaport_location.bne_nxt1.id
+  term        = 12
+  diversity_zone = "red"
+}
+```
+
+This example results in the creation of a single Port located at NextDC Brisbane 1, under a 12 month term with a Port
+speed of 10 Gbps, in the Red Diversity Zone.
+
 ## Example Usage (Link Aggregation Group)
 ```
 data "megaport_location" "bne_nxt1" {
@@ -46,6 +65,26 @@ resource "megaport_port" "lag_port" {
 This example results in the creation of a LAG Port with 3 Ports located at NextDC Brisbane 1, under a 1 month term with 
 an aggregate speed of 30 Gbps.
 
+## Example Usage (Link Aggregation Group with Zone)
+```
+data "megaport_location" "bne_nxt1" {
+  name    = "NextDC B1"
+}
+
+resource "megaport_port" "lag_port" {
+  port_name      = "Terraform Example - LAG Port"
+  port_speed     = 10000
+  location_id    = data.megaport_location.bne_nxt1.id
+  term           = 1
+  lag            = true
+  lag_port_count = 3
+  diversity_zone = "blue"
+}
+```
+
+This example results in the creation of a LAG Port with 3 Ports located at NextDC Brisbane 1, under a 1 month term with 
+an aggregate speed of 30 Gbps, in the Blue Diversity Zone.
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -57,6 +96,7 @@ The following arguments are supported:
  - `lag` - (Optional) Indicates that you want the Port to be a member of a Link Aggregation Port (LAG). A LAG is a set of physical Ports that are grouped into a single logical connection.
  - `lag_port_count` - (Optional) The number of Ports you would like in your LAG. This argument should only be used if
  `lag` is true. Note, the LAG Port speed will be this number multiplied by `port_speed`.
+ - `diversity_zone` - (Optional) Diversity Zone in which the Port will be created, `red` or `blue`.
  - `marketplace_visibility` - (Optional) Whether to make this Port public on the 
  [Megaport Marketplace](https://docs.megaport.com/marketplace/).
  

--- a/resource_megaport/resource_megaport_port.go
+++ b/resource_megaport/resource_megaport_port.go
@@ -51,6 +51,7 @@ func resourceMegaportPortCreate(d *schema.ResourceData, m interface{}) error {
 	isLag := d.Get("lag").(bool)
 	numberOfPorts := d.Get("lag_port_count").(int)
 	loc, locationErr := location.GetLocationByID(locationId)
+	diversityZone := d.Get("diversity_zone").(string)
 
 	if locationErr != nil {
 		return locationErr
@@ -59,9 +60,17 @@ func resourceMegaportPortCreate(d *schema.ResourceData, m interface{}) error {
 	marketCode := loc.Market
 
 	if isLag {
-		portId, portErr = port.BuyLAGPort(portName, term, portSpeed, locationId, marketCode, numberOfPorts, !marketplaceVisibility)
+		if len(diversityZone) > 0 {
+			portId, portErr = port.BuyZonedLAGPort(portName, term, portSpeed, locationId, marketCode, numberOfPorts, !marketplaceVisibility, diversityZone)
+		} else {
+			portId, portErr = port.BuyLAGPort(portName, term, portSpeed, locationId, marketCode, numberOfPorts, !marketplaceVisibility)
+		}
 	} else {
-		portId, portErr = port.BuySinglePort(portName, term, portSpeed, locationId, marketCode, !marketplaceVisibility)
+		if len(diversityZone) > 0 {
+			portId, portErr = port.BuyZonedSinglePort(portName, term, portSpeed, locationId, marketCode, !marketplaceVisibility, diversityZone)
+		} else {
+			portId, portErr = port.BuySinglePort(portName, term, portSpeed, locationId, marketCode, !marketplaceVisibility)
+		}
 	}
 
 	if portErr != nil {
@@ -98,6 +107,7 @@ func resourceMegaportPortRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("lag_id", portDetails.LAGID)
 	d.Set("locked", portDetails.Locked)
 	d.Set("admin_locked", portDetails.AdminLocked)
+	d.Set("diversity_zone", portDetails.DiversityZone)
 
 	return nil
 }

--- a/schema_megaport/megaport_port.go
+++ b/schema_megaport/megaport_port.go
@@ -14,7 +14,9 @@
 
 package schema_megaport
 
-import "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
 
 func ResourcePortSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
@@ -98,6 +100,12 @@ func ResourcePortSchema() map[string]*schema.Schema {
 			Type:     schema.TypeInt,
 			Optional: true,
 			Default:  0,
+			ForceNew: true,
+		},
+		"diversity_zone": {
+			Type:     schema.TypeString,
+			Computed: true,
+			Optional: true,
 			ForceNew: true,
 		},
 	}
@@ -185,6 +193,12 @@ func DataPortSchema() map[string]*schema.Schema {
 			Type:     schema.TypeInt,
 			Optional: true,
 			Default:  0,
+			ForceNew: true,
+		},
+		"diversity_zone": {
+			Type:     schema.TypeString,
+			Computed: true,
+			Optional: true,
 			ForceNew: true,
 		},
 	}


### PR DESCRIPTION
## Contributions

Please read the (Contribution Guidelines)[https://github.com/megaport/terraform-provider-megaport/wiki/Contributing.md]
prior to lodging Pull Requests (PR).

## Description

Add support for optionally specifying Diversity Zone when ordering Ports and LAGs using a new diversity_zone parameter on the megaport_port resource. Relies on pending updates to the megaportgo module.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Contributor Agreement

Lodging this Pull Request (PR) indicates agreement with the project's 
(Contributor License Agreement)[https://github.com/megaport/terraform-provider-megaport/wiki/Megaport_Contributor_Licence_Agreement.md].

Please read the Contributor Licence Agreement (CLA) and affirm your acceptance here:

[I have read an accept the CLA]

**NOTE** If multiple authors have commited to this PR, each one will need to comment on this PR and 
agree to the CLA before this PR can be accepted.
