### PR TITLE
fix: Improve VXC Resource Documentation and Warning Messaging

### DIFF
--- a/docs/resources/vxc.md
+++ b/docs/resources/vxc.md
@@ -307,7 +307,7 @@ resource "megaport_vxc" "transit_vxc" {
 
 Required:
 
-- `requested_product_uid` (String) The Product UID requested by the user for the A-End configuration.
+- `requested_product_uid` (String) The Product UID requested by the user for the A-End configuration. Note: For cloud provider connections, the actual Product UID may differ from the requested UID due to Megaport's automatic port assignment for partner ports. This is expected behavior and ensures proper connectivity.
 
 Optional:
 
@@ -334,7 +334,7 @@ Optional:
 - `current_product_uid` (String) The current product UID of the B-End configuration. The Megaport API may change a Partner Port on the end configuration from the Requested Port UID to a different Port in the same location and diversity zone.
 - `inner_vlan` (Number) The inner VLAN of the B-End configuration. If the B-End ordered_vlan is untagged and set as -1, this field cannot be set by the API, as the VLAN of the B-End is designated as untagged.
 - `ordered_vlan` (Number) The customer-ordered unique VLAN ID of the B-End configuration. Values can range from 2 to 4093. If this value is set to 0, or not included, the Megaport system allocates a valid VLAN ID to the B-End configuration.  To set this VLAN to untagged, set the VLAN value to -1. Please note that if the B-End ordered_vlan is set to -1, the Megaport API will not allow for the B-End inner_vlan field to be set as the VLAN for this end configuration will be untagged.
-- `requested_product_uid` (String) The Product UID requested by the user for the B-End configuration.
+- `requested_product_uid` (String) The Product UID requested by the user for the B-End configuration. Note: For cloud provider connections, the actual Product UID may differ from the requested UID due to Megaport's automatic port assignment for partner ports. This is expected behavior and ensures proper connectivity.
 - `vnic_index` (Number) The network interface index of the B-End configuration.
 
 Read-Only:

--- a/internal/provider/vxc_resource.go
+++ b/internal/provider/vxc_resource.go
@@ -1080,7 +1080,7 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 						},
 					},
 					"requested_product_uid": schema.StringAttribute{
-						Description: "The Product UID requested by the user for the A-End configuration.",
+						Description: "The Product UID requested by the user for the A-End configuration. Note: For cloud provider connections, the actual Product UID may differ from the requested UID due to Megaport's automatic port assignment for partner ports. This is expected behavior and ensures proper connectivity.",
 						Required:    true,
 						// PlanModifiers: []planmodifier.String{
 						// 	stringplanmodifier.RequiresReplaceIf(
@@ -1162,7 +1162,7 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 						},
 					},
 					"requested_product_uid": schema.StringAttribute{
-						Description: "The Product UID requested by the user for the B-End configuration.",
+						Description: "The Product UID requested by the user for the B-End configuration. Note: For cloud provider connections, the actual Product UID may differ from the requested UID due to Megaport's automatic port assignment for partner ports. This is expected behavior and ensures proper connectivity.",
 						Optional:    true,
 						Computed:    true,
 						// PlanModifiers: []planmodifier.String{
@@ -4558,7 +4558,12 @@ func (r *vxcResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 				}
 			} else if aEndCSP {
 				if !aEndPlanConfig.RequestedProductUID.IsNull() && !aEndPlanConfig.RequestedProductUID.Equal(aEndStateConfig.RequestedProductUID) {
-					diags.AddWarning("VXC A-End product UID is from a partner port, therefore it will not be changed.", "VXC A-End product UID is from a CSP partner port, therefore it will not be changed.")
+					diags.AddWarning(
+						"Cloud provider port mapping detected",
+						fmt.Sprintf("Different A-End Product UIDs detected for cloud provider endpoint: requested=%s, actual=%s. This is normal - Megaport automatically manages cloud connection port assignments. Your configuration remains unchanged while the connection uses the provider-assigned Product UID. No action needed.",
+							aEndPlanConfig.RequestedProductUID.ValueString(),
+							aEndStateConfig.CurrentProductUID.ValueString()),
+					)
 				}
 				aEndPlanConfig.RequestedProductUID = aEndStateConfig.RequestedProductUID
 			}
@@ -4596,7 +4601,12 @@ func (r *vxcResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 				}
 			} else if bEndCSP {
 				if !bEndPlanConfig.RequestedProductUID.IsNull() && !bEndPlanConfig.RequestedProductUID.Equal(bEndStateConfig.CurrentProductUID) {
-					diags.AddWarning("VXC B-End product UID is from a partner port, therefore it will not be changed.", "VXC B-End product UID is from a CSP partner port, therefore it will not be changed.")
+					diags.AddWarning(
+						"Cloud provider port mapping detected",
+						fmt.Sprintf("Different B-End Product UIDs detected for cloud provider endpoint: requested=%s, actual=%s. This is normal - Megaport automatically manages cloud connection port assignments. Your configuration remains unchanged while the connection uses the provider-assigned Product UID. No action needed.",
+							bEndPlanConfig.RequestedProductUID.ValueString(),
+							bEndStateConfig.CurrentProductUID.ValueString()),
+					)
 				}
 				bEndPlanConfig.RequestedProductUID = bEndStateConfig.RequestedProductUID
 			}


### PR DESCRIPTION
- Enhanced the schema documentation for `requested_product_uid` in both A-End and B-End configurations to clarify that the actual Product UID may differ from the requested UID for cloud provider connections due to Megaport's automatic port assignment. This ensures proper connectivity and is expected behavior.
- Updated the warning message for mismatched Product UIDs to be clearer and more user-friendly, emphasizing that no action is required.

Addresses #214 