### PR TITLE
Update schema for private_peering

### DIFF
--- a/schema_megaport/megaport_azure_connection.go
+++ b/schema_megaport/megaport_azure_connection.go
@@ -109,15 +109,15 @@ func ResourceAzureConnectionCspSettingsPrivatePeering() *schema.Schema {
 			Schema: map[string]*schema.Schema{
 				"peer_asn": {
 					Type:     schema.TypeString,
-					Required: true,
+					Optional: true,
 				},
 				"primary_subnet": {
 					Type:     schema.TypeString,
-					Required: true,
+					Optional: true,
 				},
 				"secondary_subnet": {
 					Type:     schema.TypeString,
-					Required: true,
+					Optional: true,
 				},
 				"shared_key": {
 					Type:     schema.TypeString,
@@ -125,7 +125,7 @@ func ResourceAzureConnectionCspSettingsPrivatePeering() *schema.Schema {
 				},
 				"requested_vlan": {
 					Type:     schema.TypeInt,
-					Required: true,
+					Optional: true,
 				},
 			},
 		},


### PR DESCRIPTION
## Description

Updated schema definition to pass validation when using `auto_create_private_peering` with Azure VXC.

Fixes #41 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Contributor Agreement

I have read an accept the CLA
