### PR TITLE
feat: support ipMtu in vrouter/aend partner config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.22.1
 	github.com/hashicorp/terraform-plugin-log v0.9.0
-	github.com/megaport/megaportgo v1.3.8
+	github.com/megaport/megaportgo v1.3.9
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/megaport/megaportgo v1.3.8 h1:CVPcVjTSnV4VSzvwyMVvGHAaEtcau7jK6rbuyDUqU2U=
-github.com/megaport/megaportgo v1.3.8/go.mod h1:dB0kCv1QQvfOR07J+Q75Cw5Kvs3n3O52C9cCt6LJvYs=
+github.com/megaport/megaportgo v1.3.9 h1:fuQcvj44csscQC8Kutte5Zzk3nuf/AxV3eI6/Cy0iNs=
+github.com/megaport/megaportgo v1.3.9/go.mod h1:dB0kCv1QQvfOR07J+Q75Cw5Kvs3n3O52C9cCt6LJvYs=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=

--- a/internal/provider/vxc_resource.go
+++ b/internal/provider/vxc_resource.go
@@ -147,6 +147,7 @@ var (
 
 	// deprecated
 	vxcInterfaceAttrs = map[string]attr.Type{
+		"ip_mtu":           types.Int64Type,
 		"ip_addresses":     types.ListType{}.WithElementType(types.StringType),
 		"ip_routes":        types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(ipRouteAttrs)),
 		"nat_ip_addresses": types.ListType{}.WithElementType(types.StringType),
@@ -181,6 +182,7 @@ var (
 	}
 
 	vxcVrouterInterfaceAttrs = map[string]attr.Type{
+		"ip_mtu":           types.Int64Type,
 		"ip_addresses":     types.ListType{}.WithElementType(types.StringType),
 		"ip_routes":        types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(ipRouteAttrs)),
 		"nat_ip_addresses": types.ListType{}.WithElementType(types.StringType),
@@ -402,6 +404,7 @@ type vxcPartnerConfigIbmModel struct {
 
 // vxcPartnerConfigInterfaceModel maps the partner configuration schema data for an interface.
 type vxcPartnerConfigInterfaceModel struct {
+	IpMtu          types.Int64  `tfsdk:"ip_mtu"`
 	IPAddresses    types.List   `tfsdk:"ip_addresses"`
 	IPRoutes       types.List   `tfsdk:"ip_routes"`
 	NatIPAddresses types.List   `tfsdk:"nat_ip_addresses"`

--- a/internal/provider/vxc_resource_utils.go
+++ b/internal/provider/vxc_resource_utils.go
@@ -390,6 +390,9 @@ func createVrouterPartnerConfig(ctx context.Context, vrouterConfig vxcPartnerCon
 	diags.Append(ifaceDiags...)
 	for _, iface := range ifaceModels {
 		toAppend := megaport.PartnerConfigInterface{}
+		if !iface.IpMtu.IsNull() {
+			toAppend.IpMtu = int(iface.IpMtu.ValueInt64())
+		}
 		if !iface.IPAddresses.IsNull() {
 			ipAddresses := []string{}
 			ipDiags := iface.IPAddresses.ElementsAs(ctx, &ipAddresses, true)
@@ -526,6 +529,9 @@ func createAEndPartnerConfig(ctx context.Context, partnerConfigAEndModel vxcPart
 	diags.Append(ifaceDiags...)
 	for _, iface := range ifaceModels {
 		toAppend := megaport.PartnerConfigInterface{}
+		if !iface.IpMtu.IsNull() {
+			toAppend.IpMtu = int(iface.IpMtu.ValueInt64())
+		}
 		if !iface.IPAddresses.IsNull() {
 			ipAddresses := []string{}
 			ipDiags := iface.IPAddresses.ElementsAs(ctx, &ipAddresses, true)

--- a/internal/provider/vxc_schemas.go
+++ b/internal/provider/vxc_schemas.go
@@ -171,6 +171,13 @@ var (
 				Required:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
+						"ip_mtu": schema.Int64Attribute{
+							Description: "The IP MTU of the partner configuration interface. Defaults to 1500.",
+							Optional:    true,
+							Validators: []validator.Int64{
+								int64validator.Between(68, 9074),
+							},
+						},
 						"ip_addresses": schema.ListAttribute{
 							Description: "The IP addresses of the partner configuration. Each entry must be in CIDR notation (e.g., \"169.254.100.6/29\").",
 							Optional:    true,
@@ -328,6 +335,13 @@ var (
 				Required:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
+						"ip_mtu": schema.Int64Attribute{
+							Description: "The IP MTU of the partner configuration interface. Defaults to 1500.",
+							Optional:    true,
+							Validators: []validator.Int64{
+								int64validator.Between(68, 9074),
+							},
+						},
 						"ip_addresses": schema.ListAttribute{
 							Description: "The IP addresses of the partner configuration. Each entry must be in CIDR notation (e.g., \"169.254.100.6/29\").",
 							Optional:    true,


### PR DESCRIPTION
### User-Facing Summary

This PR adds support for IP MTU (Maximum Transmission Unit) configuration in the Megaport Terraform provider. The IP MTU setting was implemented in the Megaport API in April 2025, but was missing from the Terraform provider. This addition allows users to configure custom MTU values for their virtual cross connects, which is particularly valuable when connecting to cloud providers that support jumbo frames (like Oracle Cloud Infrastructure).

---

### Type of Change

- [x] 🚀 New Feature
- [x] ✨ Enhancement
- [ ] 🐛 Bug Fix
- [ ] 📚 Documentation Update
- [ ] 🏗️ Chore / Other

---

### Related Issues

---

### How to Test

* Create a new MCR (Megaport Cloud Router) or update an existing one
* Create a VXC (Virtual Cross Connect) between your MCR and a cloud provider that supports jumbo frames
* Configure the `ip_mtu` parameter (either globally or on specific ends) to a value larger than the default 1500
* Apply the configuration and verify that:
1. The resource is created/updated successfully
2. The MTU is set correctly in the Megaport Portal UI
3. The MTU setting is preserved on subsequent terraform plan operations


---
