### PR TITLE
fix: allow user to manually input product UID for partner port with a…

### DIFF
--- a/internal/provider/location_data_source_test.go
+++ b/internal/provider/location_data_source_test.go
@@ -22,7 +22,7 @@ const (
 	SinglePortTestLocationName = "NextDC B1"
 	VXCLocationNameOne         = "NextDC M1"
 	VXCLocationNameTwo         = "Global Switch Sydney West"
-	VXCLocationNameThree       = "5GN Melbourne Data Centre (MDC)"
+	VXCLocationNameThree       = "5G Networks MDC"
 )
 
 func TestLagPortLocation(t *testing.T) {


### PR DESCRIPTION
…zure/gcp/oracle vxc, fix location name in data source test

### User-Facing Summary

This PR allows a user to manually input the product UID (typically retrieved from a data source) for a partner port for a CSP End Config to a VXC. This is particularly useful with Google Cloud VXCs where there can sometimes be many partner ports where a pairing key can connect. Prior to this, we were querying for the first available partner port to match that pairing key. This gives the user more flexibility. 

---

### Type of Change

- [ ] 🚀 New Feature
- [x] ✨ Enhancement
- [ ] 🐛 Bug Fix
- [ ] 📚 Documentation Update
- [ ] 🏗️ Chore / Other

---

### Related Issues

---

### How to Test

Deploy a CSP VXC and specify the Product UID for the end config connecting to the CSP (Google/Azure/Oracle).  

---
