### PR TITLE
fix: add check for prefix filter lists in import, but not entries that are only available on creation

### DIFF
--- a/internal/provider/mcr_resource_test.go
+++ b/internal/provider/mcr_resource_test.go
@@ -82,7 +82,7 @@ func TestAccMegaportMCR_Basic(t *testing.T) {
 					}
 					return rawState["product_uid"], nil
 				},
-				ImportStateVerifyIgnore: []string{"last_updated", "contract_start_date", "prefix_filter_list", "contract_end_date", "live_date", "provisioning_status"},
+				ImportStateVerifyIgnore: []string{"last_updated", "contract_start_date", "contract_end_date", "live_date", "prefix_filter_lists.0.entries", "provisioning_status"},
 			},
 			{
 				Config: providerConfig + fmt.Sprintf(`


### PR DESCRIPTION
fix: add check for prefix filter lists in import, but not entries that are only available on creation