### PR TITLE
docs: fix partner port documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,38 @@ Please note that datacenter locations can sometimes change their name or less fr
 However, their numeric ID will always remain the same in the Megaport API.
 
 The most up-to-date listing of Megaport Datacenter Locations can be accessed through the Megaport API at `GET /v2/locations`
+
+## Partner Port Stability
+
+Partner ports (used to connect to cloud service providers) may occasionally have their UIDs changed by Megaport as part of capacity management. This can lead to unexpected warning messages during Terraform operations even when the VXCs themselves are not being modified:
+
+```
+Warning: VXC B-End product UID is from a partner port, therefore it will not be changed.
+```
+
+This warning appears because Terraform detects a difference in the partner port UID even when applying changes unrelated to those specific VXCs.
+
+### Workaround
+
+To prevent these warnings and ensure configuration stability, we recommend explicitly specifying the `product_uid` in your partner port data source once your connections are established:
+
+```terraform
+# Initial setup - use standard filtering to find the partner port
+data "megaport_partner" "awshc" {
+  connect_type    = "AWSHC"
+  company_name    = "AWS"
+  product_name    = "US East (N. Virginia) (us-east-1)"
+  diversity_zone  = "blue"
+  location_id     = 123
+}
+
+# After your connections are established, update your configuration
+# to explicitly specify the product_uid for stability
+data "megaport_partner" "awshc" {
+  product_uid     = "a1b2c3d4-5678-90ef-ghij-klmnopqrstuv"
+  # You can keep other filters for documentation purposes
+  # but product_uid takes precedence
+}
+```
+
+This ensures that even if Megaport rotates the underlying ports, your Terraform configurations will continue to reference the same specific partner port.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The most up-to-date listing of Megaport Datacenter Locations can be accessed thr
 
 ## Partner Port Stability
 
-Partner ports (used to connect to cloud service providers) may occasionally have their UIDs changed by Megaport as part of capacity management. This can lead to unexpected warning messages during Terraform operations even when the VXCs themselves are not being modified:
+When using filter criteria to select partner ports (used to connect to cloud service providers), the specific partner port (and therefore UID) that best matches your filters may change over time as Megaport manages capacity by rotating ports. This can lead to unexpected warning messages during Terraform operations even when the VXCs themselves are not being modified:
 
 ```
 Warning: VXC B-End product UID is from a partner port, therefore it will not be changed.

--- a/docs/data-sources/partner.md
+++ b/docs/data-sources/partner.md
@@ -40,7 +40,7 @@ data "megaport_partner" "aws_port" {
 - `diversity_zone` (String) The diversity zone of the partner port.
 - `location_id` (Number) The unique identifier of the location of the partner port.
 - `product_name` (String) The name of the partner port.
-- `product_uid` (String) The unique identifier of the partner port. This ID may change over time as Megaport rotates ports for capacity management, which can cause warnings like "VXC B-End product UID is from a partner port, therefore it will not be changed" during unrelated modifications. To avoid this, once you've established your connections, you can explicitly set this value in your configuration to ensure stability.
+- `product_uid` (String) The unique identifier of the partner port. This ID may change when port parameters are modified, especially when changing which port has vxc_permitted: true. This can cause warnings like "VXC B-End product UID is from a partner port, therefore it will not be changed" during unrelated modifications. To ensure stability after establishing your connections, explicitly set this value in your configuration.
 
 ### Read-Only
 

--- a/docs/data-sources/partner.md
+++ b/docs/data-sources/partner.md
@@ -4,11 +4,19 @@ page_title: "megaport_partner Data Source - terraform-provider-megaport"
 subcategory: ""
 description: |-
   Partner Port Data Source. Returns the interfaces Megaport has with cloud service providers.
+  NOTE: Partner port UIDs may change over time as Megaport manages capacity by rotating ports.
+  This can cause unexpected warnings when modifying resources that reference partner ports,
+  even when those resources are not being directly changed. If you need stability, consider explicitly
+  specifying the product_uid in your configuration once you've established your connections.
 ---
 
 # megaport_partner (Data Source)
 
-Partner Port Data Source. Returns the interfaces Megaport has with cloud service providers.
+Partner Port Data Source. Returns the interfaces Megaport has with cloud service providers. 
+NOTE: Partner port UIDs may change over time as Megaport manages capacity by rotating ports. 
+This can cause unexpected warnings when modifying resources that reference partner ports, 
+even when those resources are not being directly changed. If you need stability, consider explicitly 
+specifying the product_uid in your configuration once you've established your connections.
 
 ## Example Usage
 
@@ -28,14 +36,14 @@ data "megaport_partner" "aws_port" {
 
 - `company_name` (String) The name of the company that owns the partner port.
 - `company_uid` (String) The unique identifier of the company that owns the partner port.
-- `connect_type` (String) The type of connection for the partner port. Filters the locations based on the cloud providers, such as AWS (for Hosted VIF), AWSHC (for Hosted Connection), AZURE, GOOGLE, ORACLE, OUTSCALE, and IBM. Use TRANSIT fto display Ports that support a Megaport Internet connection. Use FRANCEIX to display France-IX Ports that you can connect to.
+- `connect_type` (String) The type of connection for the partner port. Filters the locations based on the cloud providers, such as AWS (for Hosted VIF), AWSHC (for Hosted Connection), AZURE, GOOGLE, ORACLE, OUTSCALE, and IBM. Use TRANSIT to display Ports that support a Megaport Internet connection. Use FRANCEIX to display France-IX Ports that you can connect to.
 - `diversity_zone` (String) The diversity zone of the partner port.
 - `location_id` (Number) The unique identifier of the location of the partner port.
 - `product_name` (String) The name of the partner port.
+- `product_uid` (String) The unique identifier of the partner port. This ID may change over time as Megaport rotates ports for capacity management, which can cause warnings like "VXC B-End product UID is from a partner port, therefore it will not be changed" during unrelated modifications. To avoid this, once you've established your connections, you can explicitly set this value in your configuration to ensure stability.
 
 ### Read-Only
 
-- `product_uid` (String) The unique identifier of the partner port.
 - `rank` (Number) The rank of the partner port.
 - `speed` (Number) The speed of the partner port.
 - `vxc_permitted` (Boolean) Whether VXCs are permitted on the partner port. If false, you can not create a VXC on this port. If true, you can create a VXC on this port.

--- a/internal/provider/partner_port_data_source.go
+++ b/internal/provider/partner_port_data_source.go
@@ -53,15 +53,20 @@ func (d *partnerPortDataSource) Metadata(_ context.Context, req datasource.Metad
 // Schema defines the schema for the data source.
 func (d *partnerPortDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Partner Port Data Source. Returns the interfaces Megaport has with cloud service providers.",
+		Description: `Partner Port Data Source. Returns the interfaces Megaport has with cloud service providers. 
+NOTE: Partner port UIDs may change over time as Megaport manages capacity by rotating ports. 
+This can cause unexpected warnings when modifying resources that reference partner ports, 
+even when those resources are not being directly changed. If you need stability, consider explicitly 
+specifying the product_uid in your configuration once you've established your connections.`,
 		Attributes: map[string]schema.Attribute{
 			"connect_type": &schema.StringAttribute{
-				Description: "The type of connection for the partner port. Filters the locations based on the cloud providers, such as AWS (for Hosted VIF), AWSHC (for Hosted Connection), AZURE, GOOGLE, ORACLE, OUTSCALE, and IBM. Use TRANSIT fto display Ports that support a Megaport Internet connection. Use FRANCEIX to display France-IX Ports that you can connect to.",
+				Description: "The type of connection for the partner port. Filters the locations based on the cloud providers, such as AWS (for Hosted VIF), AWSHC (for Hosted Connection), AZURE, GOOGLE, ORACLE, OUTSCALE, and IBM. Use TRANSIT to display Ports that support a Megaport Internet connection. Use FRANCEIX to display France-IX Ports that you can connect to.",
 				Optional:    true,
 				Computed:    true,
 			},
 			"product_uid": &schema.StringAttribute{
-				Description: "The unique identifier of the partner port.",
+				Description: `The unique identifier of the partner port. This ID may change over time as Megaport rotates ports for capacity management, which can cause warnings like "VXC B-End product UID is from a partner port, therefore it will not be changed" during unrelated modifications. To avoid this, once you've established your connections, you can explicitly set this value in your configuration to ensure stability.`,
+				Optional:    true,
 				Computed:    true,
 			},
 			"product_name": &schema.StringAttribute{

--- a/internal/provider/partner_port_data_source.go
+++ b/internal/provider/partner_port_data_source.go
@@ -65,7 +65,7 @@ specifying the product_uid in your configuration once you've established your co
 				Computed:    true,
 			},
 			"product_uid": &schema.StringAttribute{
-				Description: `The unique identifier of the partner port. This ID may change over time as Megaport rotates ports for capacity management, which can cause warnings like "VXC B-End product UID is from a partner port, therefore it will not be changed" during unrelated modifications. To avoid this, once you've established your connections, you can explicitly set this value in your configuration to ensure stability.`,
+				Description: `The unique identifier of the partner port. This ID may change when port parameters are modified, especially when changing which port has vxc_permitted: true. This can cause warnings like "VXC B-End product UID is from a partner port, therefore it will not be changed" during unrelated modifications. To ensure stability after establishing your connections, explicitly set this value in your configuration.`,
 				Optional:    true,
 				Computed:    true,
 			},


### PR DESCRIPTION
### User-Facing Summary

This PR adds documentation explaining the partner port stability issue that customers have been experiencing. When Megaport rotates partner ports for capacity management, it can cause unexpected warning messages during Terraform operations, even when the VXCs themselves are not being modified. The PR adds clear guidance and a workaround by explicitly specifying the product_uid in partner port data sources once connections are established.

---

### Type of Change

- [ ] 🚀 New Feature
- [ ] ✨ Enhancement
- [ ] 🐛 Bug Fix
- [x] 📚 Documentation Update
- [ ] 🏗️ Chore / Other

---

### Related Issues

Addresses #214 - Unexpected warning messages about partner ports during unrelated terraform operations

### Detailed Description

This PR addresses a common issue where customers receive unexpected warning messages (Warning: VXC B-End product UID is from a partner port, therefore it will not be changed.) when making changes to Terraform configurations that are unrelated to their VXC connections.

The issue occurs because partner port UIDs may change as Megaport rotates ports for capacity management. This causes Terraform to detect a difference in the partner port UID even when no actual changes to the VXC are intended.

### Changes:

* Added a new "Partner Port Stability" section in the `README.md` that explains the issue and provides a workaround
* Enhanced the schema description for `product_uid` in `partner_port_data_source.go` to better explain the issue
* Provided code examples showing how to transition from dynamic port selection to explicit `product_uid` specification

---

### How to Test

1. Review the documentation changes in README.md
2. Verify that the workaround is clear and actionable
3. Ensure the enhanced schema descriptions in the code provide proper context for the issue

---
