### PR TITLE
fix: avoid race condition in MCR prefix filter list operations by using sequential processing

### DIFF
--- a/internal/provider/mcr_resource_test.go
+++ b/internal/provider/mcr_resource_test.go
@@ -469,6 +469,211 @@ func (suite *MCRProviderTestSuite) TestAccMegaportMCRCustomASN_Basic() {
 	})
 }
 
+func (suite *MCRProviderTestSuite) TestAccMegaportMCR_MultipleInstancesWithPrefixLists() {
+	mcrName1 := RandomTestName()
+	mcrName2 := RandomTestName()
+	prefixList1 := "AWS-prefixes"
+	prefixList2 := "Azure-prefixes"
+	prefixList3 := "OCI-prefixes"
+	prefixList4 := "GCP-prefixes"
+	costCentre := RandomTestName()
+
+	// Initial configuration: Create multiple MCRs with multiple prefix filter lists
+	initialConfig := providerConfig + fmt.Sprintf(`
+    data "megaport_location" "test_location" {
+        id = %d
+    }
+    
+    locals {
+        mcrs = {
+            "FR" = {
+                name = "%s"
+            }
+            "US" = {
+                name = "%s"
+            }
+        }
+    }
+    
+    resource "megaport_mcr" "test" {
+        for_each = local.mcrs
+        
+        product_name         = each.value.name
+        port_speed           = 1000
+        location_id          = data.megaport_location.test_location.id
+        contract_term_months = 12
+        cost_centre          = "%s"
+        
+        prefix_filter_lists = [
+            {
+                description    = "${each.key}-%s"
+                address_family = "IPv4"
+                entries = [
+                    {
+                        action = "permit"
+                        prefix = "10.0.1.0/24"
+                        ge     = 24
+                        le     = 32
+                    }
+                ]
+            },
+            {
+                description    = "${each.key}-%s"
+                address_family = "IPv4"
+                entries = [
+                    {
+                        action = "permit"
+                        prefix = "10.0.2.0/24"
+                        ge     = 24
+                        le     = 32
+                    }
+                ]
+            },
+            {
+                description    = "${each.key}-%s"
+                address_family = "IPv4"
+                entries = [
+                    {
+                        action = "permit"
+                        prefix = "10.0.3.0/24"
+                        ge     = 24
+                        le     = 32
+                    }
+                ]
+            }
+        ]
+    }
+    `, MCRTestLocationIDNum, mcrName1, mcrName2, costCentre, prefixList1, prefixList2, prefixList3)
+
+	// Updated configuration: Change entries and add new prefix filter list
+	updatedConfig := providerConfig + fmt.Sprintf(`
+    data "megaport_location" "test_location" {
+        id = %d
+    }
+    
+    locals {
+        mcrs = {
+            "FR" = {
+                name = "%s"
+            }
+            "US" = {
+                name = "%s"
+            }
+        }
+    }
+    
+    resource "megaport_mcr" "test" {
+        for_each = local.mcrs
+        
+        product_name         = each.value.name
+        port_speed           = 1000
+        location_id          = data.megaport_location.test_location.id
+        contract_term_months = 12
+        cost_centre          = "%s"
+        
+        prefix_filter_lists = [
+            {
+                description    = "${each.key}-%s"
+                address_family = "IPv4"
+                entries = [
+                    {
+                        action = "permit"
+                        prefix = "10.0.1.0/24"
+                        ge     = 24
+                        le     = 32
+                    }
+                ]
+            },
+            {
+                description    = "${each.key}-%s"
+                address_family = "IPv4"
+                entries = [
+                    {
+                        action = "permit"
+                        prefix = "10.0.2.0/24"
+                        ge     = 25  # Changed from 24
+                        le     = 30  # Changed from 32
+                    }
+                ]
+            },
+            {
+                description    = "${each.key}-%s"
+                address_family = "IPv4"
+                entries = [
+                    {
+                        action = "permit"
+                        prefix = "10.0.4.0/24"  # Changed from 10.0.3.0/24
+                        ge     = 26
+                        le     = 32
+                    }
+                ]
+            },
+            {
+                description    = "${each.key}-%s"
+                address_family = "IPv4" 
+                entries = [
+                    {
+                        action = "permit"
+                        prefix = "10.0.5.0/24"
+                        ge     = 24
+                        le     = 28
+                    }
+                ]
+            }
+        ]
+    }
+    `, MCRTestLocationIDNum, mcrName1, mcrName2, costCentre, prefixList1, prefixList2, prefixList3, prefixList4)
+
+	resource.Test(suite.T(), resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Initial creation
+			{
+				Config: initialConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Check first MCR (FR)
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"FR\"]", "product_name", mcrName1),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"FR\"]", "prefix_filter_lists.#", "3"),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"FR\"]", "prefix_filter_lists.0.description", fmt.Sprintf("FR-%s", prefixList1)),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"FR\"]", "prefix_filter_lists.1.description", fmt.Sprintf("FR-%s", prefixList2)),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"FR\"]", "prefix_filter_lists.2.description", fmt.Sprintf("FR-%s", prefixList3)),
+
+					// Check second MCR (US)
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"US\"]", "product_name", mcrName2),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"US\"]", "prefix_filter_lists.#", "3"),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"US\"]", "prefix_filter_lists.0.description", fmt.Sprintf("US-%s", prefixList1)),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"US\"]", "prefix_filter_lists.1.description", fmt.Sprintf("US-%s", prefixList2)),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"US\"]", "prefix_filter_lists.2.description", fmt.Sprintf("US-%s", prefixList3)),
+				),
+			},
+			// Update with changes to prefix filter lists and add a new one
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Check first MCR (FR)
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"FR\"]", "prefix_filter_lists.#", "4"),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"FR\"]", "prefix_filter_lists.0.description", fmt.Sprintf("FR-%s", prefixList1)),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"FR\"]", "prefix_filter_lists.1.description", fmt.Sprintf("FR-%s", prefixList2)),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"FR\"]", "prefix_filter_lists.1.entries.0.ge", "25"),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"FR\"]", "prefix_filter_lists.1.entries.0.le", "30"),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"FR\"]", "prefix_filter_lists.2.description", fmt.Sprintf("FR-%s", prefixList3)),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"FR\"]", "prefix_filter_lists.2.entries.0.prefix", "10.0.4.0/24"),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"FR\"]", "prefix_filter_lists.3.description", fmt.Sprintf("FR-%s", prefixList4)),
+
+					// Check second MCR (US)
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"US\"]", "prefix_filter_lists.#", "4"),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"US\"]", "prefix_filter_lists.0.description", fmt.Sprintf("US-%s", prefixList1)),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"US\"]", "prefix_filter_lists.1.description", fmt.Sprintf("US-%s", prefixList2)),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"US\"]", "prefix_filter_lists.1.entries.0.ge", "25"),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"US\"]", "prefix_filter_lists.2.description", fmt.Sprintf("US-%s", prefixList3)),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"US\"]", "prefix_filter_lists.2.entries.0.prefix", "10.0.4.0/24"),
+					resource.TestCheckResourceAttr("megaport_mcr.test[\"US\"]", "prefix_filter_lists.3.description", fmt.Sprintf("US-%s", prefixList4)),
+				),
+			},
+		},
+	})
+}
+
 func TestRateLimiter_SingleToken(t *testing.T) {
 	rl := NewRateLimiter(5, 100*time.Millisecond)
 


### PR DESCRIPTION
### User-Facing Summary
This PR fixes a race condition in the MCR resource that occurs when managing multiple prefix filter lists across different MCRs. The issue manifested as inconsistent state values, where prefix filter list descriptions would get mixed up between different lists. The fix converts parallel processing to sequential operations to maintain state consistency.

---

### Type of Change

- [ ] 🚀 New Feature
- [ ] ✨ Enhancement
- [x] 🐛 Bug Fix
- [ ] 📚 Documentation Update
- [ ] 🏗️ Chore / Other

---

### Related Issues
Fixes an issue where applying changes to MCRs with multiple prefix filter lists would result in the error:
"Provider produced inconsistent result after apply" with attribute values being swapped between lists.

---

### How to Test
1. Create multiple MCRs with various prefix filter lists using `for_each`
2. Update the prefix filter lists with new descriptions and entries
3. Verify that all prefix filter lists are correctly updated without errors
4. Run the new acceptance test `TestAccMegaportMCR_MultipleInstancesWithPrefixLists` which reproduces and verifies the fix for the race condition