### PR TITLE
fix: add computed diversity zone field to mcr based on api assignment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.22.1
 	github.com/hashicorp/terraform-plugin-log v0.9.0
-	github.com/megaport/megaportgo v1.3.5
+	github.com/megaport/megaportgo v1.3.7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/megaport/megaportgo v1.3.5 h1:7548bQYH2IvAEq5U30u4Q8nyenFssRMrHRCyexk+aT8=
-github.com/megaport/megaportgo v1.3.5/go.mod h1:dB0kCv1QQvfOR07J+Q75Cw5Kvs3n3O52C9cCt6LJvYs=
+github.com/megaport/megaportgo v1.3.7 h1:ivEouHH/dQ6Zap6pEM16BLcjTSW5knB229tMWm/3LhE=
+github.com/megaport/megaportgo v1.3.7/go.mod h1:dB0kCv1QQvfOR07J+Q75Cw5Kvs3n3O52C9cCt6LJvYs=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=

--- a/internal/provider/mcr_resource.go
+++ b/internal/provider/mcr_resource.go
@@ -181,6 +181,7 @@ func (orm *mcrResourceModel) fromAPIMCR(ctx context.Context, m *megaport.MCR, ta
 	orm.Locked = types.BoolValue(m.Locked)
 	orm.AdminLocked = types.BoolValue(m.AdminLocked)
 	orm.Cancelable = types.BoolValue(m.Cancelable)
+	orm.DiversityZone = types.StringValue(m.DiversityZone)
 
 	if m.CreateDate != nil {
 		orm.CreateDate = types.StringValue(m.CreateDate.String())
@@ -355,6 +356,7 @@ func (r *mcrResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 			"diversity_zone": schema.StringAttribute{
 				Description: "Diversity zone of the product. If the parameter is not provided, a diversity zone will be automatically allocated.",
 				Optional:    true,
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),


### PR DESCRIPTION
This will prevent an unnecessary replacement trigger if the user provided diversity zone is the same as what the API assigns on provision.