### PR TITLE
fix: prevent partner port from failing if more than one partner port

### DIFF
--- a/internal/provider/partner_port_data_source.go
+++ b/internal/provider/partner_port_data_source.go
@@ -171,7 +171,6 @@ func (d *partnerPortDataSource) Read(ctx context.Context, req datasource.ReadReq
 			"More Than 1 Matching Partner Port Was Found",
 			"There was more than 1 matching partner port for the search criteria, chose highest ranked port. Try narrowing your search criteria.",
 		)
-		return
 	}
 
 	// pick the first matching port


### PR DESCRIPTION
Chooses top ranked partner port rather than returning out without a chosen partner port, keeps warning intact.