### PR TITLE
docs: service key example

### DIFF
--- a/docs/resources/vxc.md
+++ b/docs/resources/vxc.md
@@ -237,13 +237,13 @@ resource "megaport_vxc" "azure_vxc" {
   }
 }
 
-resource "megaport_vxc" "transit_vxc" {
+resource "megaport_vxc" "service_key_vxc" {
   product_name         = "Transit VXC Example"
   rate_limit           = 100
   contract_term_months = 1
 
   a_end = {
-    requested_product_uid = megaport_mve.mve.product_uid
+    requested_product_uid = megaport_port.port.product_uid
     vnic_index            = 2
   }
 
@@ -254,6 +254,19 @@ resource "megaport_vxc" "transit_vxc" {
   b_end_partner_config = {
     partner = "transit"
   }
+}
+
+resource "megaport_vxc" "service_key_vxc" {
+  product_name         = "Transit VXC Example"
+  rate_limit           = 100
+  contract_term_months = 1
+  service_key          = "SERVICE_KEY_TO_B_END_HERE" # For the B-End Product
+
+  a_end = {
+    requested_product_uid = megaport_port.port.product_uid
+  }
+
+  b_end = {}
 }
 ```
 

--- a/docs/resources/vxc.md
+++ b/docs/resources/vxc.md
@@ -257,7 +257,7 @@ resource "megaport_vxc" "transit_vxc" {
 }
 
 resource "megaport_vxc" "service_key_vxc" {
-  product_name         = "Transit VXC Example"
+  product_name         = "Service Key Example"
   rate_limit           = 100
   contract_term_months = 1
   service_key          = "SERVICE_KEY_TO_B_END_HERE" # For the B-End Product

--- a/docs/resources/vxc.md
+++ b/docs/resources/vxc.md
@@ -237,13 +237,13 @@ resource "megaport_vxc" "azure_vxc" {
   }
 }
 
-resource "megaport_vxc" "service_key_vxc" {
+resource "megaport_vxc" "transit_vxc" {
   product_name         = "Transit VXC Example"
   rate_limit           = 100
   contract_term_months = 1
 
   a_end = {
-    requested_product_uid = megaport_port.port.product_uid
+    requested_product_uid = megaport_mve.mve.product_uid
     vnic_index            = 2
   }
 

--- a/examples/resources/megaport_vxc/resource.tf
+++ b/examples/resources/megaport_vxc/resource.tf
@@ -242,7 +242,7 @@ resource "megaport_vxc" "transit_vxc" {
 }
 
 resource "megaport_vxc" "service_key_vxc" {
-  product_name         = "Transit VXC Example"
+  product_name         = "Service Key Example"
   rate_limit           = 100
   contract_term_months = 1
   service_key          = "SERVICE_KEY_TO_B_END_HERE" # For the B-End Product

--- a/examples/resources/megaport_vxc/resource.tf
+++ b/examples/resources/megaport_vxc/resource.tf
@@ -222,13 +222,13 @@ resource "megaport_vxc" "azure_vxc" {
   }
 }
 
-resource "megaport_vxc" "service_key_vxc" {
+resource "megaport_vxc" "transit_vxc" {
   product_name         = "Transit VXC Example"
   rate_limit           = 100
   contract_term_months = 1
 
   a_end = {
-    requested_product_uid = megaport_port.port.product_uid
+    requested_product_uid = megaport_mve.mve.product_uid
     vnic_index            = 2
   }
 

--- a/examples/resources/megaport_vxc/resource.tf
+++ b/examples/resources/megaport_vxc/resource.tf
@@ -222,13 +222,13 @@ resource "megaport_vxc" "azure_vxc" {
   }
 }
 
-resource "megaport_vxc" "transit_vxc" {
+resource "megaport_vxc" "service_key_vxc" {
   product_name         = "Transit VXC Example"
   rate_limit           = 100
   contract_term_months = 1
 
   a_end = {
-    requested_product_uid = megaport_mve.mve.product_uid
+    requested_product_uid = megaport_port.port.product_uid
     vnic_index            = 2
   }
 
@@ -239,4 +239,17 @@ resource "megaport_vxc" "transit_vxc" {
   b_end_partner_config = {
     partner = "transit"
   }
+}
+
+resource "megaport_vxc" "service_key_vxc" {
+  product_name         = "Transit VXC Example"
+  rate_limit           = 100
+  contract_term_months = 1
+  service_key          = "SERVICE_KEY_TO_B_END_HERE" # For the B-End Product
+
+  a_end = {
+    requested_product_uid = megaport_port.port.product_uid
+  }
+
+  b_end = {}
 }


### PR DESCRIPTION
### User-Facing Summary

Added a new service key VXC example to the Terraform provider documentation. This example demonstrates how to create a VXC using a service key for the B-End connection, which is useful when connecting to existing Megaport products using their service keys.

---

### Type of Change

- [ ] 🚀 New Feature
- [ ] ✨ Enhancement
- [ ] 🐛 Bug Fix
- [x] 📚 Documentation Update
- [ ] 🏗️ Chore / Other

---

### Related Issues

None - This is a documentation enhancement to provide users with a service key VXC example.

---

### How to Test

1. Review the new service key VXC example in `examples/resources/megaport_vxc/resource.tf`
2. Verify that the example follows Terraform best practices and is properly formatted
3. Confirm that the service key configuration demonstrates the correct usage pattern for B-End connections
4. Test that the example can be used as a reference for creating VXCs with service keys

**Note**: This is a documentation-only change that adds a code example. No functional testing is required.

---
