### PR TITLE
fix: adds a PlanModifier to VXCs to handle unexpected deletion 

### DIFF
--- a/internal/provider/vxc_resource.go
+++ b/internal/provider/vxc_resource.go
@@ -947,6 +947,16 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 					"requested_product_uid": schema.StringAttribute{
 						Description: "The Product UID requested by the user for the A-End configuration.",
 						Required:    true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplaceIf(
+								func(ctx context.Context, sr planmodifier.StringRequest, rrifr *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+									if sr.PlanValue.IsUnknown() {
+										rrifr.RequiresReplace = true
+									}
+								},
+								"This modifier will replace the VXC if the new `requested_product_uid` is unknown. This allows the provider to better handle situations when the connected product (Port, MVE, MCR) is being replaced. To avoid replacement, make sure the new `requested_product_uid` is a known value (i.e. an existing product in the state).",
+								""),
+						},
 					},
 					"current_product_uid": schema.StringAttribute{
 						Description: "The current product UID of the A-End configuration. The Megaport API may change a Partner Port from the Requested Port to a different Port in the same location and diversity zone.",
@@ -1021,6 +1031,17 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 						Description: "The Product UID requested by the user for the B-End configuration.",
 						Optional:    true,
 						Computed:    true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplaceIf(
+								func(ctx context.Context, sr planmodifier.StringRequest, rrifr *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+									if sr.PlanValue.IsUnknown() {
+										rrifr.RequiresReplace = true
+									}
+								},
+								"This modifier will replace the VXC if the new `requested_product_uid` is unknown. This allows the provider to better handle situations when the connected product (Port, MVE, MCR) is being replaced. To avoid replacement, make sure the new `requested_product_uid` is a known value (i.e. an existing product in the state).",
+								"This modifier will replace the VXC if the new `requested_product_uid` is unknown. This allows the provider to better handle situations when the connected product (Port, MVE, MCR) is being replaced. To avoid replacement, make sure the new `requested_product_uid` is a known value (i.e. an existing product in the state).",
+							),
+						},
 					},
 					"current_product_uid": schema.StringAttribute{
 						Description: "The current product UID of the B-End configuration. The Megaport API may change a Partner Port on the end configuration from the Requested Port UID to a different Port in the same location and diversity zone.",


### PR DESCRIPTION
fix: adds a PlanModifier to VXCs to handle unexpected deletion when connected product is deleted. 

This handles an issue where a VXC was deleted as part of the deletion of the connected product, which would then cause the provider to fail to move the VXC that no longer exists.

Now a VXC will require recreation when it's new `requested_product_uid` is **unknown**. For exampled: when a connected port/mve/mcr is replaced because of a change that requires recreation, the VXC will also be replaced because it's new `requested_product_uid` will not be known. This works well because if the product does exist in the state already, a move will work fine and won't trigger a replacement. 