### PR TITLE
fix: fix inconsistent Palo Alto name format in MVE image data source …

### DIFF
--- a/internal/provider/mve_image_data_source.go
+++ b/internal/provider/mve_image_data_source.go
@@ -239,7 +239,11 @@ func (orm *mveImageDetailsModel) fromAPIMVEImage(image *megaport.MVEImage) {
 	orm.ID = types.Int64Value(int64(image.ID))
 	orm.Version = types.StringValue(image.Version)
 	orm.Product = types.StringValue(image.Product)
-	orm.Vendor = types.StringValue(image.Vendor)
+	vendorStr := image.Vendor
+	if strings.EqualFold(vendorStr, "PALO ALTO") {
+		vendorStr = "PALO_ALTO"
+	}
+	orm.Vendor = types.StringValue(vendorStr)
 	orm.VendorDescription = types.StringValue(image.VendorDescription)
 	orm.ReleaseImage = types.BoolValue(image.ReleaseImage)
 	orm.ProductCode = types.StringValue(image.ProductCode)
@@ -275,6 +279,9 @@ func filterMVEImageByVersion(version string) func(*megaport.MVEImage) bool {
 
 func filterMVEImageByVendor(vendor string) func(*megaport.MVEImage) bool {
 	return func(i *megaport.MVEImage) bool {
+		if strings.EqualFold(vendor, "PALO_ALTO") {
+			vendor = "PALO ALTO"
+		}
 		return !strings.EqualFold(i.Vendor, vendor)
 	}
 }


### PR DESCRIPTION
…- normalize to api spec of PALO_ALTO

Fixes a bug where the MVE image data source outputs vendor names in a format that's incompatible with the MVE resource. The data source was returning `"Palo Alto"` but the resource and API expect `"PALO_ALTO"`. This specifically affected users trying to use the data source output directly in the resource.

The fix ensures consistent vendor name formatting between data source and resource by normalizing the vendor name format throughout the code.