### PR TITLE
fix: improve vendor name handling for Palo Alto Networks MVE images

### DIFF
--- a/docs/data-sources/mve_images.md
+++ b/docs/data-sources/mve_images.md
@@ -21,7 +21,7 @@ MVE Images
 - `product_code_filter` (String) Filter the MVE Images by Product Code
 - `product_filter` (String) Filter the MVE Images by Product
 - `release_image_filter` (Boolean) Filter the MVE Images by Release Image
-- `vendor_filter` (String) Filter the MVE Images by Vendor Name
+- `vendor_filter` (String) Filter the MVE Images by Vendor Name. Note that for Palo Alto Networks, both 'palo_alto' and 'palo alto' formats are accepted.
 - `version_filter` (String) Filter the MVE Images by Version
 
 ### Read-Only

--- a/docs/resources/mve.md
+++ b/docs/resources/mve.md
@@ -143,7 +143,7 @@ Required:
 
 - `image_id` (Number) The image ID of the MVE. Indicates the software version.
 - `product_size` (String) The product size for the vendor config. The size defines the MVE specifications including number of cores, bandwidth, and number of connections.
-- `vendor` (String) The name of vendor of the MVE. Currently supported values: "6wind", "aruba", "aviatrix", "cisco", "fortinet", "palo_alto", "prisma", "versa", "vmware", "meraki".
+- `vendor` (String) The name of vendor of the MVE. Currently supported values: "6wind", "aruba", "aviatrix", "cisco", "fortinet", "palo_alto" (also accepts a case insensitive "palo alto" or "paloalto"), "prisma", "versa", "vmware", "meraki".
 
 Optional:
 

--- a/internal/provider/mve_image_data_source_test.go
+++ b/internal/provider/mve_image_data_source_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"strings"
 	"testing"
 
 	megaport "github.com/megaport/megaportgo"
@@ -47,6 +48,30 @@ func TestMVEImageFilters(t *testing.T) {
 			ProductCode:  "pc4",
 			ReleaseImage: false,
 		},
+		{
+			ID:           5,
+			Version:      "10.1.0",
+			Product:      "VM-Series",
+			Vendor:       "palo_alto",
+			ProductCode:  "pa-vm",
+			ReleaseImage: true,
+		},
+		{
+			ID:           6,
+			Version:      "10.1.0",
+			Product:      "VM-Series",
+			Vendor:       "palo alto",
+			ProductCode:  "pa-vm",
+			ReleaseImage: true,
+		},
+		{
+			ID:           7,
+			Version:      "10.2.0",
+			Product:      "VM-Series",
+			Vendor:       "Palo Alto Networks",
+			ProductCode:  "pa-vm",
+			ReleaseImage: true,
+		},
 	}
 
 	for _, scenario := range []filterTestCases{
@@ -58,6 +83,9 @@ func TestMVEImageFilters(t *testing.T) {
 			expectedMVEImages: []*megaport.MVEImage{
 				images[0],
 				images[2],
+				images[4],
+				images[5],
+				images[6],
 			},
 		},
 		{
@@ -125,10 +153,90 @@ func TestMVEImageFilters(t *testing.T) {
 				images[0],
 			},
 		},
+		// Add specific tests for Palo Alto vendor name variations
+		{
+			description: "vendor_palo_alto_with_underscore",
+			filters: []func(*megaport.MVEImage) bool{
+				filterMVEImageByVendor("palo_alto"),
+			},
+			expectedMVEImages: []*megaport.MVEImage{
+				images[4],
+			},
+		},
+		{
+			description: "vendor_palo_alto_with_space",
+			filters: []func(*megaport.MVEImage) bool{
+				filterMVEImageByVendor("palo alto"),
+			},
+			expectedMVEImages: []*megaport.MVEImage{
+				images[5],
+			},
+		},
+		{
+			description: "vendor_palo_alto_networks_full_name",
+			filters: []func(*megaport.MVEImage) bool{
+				filterMVEImageByVendor("Palo Alto Networks"),
+			},
+			expectedMVEImages: []*megaport.MVEImage{
+				images[6],
+			},
+		},
+		// Test for normalized search that should match all Palo Alto variants
+		{
+			description: "vendor_palo_alto_normalized_search",
+			filters: []func(*megaport.MVEImage) bool{
+				func(i *megaport.MVEImage) bool {
+					// Custom filter - keep if contains "palo" and "alto" in any format
+					if i.Vendor == "" {
+						return true
+					}
+					vendorLower := strings.ToLower(i.Vendor)
+					return !(strings.Contains(vendorLower, "palo") &&
+						(strings.Contains(vendorLower, "alto") ||
+							strings.Contains(vendorLower, "_alto")))
+				},
+			},
+			expectedMVEImages: []*megaport.MVEImage{
+				images[4],
+				images[5],
+				images[6],
+			},
+		},
 	} {
 		t.Run(scenario.description, func(t *testing.T) {
 			filtered := runImageFiltersAndSort(images, scenario.filters)
 			assert.ElementsMatch(t, filtered, scenario.expectedMVEImages)
+		})
+	}
+}
+
+// TestFilterMVEImageByVendor tests various vendor name formats
+func TestFilterMVEImageByVendor(t *testing.T) {
+	testCases := []struct {
+		name         string
+		filterValue  string
+		vendor       string
+		shouldBeKept bool
+	}{
+		{"exact match lowercase", "palo alto", "palo alto", true},
+		{"exact match with underscore", "palo_alto", "palo_alto", true},
+		{"exact match with full name", "Palo Alto Networks", "Palo Alto Networks", true},
+		{"case insensitive", "PALO ALTO", "palo alto", true},
+		{"case insensitive underscore", "PALO_ALTO", "palo_alto", true},
+		{"no match", "palo alto", "cisco", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			img := &megaport.MVEImage{
+				Vendor: tc.vendor,
+			}
+			filter := filterMVEImageByVendor(tc.filterValue)
+			// Our filter returns true if it should be REMOVED
+			shouldRemove := filter(img)
+			assert.Equal(t, !tc.shouldBeKept, shouldRemove,
+				"Filter should return %v for vendor '%s' with filter '%s'",
+				!tc.shouldBeKept, tc.vendor, tc.filterValue)
 		})
 	}
 }


### PR DESCRIPTION
Support case insensitive `palo alto` `palo_alto` or `paloalto` in the provider.