### PR TITLE
docs: clarify IP address format for BGP fields in megaport_vxc resource

### DIFF
--- a/docs/resources/vxc.md
+++ b/docs/resources/vxc.md
@@ -459,7 +459,7 @@ Optional:
 
 - `bfd` (Attributes) The BFD of the partner configuration interface. (see [below for nested schema](#nestedatt--a_end_partner_config--partner_a_end_config--interfaces--bfd))
 - `bgp_connections` (Attributes List) The BGP connections of the partner configuration interface. (see [below for nested schema](#nestedatt--a_end_partner_config--partner_a_end_config--interfaces--bgp_connections))
-- `ip_addresses` (List of String) The IP addresses of the partner configuration.
+- `ip_addresses` (List of String) The IP addresses of the partner configuration. Each entry must be in CIDR notation (e.g., "169.254.100.6/29").
 - `ip_routes` (Attributes List) The IP routes of the partner configuration. (see [below for nested schema](#nestedatt--a_end_partner_config--partner_a_end_config--interfaces--ip_routes))
 - `nat_ip_addresses` (List of String) The NAT IP addresses of the partner configuration.
 
@@ -488,12 +488,12 @@ Optional:
 - `import_blacklist` (String) The import blacklist of the BGP connection.
 - `import_whitelist` (String) The import whitelist of the BGP connection.
 - `local_asn` (Number) The local ASN of the BGP connection.
-- `local_ip_address` (String) The local IP address of the BGP connection.
+- `local_ip_address` (String) The local IP address of the BGP connection. Must be an IP address without a CIDR mask (e.g., "169.254.100.6").
 - `med_in` (Number) The MED in of the BGP connection.
 - `med_out` (Number) The MED out of the BGP connection.
 - `password` (String) The password of the BGP connection.
 - `peer_asn` (Number) The peer ASN of the BGP connection.
-- `peer_ip_address` (String) The peer IP address of the BGP connection.
+- `peer_ip_address` (String) The peer IP address of the BGP connection. Must be an IP address without a CIDR mask (e.g., "169.254.100.1").
 - `permit_export_to` (List of String) The permitted export to of the BGP connection.
 - `shutdown` (Boolean) Whether the BGP connection is shut down.
 
@@ -524,7 +524,7 @@ Optional:
 
 - `bfd` (Attributes) The BFD of the partner configuration interface. (see [below for nested schema](#nestedatt--a_end_partner_config--vrouter_config--interfaces--bfd))
 - `bgp_connections` (Attributes List) The BGP connections of the partner configuration interface. (see [below for nested schema](#nestedatt--a_end_partner_config--vrouter_config--interfaces--bgp_connections))
-- `ip_addresses` (List of String) The IP addresses of the partner configuration.
+- `ip_addresses` (List of String) The IP addresses of the partner configuration. Each entry must be in CIDR notation (e.g., "169.254.100.6/29").
 - `ip_routes` (Attributes List) The IP routes of the partner configuration. (see [below for nested schema](#nestedatt--a_end_partner_config--vrouter_config--interfaces--ip_routes))
 - `nat_ip_addresses` (List of String) The NAT IP addresses of the partner configuration.
 - `vlan` (Number) Inner-VLAN for implicit Q-inQ VXCs. Typically used only for Azure VXCs. The default is no inner-vlan.
@@ -554,12 +554,12 @@ Optional:
 - `import_blacklist` (String) The import blacklist of the BGP connection.
 - `import_whitelist` (String) The import whitelist of the BGP connection.
 - `local_asn` (Number) The local ASN of the BGP connection.
-- `local_ip_address` (String) The local IP address of the BGP connection.
+- `local_ip_address` (String) The local IP address of the BGP connection. Must be an IP address without a CIDR mask (e.g., "169.254.100.6").
 - `med_in` (Number) The MED in of the BGP connection.
 - `med_out` (Number) The MED out of the BGP connection.
 - `password` (String) The password of the BGP connection.
 - `peer_asn` (Number) The peer ASN of the BGP connection.
-- `peer_ip_address` (String) The peer IP address of the BGP connection.
+- `peer_ip_address` (String) The peer IP address of the BGP connection. Must be an IP address without a CIDR mask (e.g., "169.254.100.1").
 - `peer_type` (String) Defines the default BGP routing policy for this BGP connection. The default depends on the CSP type of the far end of this VXC.
 - `permit_export_to` (List of String) The permitted export to of the BGP connection.
 - `shutdown` (Boolean) Whether the BGP connection is shut down.
@@ -690,7 +690,7 @@ Optional:
 
 - `bfd` (Attributes) The BFD of the partner configuration interface. (see [below for nested schema](#nestedatt--b_end_partner_config--partner_a_end_config--interfaces--bfd))
 - `bgp_connections` (Attributes List) The BGP connections of the partner configuration interface. (see [below for nested schema](#nestedatt--b_end_partner_config--partner_a_end_config--interfaces--bgp_connections))
-- `ip_addresses` (List of String) The IP addresses of the partner configuration.
+- `ip_addresses` (List of String) The IP addresses of the partner configuration. Each entry must be in CIDR notation (e.g., "169.254.100.6/29").
 - `ip_routes` (Attributes List) The IP routes of the partner configuration. (see [below for nested schema](#nestedatt--b_end_partner_config--partner_a_end_config--interfaces--ip_routes))
 - `nat_ip_addresses` (List of String) The NAT IP addresses of the partner configuration.
 
@@ -719,12 +719,12 @@ Optional:
 - `import_blacklist` (String) The import blacklist of the BGP connection.
 - `import_whitelist` (String) The import whitelist of the BGP connection.
 - `local_asn` (Number) The local ASN of the BGP connection.
-- `local_ip_address` (String) The local IP address of the BGP connection.
+- `local_ip_address` (String) The local IP address of the BGP connection. Must be an IP address without a CIDR mask (e.g., "169.254.100.6").
 - `med_in` (Number) The MED in of the BGP connection.
 - `med_out` (Number) The MED out of the BGP connection.
 - `password` (String) The password of the BGP connection.
 - `peer_asn` (Number) The peer ASN of the BGP connection.
-- `peer_ip_address` (String) The peer IP address of the BGP connection.
+- `peer_ip_address` (String) The peer IP address of the BGP connection. Must be an IP address without a CIDR mask (e.g., "169.254.100.1").
 - `permit_export_to` (List of String) The permitted export to of the BGP connection.
 - `shutdown` (Boolean) Whether the BGP connection is shut down.
 
@@ -755,7 +755,7 @@ Optional:
 
 - `bfd` (Attributes) The BFD of the partner configuration interface. (see [below for nested schema](#nestedatt--b_end_partner_config--vrouter_config--interfaces--bfd))
 - `bgp_connections` (Attributes List) The BGP connections of the partner configuration interface. (see [below for nested schema](#nestedatt--b_end_partner_config--vrouter_config--interfaces--bgp_connections))
-- `ip_addresses` (List of String) The IP addresses of the partner configuration.
+- `ip_addresses` (List of String) The IP addresses of the partner configuration. Each entry must be in CIDR notation (e.g., "169.254.100.6/29").
 - `ip_routes` (Attributes List) The IP routes of the partner configuration. (see [below for nested schema](#nestedatt--b_end_partner_config--vrouter_config--interfaces--ip_routes))
 - `nat_ip_addresses` (List of String) The NAT IP addresses of the partner configuration.
 - `vlan` (Number) Inner-VLAN for implicit Q-inQ VXCs. Typically used only for Azure VXCs. The default is no inner-vlan.
@@ -785,12 +785,12 @@ Optional:
 - `import_blacklist` (String) The import blacklist of the BGP connection.
 - `import_whitelist` (String) The import whitelist of the BGP connection.
 - `local_asn` (Number) The local ASN of the BGP connection.
-- `local_ip_address` (String) The local IP address of the BGP connection.
+- `local_ip_address` (String) The local IP address of the BGP connection. Must be an IP address without a CIDR mask (e.g., "169.254.100.6").
 - `med_in` (Number) The MED in of the BGP connection.
 - `med_out` (Number) The MED out of the BGP connection.
 - `password` (String) The password of the BGP connection.
 - `peer_asn` (Number) The peer ASN of the BGP connection.
-- `peer_ip_address` (String) The peer IP address of the BGP connection.
+- `peer_ip_address` (String) The peer IP address of the BGP connection. Must be an IP address without a CIDR mask (e.g., "169.254.100.1").
 - `peer_type` (String) Defines the default BGP routing policy for this BGP connection. The default depends on the CSP type of the far end of this VXC.
 - `permit_export_to` (List of String) The permitted export to of the BGP connection.
 - `shutdown` (Boolean) Whether the BGP connection is shut down.

--- a/internal/provider/vxc_schemas.go
+++ b/internal/provider/vxc_schemas.go
@@ -172,7 +172,7 @@ var (
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"ip_addresses": schema.ListAttribute{
-							Description: "The IP addresses of the partner configuration.",
+							Description: "The IP addresses of the partner configuration. Each entry must be in CIDR notation (e.g., \"169.254.100.6/29\").",
 							Optional:    true,
 							ElementType: types.StringType,
 						},
@@ -244,11 +244,11 @@ var (
 										},
 									},
 									"local_ip_address": schema.StringAttribute{
-										Description: "The local IP address of the BGP connection.",
+										Description: "The local IP address of the BGP connection. Must be an IP address without a CIDR mask (e.g., \"169.254.100.6\").",
 										Optional:    true,
 									},
 									"peer_ip_address": schema.StringAttribute{
-										Description: "The peer IP address of the BGP connection.",
+										Description: "The peer IP address of the BGP connection. Must be an IP address without a CIDR mask (e.g., \"169.254.100.1\").",
 										Optional:    true,
 									},
 									"password": schema.StringAttribute{
@@ -329,7 +329,7 @@ var (
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"ip_addresses": schema.ListAttribute{
-							Description: "The IP addresses of the partner configuration.",
+							Description: "The IP addresses of the partner configuration. Each entry must be in CIDR notation (e.g., \"169.254.100.6/29\").",
 							Optional:    true,
 							ElementType: types.StringType,
 						},
@@ -390,11 +390,11 @@ var (
 										Optional:    true,
 									},
 									"local_ip_address": schema.StringAttribute{
-										Description: "The local IP address of the BGP connection.",
+										Description: "The local IP address of the BGP connection. Must be an IP address without a CIDR mask (e.g., \"169.254.100.6\").",
 										Optional:    true,
 									},
 									"peer_ip_address": schema.StringAttribute{
-										Description: "The peer IP address of the BGP connection.",
+										Description: "The peer IP address of the BGP connection. Must be an IP address without a CIDR mask (e.g., \"169.254.100.1\").",
 										Optional:    true,
 									},
 									"password": schema.StringAttribute{


### PR DESCRIPTION
- Updated documentation for `interfaces.ip_addresses` to explicitly state that each entry must be in CIDR notation (e.g., "169.254.100.6/29").
- Updated documentation for `bgp_connections.local_ip_address` and `bgp_connections.peer_ip_address` to specify that these fields require an IP address without a CIDR mask (e.g., "169.254.100.6").
- Applied these clarifications to both the vrouter config schema and the a_end partner config schema.
- Addresses user feedback to reduce ambiguity and improve the user experience when configuring BGP settings.

### User-Facing Summary

The documentation for the `megaport_vxc` resource has been updated to clarify the required IP address format for BGP configurations. Based on user feedback, the descriptions for the following fields now explicitly state whether to use CIDR notation or a plain IP address:

- `interfaces.ip_addresses` (requires CIDR notation, e.g., "1.2.3.4/29")
- `bgp_connections.local_ip_address` (requires IP address only, e.g., "1.2.3.4")
- `bgp_connections.peer_ip_address` (requires IP address only, e.g., "1.2.3.4")

This change resolves ambiguity within the provider documentation and helps prevent common configuration errors.

---

### Type of Change

- [ ] 🚀 New Feature
- [ ] ✨ Enhancement
- [ ] 🐛 Bug Fix
- [x] 📚 Documentation Update
- [ ] 🏗️ Chore / Other

---

### Related Issues

---

### How to Test

This is a documentation-only change reflected in the resource schema.

---
