### PR TITLE
fix: bump megaportgo version, make vendor config fields more flexible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.22.1
 	github.com/hashicorp/terraform-plugin-log v0.9.0
-	github.com/megaport/megaportgo v1.4.0
+	github.com/megaport/megaportgo v1.4.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/megaport/megaportgo v1.4.0 h1:zPF3lcH8jdGkcolXAiVzVYuC2YE+tlpLcRHrLGK2Pos=
-github.com/megaport/megaportgo v1.4.0/go.mod h1:dB0kCv1QQvfOR07J+Q75Cw5Kvs3n3O52C9cCt6LJvYs=
+github.com/megaport/megaportgo v1.4.1 h1:gekXD/Tyj01g5fX6RuUAtPQkJpRwx5DzqrAVBq63lWY=
+github.com/megaport/megaportgo v1.4.1/go.mod h1:dB0kCv1QQvfOR07J+Q75Cw5Kvs3n3O52C9cCt6LJvYs=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=


### PR DESCRIPTION
### User-Facing Summary

Adds flexibility to MVE vendor configs to prevent empty string errors being triggered by the Megaport API.
---

### Type of Change

- [ ] 🚀 New Feature
- [ ] ✨ Enhancement
- [ ] 🐛 Bug Fix
- [ ] 📚 Documentation Update
- [ ] 🏗️ Chore / Other

---

### Related Issues

Addresses https://github.com/megaport/terraform-provider-megaport/issues/278

---

### How to Test

Deploy Cisco SD-Wan MVE via MVE Terraform Provider with only necessary vendor config fields for that MVE. API should no longer return validation related errors.

---
