### PR TITLE
feat: Update LAG port resource to handle LagPortUIDs and LagCount cor…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.22.1
 	github.com/hashicorp/terraform-plugin-log v0.9.0
-	github.com/megaport/megaportgo v1.3.0
+	github.com/megaport/megaportgo v1.3.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/megaport/megaportgo v1.3.0 h1:NA1RMcBgXJD/OA/B6PzpcM5q4Di82y3JdjzFas7uxCc=
-github.com/megaport/megaportgo v1.3.0/go.mod h1:dB0kCv1QQvfOR07J+Q75Cw5Kvs3n3O52C9cCt6LJvYs=
+github.com/megaport/megaportgo v1.3.1 h1:nclkh2K3njw4QWO4CBCyeMVl+e/DR91ign4dla7m+sE=
+github.com/megaport/megaportgo v1.3.1/go.mod h1:dB0kCv1QQvfOR07J+Q75Cw5Kvs3n3O52C9cCt6LJvYs=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=


### PR DESCRIPTION
…rectly

- Updated the Read function to properly populate the LagPortUIDs and LagCount fields based on the API response.
- Simplified the ModifyPlan function to handle the comparison of LagCount directly.
- Ensured that the state is correctly updated with the LAG port details, including LagPortUIDs and LagCount.
- ModifyPlan now triggers replacement if the actual LAG count does not match the planned LAG count.
- Bump Megaport Go Version to reflect changes there.