### PR TITLE
fix: add mve label to tests, change test cases to use small mve size

### DIFF
--- a/internal/provider/mve_resource_test.go
+++ b/internal/provider/mve_resource_test.go
@@ -56,7 +56,8 @@ func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEAruba_Basic() {
 
                     vendor_config = {
                         vendor = "aruba"
-                        product_size = "MEDIUM"
+                        product_size = "SMALL"
+						mve_label = "MVE 2/8"
                         image_id = data.megaport_mve_images.aruba.mve_images.0.id
 						account_name = "%s"
 						account_key = "%s"
@@ -88,7 +89,7 @@ func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEAruba_Basic() {
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_type", "MVE"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "contract_term_months", "1"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "vendor", "ARUBA"),
-					resource.TestCheckResourceAttr("megaport_mve.mve", "mve_size", "MEDIUM"),
+					resource.TestCheckResourceAttr("megaport_mve.mve", "mve_size", "SMALL"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "resource_tags.key1", "value1"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "resource_tags.key2", "value2"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_uid"),
@@ -147,7 +148,8 @@ func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEAruba_Basic() {
 
                     vendor_config = {
                         vendor = "ArUbA"
-                        product_size = "mEdIuM"
+                        product_size = "sMaLl"
+						mve_label = "MVE 2/8"
                         image_id = data.megaport_mve_images.aruba.mve_images.0.id
 						account_name = "%s"
 						account_key = "%s"
@@ -174,7 +176,7 @@ func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEAruba_Basic() {
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_type", "MVE"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "contract_term_months", "1"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "vendor", "ARUBA"),
-					resource.TestCheckResourceAttr("megaport_mve.mve", "mve_size", "MEDIUM"),
+					resource.TestCheckResourceAttr("megaport_mve.mve", "mve_size", "SMALL"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "diversity_zone", "red"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "resource_tags.key1updated", "value1updated"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "resource_tags.key2updated", "value2updated"),
@@ -246,7 +248,8 @@ func (suite *MVEVersaProviderTestSuite) TestAccMegaportMVEVersa_Basic() {
 
                     vendor_config = {
                         vendor = "versa"
-                        product_size = "LARGE"
+                        product_size = "SMALL"
+						mve_label = "MVE 2/8"
                         image_id = data.megaport_mve_images.versa.mve_images.0.id
 						director_address = "director1.versa.com"
 						controller_address = "controller1.versa.com"
@@ -275,7 +278,7 @@ func (suite *MVEVersaProviderTestSuite) TestAccMegaportMVEVersa_Basic() {
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_type", "MVE"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "contract_term_months", "1"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "vendor", "VERSA"),
-					resource.TestCheckResourceAttr("megaport_mve.mve", "mve_size", "LARGE"),
+					resource.TestCheckResourceAttr("megaport_mve.mve", "mve_size", "SMALL"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "resource_tags.key1", "value1"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "resource_tags.key2", "value2"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_uid"),
@@ -336,7 +339,8 @@ func (suite *MVEVersaProviderTestSuite) TestAccMegaportMVEVersa_Basic() {
 
                     vendor_config = {
                         vendor = "VeRsA"
-                        product_size = "lArGe"
+                        product_size = "sMaLl"
+						mve_label = "MVE 2/8"
                         image_id = data.megaport_mve_images.versa.mve_images.0.id
 						director_address = "director1.versa.com"
 						controller_address = "controller1.versa.com"
@@ -365,7 +369,7 @@ func (suite *MVEVersaProviderTestSuite) TestAccMegaportMVEVersa_Basic() {
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_type", "MVE"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "contract_term_months", "1"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "vendor", "VERSA"),
-					resource.TestCheckResourceAttr("megaport_mve.mve", "mve_size", "LARGE"),
+					resource.TestCheckResourceAttr("megaport_mve.mve", "mve_size", "SMALL"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "resource_tags.key1updated", "value1updated"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "resource_tags.key2updated", "value2updated"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_uid"),

--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -1605,6 +1605,7 @@ func (suite *VXCMVEProviderTestSuite) TestMVE_TransitVXC() {
 					vendor_config = {
 					  vendor        = "aruba"
 					  product_size  = "MEDIUM"
+					  mve_label     = "MVE 4/16"
 					  image_id      = 23
 					  account_name  = "%s"
 					  account_key   = "%s"
@@ -1736,6 +1737,7 @@ func (suite *VXCCSPProviderTestSuite) TestMVE_TransitVXCAWS() {
 					vendor_config = {
 					  vendor        = "aruba"
 					  product_size  = "MEDIUM"
+					  mve_label     = "MVE 4/16"
 					  image_id      = 23
 					  account_name  = "%s"
 					  account_key   = "%s"
@@ -1937,6 +1939,7 @@ func (suite *VXCCSPProviderTestSuite) TestMVE_TransitVXCAWS() {
 					vendor_config = {
 					  vendor        = "aruba"
 					  product_size  = "MEDIUM"
+					  mve_label     = "MVE 4/16"
 					  image_id      = 23
 					  account_name  = "%s"
 					  account_key   = "%s"
@@ -2081,6 +2084,7 @@ func (suite *VXCCSPProviderTestSuite) TestMVE_AWS_VXC() {
                     vendor_config = {
                         vendor = "aruba"
                         product_size = "MEDIUM"
+						mve_label     = "MVE 4/16"
                         image_id = 23
 						account_name = "%s"
 						account_key = "%s"
@@ -2194,6 +2198,7 @@ func (suite *VXCCSPProviderTestSuite) TestMVE_AWS_VXC() {
                     vendor_config = {
                         vendor = "aruba"
                         product_size = "MEDIUM"
+						mve_label     = "MVE 4/16"
                         image_id = 23
 						account_name = "%s"
 						account_key = "%s"
@@ -2511,6 +2516,7 @@ func (suite *VXCMixedProviderTestSuite) TestAccMegaportSafeDelete() {
                     vendor_config = {
                         vendor       = "aruba"
                         product_size = "MEDIUM"
+						mve_label     = "MVE 4/16"
                         image_id     = 23
                         account_name = "%s-account"
                         account_key  = "%s-key"
@@ -2653,6 +2659,7 @@ func (suite *VXCMixedProviderTestSuite) TestAccMegaportSafeDelete() {
                     vendor_config = {
                         vendor       = "aruba"
                         product_size = "MEDIUM"
+						mve_label     = "MVE 4/16"
                         image_id     = 23
                         account_name = "%s-account"
                         account_key  = "%s-key"
@@ -2712,6 +2719,7 @@ func (suite *VXCMVEProviderTestSuite) TestAccMegaportMVE_to_MVE_VXC() {
                     vendor_config = {
                       vendor        = "aruba"
                       product_size  = "MEDIUM"
+					  mve_label     = "MVE 4/16"
                       image_id      = data.megaport_mve_images.aruba.mve_images.0.id
                       account_name  = "%s-1"
                       account_key   = "%s-1"
@@ -2736,6 +2744,7 @@ func (suite *VXCMVEProviderTestSuite) TestAccMegaportMVE_to_MVE_VXC() {
                     vendor_config = {
                       vendor        = "aruba"
                       product_size  = "MEDIUM"
+					  mve_label     = "MVE 4/16"
                       image_id      = data.megaport_mve_images.aruba.mve_images.0.id
                       account_name  = "%s-2"
                       account_key   = "%s-2"
@@ -2760,6 +2769,7 @@ func (suite *VXCMVEProviderTestSuite) TestAccMegaportMVE_to_MVE_VXC() {
                     vendor_config = {
                       vendor        = "aruba"
                       product_size  = "MEDIUM"
+					  mve_label     = "MVE 4/16"
                       image_id      = data.megaport_mve_images.aruba.mve_images.0.id
                       account_name  = "%s-3"
                       account_key   = "%s-3"
@@ -2784,6 +2794,7 @@ func (suite *VXCMVEProviderTestSuite) TestAccMegaportMVE_to_MVE_VXC() {
                     vendor_config = {
                       vendor        = "aruba"
                       product_size  = "MEDIUM"
+					  mve_label     = "MVE 4/16"
                       image_id      = data.megaport_mve_images.aruba.mve_images.0.id
                       account_name  = "%s-4"
                       account_key   = "%s-4"
@@ -2852,6 +2863,7 @@ func (suite *VXCMVEProviderTestSuite) TestAccMegaportMVE_to_MVE_VXC() {
                     vendor_config = {
                       vendor        = "aruba"
                       product_size  = "MEDIUM"
+					  mve_label     = "MVE 4/16"
                       image_id      = data.megaport_mve_images.aruba.mve_images.0.id
                       account_name  = "%s-1"
                       account_key   = "%s-1"
@@ -2876,6 +2888,7 @@ func (suite *VXCMVEProviderTestSuite) TestAccMegaportMVE_to_MVE_VXC() {
                     vendor_config = {
                       vendor        = "aruba"
                       product_size  = "MEDIUM"
+					  mve_label     = "MVE 4/16"
                       image_id      = data.megaport_mve_images.aruba.mve_images.0.id
                       account_name  = "%s-2"
                       account_key   = "%s-2"
@@ -2900,6 +2913,7 @@ func (suite *VXCMVEProviderTestSuite) TestAccMegaportMVE_to_MVE_VXC() {
                     vendor_config = {
                       vendor        = "aruba"
                       product_size  = "MEDIUM"
+					  mve_label     = "MVE 4/16"
                       image_id      = data.megaport_mve_images.aruba.mve_images.0.id
                       account_name  = "%s-3"
                       account_key   = "%s-3"
@@ -2924,6 +2938,7 @@ func (suite *VXCMVEProviderTestSuite) TestAccMegaportMVE_to_MVE_VXC() {
                     vendor_config = {
                       vendor        = "aruba"
                       product_size  = "MEDIUM"
+					  mve_label     = "MVE 4/16"
                       image_id      = data.megaport_mve_images.aruba.mve_images.0.id
                       account_name  = "%s-4"
                       account_key   = "%s-4"


### PR DESCRIPTION
### User-Facing Summary

Modifies acceptance test cases to use small MVE Images to avoid capacity issues with the API.

---

### Type of Change

- [ ] 🚀 New Feature
- [ ] ✨ Enhancement
- [ ] 🐛 Bug Fix
- [ ] 📚 Documentation Update
- [x] 🏗️ Chore / Other

---

### Related Issues

---

### How to Test

Run acceptance tests in the Megaport Terraform Provider.

---
