### PR TITLE
fix: VXC update improvements to prevent unintended update calls or vxc moves

### DIFF
--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -5,10 +5,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	megaport "github.com/megaport/megaportgo"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -3145,38 +3143,4 @@ func (suite *VXCMVEProviderTestSuite) TestAccMegaportVXC_MVEVnicIndexUpdate() {
 			},
 		},
 	})
-}
-
-func TestShouldIncludeVnicIndex(t *testing.T) {
-	testCases := []struct {
-		name        string
-		productType string
-		vnicIndex   types.Int64
-		expected    bool
-	}{
-		{
-			name:        "MVE",
-			productType: megaport.PRODUCT_MVE,
-			expected:    true,
-		},
-		{
-			name:        "PORT",
-			productType: megaport.PRODUCT_MEGAPORT,
-			expected:    false,
-		},
-		{
-			name:        "MCR",
-			productType: megaport.PRODUCT_MCR,
-			expected:    false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := shouldIncludeVnicIndex(tc.productType)
-			if result != tc.expected {
-				t.Errorf("Expected %v but got %v for %s", tc.expected, result, tc.name)
-			}
-		})
-	}
 }

--- a/internal/provider/vxc_resource_utils.go
+++ b/internal/provider/vxc_resource_utils.go
@@ -687,11 +687,6 @@ func createTransitPartnerConfig(ctx context.Context) (diag.Diagnostics, megaport
 	return diags, transitPartnerConfig, transitConfigObj
 }
 
-func shouldIncludeVnicIndex(productType string) bool {
-	// For MVE products, always include VNIC index (even if null, which would trigger an error)
-	return productType == megaport.PRODUCT_MVE
-}
-
 func supportVLANUpdates(partnerType string) bool {
 	// AWS and Transit connections do not support VLAN updates
 	if partnerType == "aws" || partnerType == "transit" {


### PR DESCRIPTION
### User-Facing Summary

- Improved update logic for VXCs to prevent unnecessary API calls and product move attempts.
- VNIC Index is now only included in update requests if the end connection product type is MVE.
- Product UID is only included in update requests if the requested UID differs from the current state, preventing redundant move operations.
- The Update API call is now only sent if there are actual changes in the update request.

---

### Type of Change

- [ ] 🚀 New Feature
- [x] ✨ Enhancement
- [x] 🐛 Bug Fix
- [ ] 📚 Documentation Update
- [ ] 🏗️ Chore / Other

---

### Related Issues

- Resolves issues where unnecessary VXC move attempts or updates were triggered, causing provider errors and inconsistent state.

---

### How to Test

1. Apply a VXC resource with an MVE or non-MVE product type and verify that VNIC Index is only sent for MVE.
2. Change the requested_product_uid and confirm that the update only triggers a move if the UID is actually different.
3. Make a no-op update (no changes) and verify that no API call is sent.
4. Import a VXC and apply changes to ensure the provider does not attempt unnecessary moves or updates.

---
