### PR TITLE
feat: support cancellation at end of term rather than immediately for…

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,4 +177,26 @@ data "megaport_partner" "awshc" {
 }
 ```
 
-This ensures that even if Megaport rotates the underlying ports, your Terraform configurations will continue to reference the same specific partner port.
+## End-of-Term Cancellation
+
+By default, when Terraform deletes resources, they are immediately cancelled in the Megaport portal. However, you may prefer to have resources marked for cancellation at the end of their current billing term instead of immediate cancellation.
+
+The provider supports this with the `cancel_at_end_of_term` configuration option:
+
+```terraform
+provider "megaport" {
+  environment           = "production"
+  access_key            = "your-access-key"
+  secret_key            = "your-secret-key"
+  accept_purchase_terms = true
+  cancel_at_end_of_term = true  # Mark resources for end-of-term cancellation
+}
+```
+
+**Important notes:**
+
+- This feature is currently only supported for Single Ports and LAG Ports
+- For other resource types, the option will be ignored and immediate cancellation will occur
+- When `cancel_at_end_of_term` is set to `true`, resources will show as "CANCELLING" in the Megaport portal until the end of their billing term
+- Resources are removed from Terraform state immediately, regardless of this setting
+- If you re-apply your configuration after marking a resource for cancellation, Terraform will not attempt to recreate the resource as long as it remains in your state file

--- a/internal/provider/ix_resource.go
+++ b/internal/provider/ix_resource.go
@@ -756,15 +756,18 @@ func (r *ixResource) Configure(_ context.Context, req resource.ConfigureRequest,
 		return
 	}
 
-	client, ok := req.ProviderData.(*megaport.Client)
+	providerData, ok := req.ProviderData.(*megaportProviderData)
+
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *megaport.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *megaportProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
 	}
+
+	client := providerData.client
 
 	r.client = client
 }

--- a/internal/provider/location_data_source.go
+++ b/internal/provider/location_data_source.go
@@ -446,15 +446,18 @@ func (d *locationDataSource) Configure(_ context.Context, req datasource.Configu
 		return
 	}
 
-	client, ok := req.ProviderData.(*megaport.Client)
+	providerData, ok := req.ProviderData.(*megaportProviderData)
+
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *megaport.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *megaportProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
 	}
+
+	client := providerData.client
 
 	d.client = client
 }

--- a/internal/provider/mcr_resource.go
+++ b/internal/provider/mcr_resource.go
@@ -1209,15 +1209,18 @@ func (r *mcrResource) Configure(_ context.Context, req resource.ConfigureRequest
 		return
 	}
 
-	client, ok := req.ProviderData.(*megaport.Client)
+	providerData, ok := req.ProviderData.(*megaportProviderData)
+
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *megaport.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *megaportProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
 	}
+
+	client := providerData.client
 
 	r.client = client
 }

--- a/internal/provider/mve_image_data_source.go
+++ b/internal/provider/mve_image_data_source.go
@@ -222,15 +222,18 @@ func (d *mveImageDataSource) Configure(_ context.Context, req datasource.Configu
 		return
 	}
 
-	client, ok := req.ProviderData.(*megaport.Client)
+	providerData, ok := req.ProviderData.(*megaportProviderData)
+
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *megaport.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *megaportProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
 	}
+
+	client := providerData.client
 
 	d.client = client
 }

--- a/internal/provider/mve_size_data_source.go
+++ b/internal/provider/mve_size_data_source.go
@@ -140,15 +140,18 @@ func (d *mveSizeDataSource) Configure(_ context.Context, req datasource.Configur
 		return
 	}
 
-	client, ok := req.ProviderData.(*megaport.Client)
+	providerData, ok := req.ProviderData.(*megaportProviderData)
+
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *megaport.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *megaportProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
 	}
+
+	client := providerData.client
 
 	d.client = client
 }

--- a/internal/provider/partner_port_data_source.go
+++ b/internal/provider/partner_port_data_source.go
@@ -200,15 +200,18 @@ func (d *partnerPortDataSource) Configure(_ context.Context, req datasource.Conf
 		return
 	}
 
-	client, ok := req.ProviderData.(*megaport.Client)
+	providerData, ok := req.ProviderData.(*megaportProviderData)
+
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *megaport.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *megaportProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
 	}
+
+	client := providerData.client
 
 	d.client = client
 }

--- a/internal/provider/vxc_resource.go
+++ b/internal/provider/vxc_resource.go
@@ -2422,15 +2422,18 @@ func (r *vxcResource) Configure(_ context.Context, req resource.ConfigureRequest
 		return
 	}
 
-	client, ok := req.ProviderData.(*megaport.Client)
+	providerData, ok := req.ProviderData.(*megaportProviderData)
+
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *megaport.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *megaportProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
 	}
+
+	client := providerData.client
 
 	r.client = client
 }


### PR DESCRIPTION
… port and lag ports

### User-Facing Summary

Adds a new provider-level configuration option `cancel_at_end_of_term` to support cancellation of resources at the end of billing terms rather than immediately. This addresses customer requests for more flexible resource lifecycle management that aligns with billing cycles.


---

### Type of Change

- [ ] 🚀 New Feature
- [x] ✨ Enhancement
- [ ] 🐛 Bug Fix
- [ ] 📚 Documentation Update
- [ ] 🏗️ Chore / Other

---

### Related Issues

- Customer request for end-of-term cancellation support
- Aligns Terraform provider with existing functionality in megaportgo client library

---

### How to Test

1. Configure the provider with `cancel_at_end_of_term = true`
2. Create and then destroy a resource (port, MCR, etc.)
3. Verify in the Megaport portal that the resource status is "CANCELLING" rather than being immediately deleted
4. Verify that the resource is removed from Terraform state
5. Wait until the end of the billing term to confirm the resource is actually terminated in Megaport

Additional test scenarios:
- Verify default behavior (immediate cancellation) still works when option is not specified
- Test with multiple resource types to ensure consistent behavior

---
