### PR TITLE
fix: refine inner vlan state change to only untag on updates

### DIFF
--- a/internal/provider/vxc_resource_utils.go
+++ b/internal/provider/vxc_resource_utils.go
@@ -696,15 +696,35 @@ func supportVLANUpdates(partnerType string) bool {
 	return true
 }
 
+// waitForVXCUpdate polls the VXC API to verify that an update has propagated successfully.
+// It uses exponential backoff with a maximum backoff time to efficiently wait for API propagation.
+//
+// Parameters:
+//   - ctx: Context for the operation (can be used for cancellation)
+//   - uid: The unique identifier of the VXC being updated
+//   - updateReq: The update request containing the expected values to verify
+//   - timeout: Maximum time to wait for the update to propagate
+//
+// Returns an error if:
+//   - The API calls fail
+//   - The context is cancelled
+//   - The timeout is reached before the update is verified
 func (r *vxcResource) waitForVXCUpdate(ctx context.Context, uid string, updateReq *megaport.UpdateVXCRequest, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	backoff := 2 * time.Second
 	maxBackoff := 10 * time.Second
 
+	// Add initial delay before first check to allow for quick propagation
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(1 * time.Second):
+	}
+
 	for time.Now().Before(deadline) {
 		vxc, err := r.client.VXCService.GetVXC(ctx, uid)
 		if err != nil {
-			return fmt.Errorf("failed to verify update: %w", err)
+			return fmt.Errorf("failed to retrieve VXC status during update verification for VXC UID %s: %w", uid, err)
 		}
 
 		// Verify the expected changes are reflected
@@ -726,7 +746,16 @@ func (r *vxcResource) waitForVXCUpdate(ctx context.Context, uid string, updateRe
 	return fmt.Errorf("update verification timed out after %v", timeout)
 }
 
+// verifyUpdateApplied checks if the VXC returned from the API matches the expected values
+// from the update request. It verifies all fields that can be updated.
+//
+// Parameters:
+//   - vxc: The VXC object retrieved from the API
+//   - updateReq: The update request containing the expected values
+//
+// Returns true if all updated fields match their expected values, false otherwise.
 func (r *vxcResource) verifyUpdateApplied(vxc *megaport.VXC, updateReq *megaport.UpdateVXCRequest) bool {
+	// Verify VLAN-related fields
 	if updateReq.AEndInnerVLAN != nil && vxc.AEndConfiguration.InnerVLAN != *updateReq.AEndInnerVLAN {
 		return false
 	}
@@ -739,5 +768,43 @@ func (r *vxcResource) verifyUpdateApplied(vxc *megaport.VXC, updateReq *megaport
 	if updateReq.BEndVLAN != nil && vxc.BEndConfiguration.VLAN != *updateReq.BEndVLAN {
 		return false
 	}
+
+	// Verify basic VXC properties
+	if updateReq.Name != nil && vxc.Name != *updateReq.Name {
+		return false
+	}
+	if updateReq.RateLimit != nil && vxc.RateLimit != *updateReq.RateLimit {
+		return false
+	}
+	if updateReq.CostCentre != nil && vxc.CostCentre != *updateReq.CostCentre {
+		return false
+	}
+	if updateReq.Shutdown != nil && vxc.Shutdown != *updateReq.Shutdown {
+		return false
+	}
+	if updateReq.Term != nil && vxc.ContractTermMonths != *updateReq.Term {
+		return false
+	}
+
+	// Verify endpoint product UIDs
+	if updateReq.AEndProductUID != nil && vxc.AEndConfiguration.UID != *updateReq.AEndProductUID {
+		return false
+	}
+	if updateReq.BEndProductUID != nil && vxc.BEndConfiguration.UID != *updateReq.BEndProductUID {
+		return false
+	}
+
+	// Verify VNIC indices
+	if updateReq.AVnicIndex != nil && vxc.AEndConfiguration.NetworkInterfaceIndex != *updateReq.AVnicIndex {
+		return false
+	}
+	if updateReq.BVnicIndex != nil && vxc.BEndConfiguration.NetworkInterfaceIndex != *updateReq.BVnicIndex {
+		return false
+	}
+
+	// Note: Partner configs (AEndPartnerConfig, BEndPartnerConfig) are complex objects
+	// and their verification would require deep comparison. For now, we focus on the
+	// simpler scalar fields that are more prone to propagation delays.
+
 	return true
 }


### PR DESCRIPTION
### User-Facing Summary

Fixed an issue where updating `inner_vlan` values on VXC resources would cause a "Provider produced inconsistent result after apply" error. The provider now correctly handles VLAN updates across all VXC types (Private VXCs, Megaport Internet, and Cloud connections) without state inconsistencies.

**What was happening:** When users changed VLAN values (e.g., from 1200 → 1100), Terraform would report an error claiming the final state didn't match the planned state, even though the VLAN change was successfully applied in the Megaport Portal.

**What's fixed:** The provider now properly synchronizes state with the API after updates, ensuring Terraform's state always reflects the actual resource configuration.

---

### Type of Change

- [ ] 🚀 New Feature
- [ ] ✨ Enhancement
- [x] 🐛 Bug Fix
- [ ] 📚 Documentation Update
- [ ] 🏗️ Chore / Other

---

### Related Issues

Addresses [megaport/terraform-provider-megaport#[286] - "Provider produced inconsistent result after apply" when changing VXC VLAN values](https://github.com/megaport/terraform-provider-megaport/issues/286)

---

### Root Cause

The bug was caused by **premature state mutation** in the VXC Update function. The provider was writing planned VLAN values to the state object before retrieving the updated resource from the API, which corrupted the "existing state" context needed by the `fromAPIVXC()` function to make correct state mapping decisions.

**Specific problems:**

1. `aEndState.InnerVLAN` and `bEndState.InnerVLAN` were assigned plan values immediately after building the update request
2. These modified state objects were written to `state.AEndConfiguration` and `state.BEndConfiguration` BEFORE calling the API
3. When `fromAPIVXC()` processed the API response, it read the "existing state" and saw the plan values (e.g., 1100) instead of the true pre-update values (e.g., 1200)
4. This caused incorrect state mapping decisions, particularly when API propagation had any delay

**Why it was intermittent:**

- Fast API environments: The bug was masked because GetVXC returned the new value immediately
- Slow API environments: GetVXC returned the old value due to propagation delay, exposing the state pollution bug

---

### Changes Made

#### 1. **Fixed Premature State Mutation**

- Removed all premature state assignments that were corrupting the state before API calls
- State is now only populated after successfully retrieving the updated resource from the API
- Exception: Inner VLAN value of `-1` (untagged) is set immediately when planned, as this is a valid terminal state

#### 2. **Added Retry Logic with Exponential Backoff**

- Implemented `waitForVXCUpdate()` function that polls the API after update requests
- Default timeout: 60 seconds
- Exponential backoff: starts at 2s, increases by 1.5x per attempt, caps at 10s
- Gracefully handles context cancellation
- Returns warning (not error) if verification times out, allowing Terraform to continue

#### 3. **Enhanced State Validation**

- Added `verifyUpdateApplied()` function to check if API reflects expected changes
- Validates both A-End and B-End VLAN values (inner_vlan and vlan)
- Provides diagnostic warnings when API returns unexpected values after update
- Helps identify API propagation delays without blocking Terraform operations

---

### Technical Details

**Key Files Modified:**

- `internal/provider/vxc_resource.go` - Update function flow
- `internal/provider/vxc_resource_utils.go` - Added retry logic and verification helpers

**Retry Logic Flow:**

```
1. Update VXC via API
2. Call waitForVXCUpdate() with 30 second timeout
3. Poll API with exponential backoff (2s → 3s → 4.5s → ... → 10s)
4. Verify expected values match API response
5. Return success when verified OR timeout with warning
6. Continue with state refresh from API
```

**Why This Works:**

- No longer corrupts state before API calls
- Gives API time to propagate changes (up to 60s by default)
- Validates actual API state before finalizing Terraform state
- Degrades gracefully with warnings rather than errors
- Preserves user intent when API is temporarily inconsistent

---

### How to Test

**Prerequisites:**

- Access to a Megaport account with ability to create MVEs and VXCs
- Terraform 1.13.2 or later
- Updated provider with this fix

#### **Test Case 1: Update Inner VLAN on Private VXC**

1. Create test configuration:

```hcl
data "megaport_location" "location" {
  name = "Global Switch Sydney"
}

data "megaport_mve_images" "palo_alto" {
  vendor_filter        = "Palo Alto"
  product_filter       = "VM-Series"
  release_image_filter = true
}

resource "megaport_mve" "firewall_a" {
  location_id          = data.megaport_location.location.id
  product_name         = "Test Firewall A"
  contract_term_months = 1

  vendor_config = {
    vendor              = data.megaport_mve_images.palo_alto.mve_images[0].vendor
    image_id            = data.megaport_mve_images.palo_alto.mve_images[0].id
    product_size        = "SMALL"
    admin_password_hash = "<your-hash>"
    ssh_public_key      = "<your-key>"
  }

  vnics = [
    { description = "Management" },
    { description = "Data" },
  ]
}

resource "megaport_mve" "firewall_b" {
  location_id          = data.megaport_location.location.id
  product_name         = "Test Firewall B"
  contract_term_months = 1

  vendor_config = {
    vendor              = data.megaport_mve_images.palo_alto.mve_images[0].vendor
    image_id            = data.megaport_mve_images.palo_alto.mve_images[0].id
    product_size        = "SMALL"
    admin_password_hash = "<your-hash>"
    ssh_public_key      = "<your-key>"
  }

  vnics = [
    { description = "Management" },
    { description = "Data" },
  ]
}

resource "megaport_vxc" "test_vxc" {
  product_name         = "Test Private VXC"
  rate_limit           = 1000
  contract_term_months = 1

  a_end = {
    requested_product_uid = megaport_mve.firewall_a.product_uid
    inner_vlan            = 1200
    vnic_index            = 1
  }

  b_end = {
    requested_product_uid = megaport_mve.firewall_b.product_uid
    inner_vlan            = 1200
    vnic_index            = 1
  }
}
```

2. Apply initial configuration:

```bash
terraform init
terraform apply
```

3. Change `inner_vlan` from 1200 to 1100:

```hcl
  a_end = {
    requested_product_uid = megaport_mve.firewall_a.product_uid
    inner_vlan            = 1100  # Changed from 1200
    vnic_index            = 1
  }

  b_end = {
    requested_product_uid = megaport_mve.firewall_b.product_uid
    inner_vlan            = 1100  # Changed from 1200
    vnic_index            = 1
  }
```

4. Apply the change:

```bash
terraform apply
```

5. **Expected Result:**

   - ✅ Apply completes successfully without errors
   - ✅ No "Provider produced inconsistent result after apply" error
   - ✅ Megaport Portal shows VLAN values updated to 1100
   - ✅ `terraform plan` shows no changes needed

6. **Previous Behavior (without fix):**
   - ❌ Error: "Provider produced inconsistent result after apply"
   - ❌ Error message: "was cty.NumberIntVal(1100), but now cty.NumberIntVal(1200)"
   - ❌ Required re-running `terraform apply` to resolve

---

#### **Test Case 2: API Propagation Delay Warning**

To test the warning system, you can observe behavior in slower environments:

**Expected Warning (if propagation exceeds timeout):**

```
Warning: VXC Update Propagation Delay

VXC update completed but verification timed out: update verification
timed out after 60s. The update may still be propagating.
```

**Additional Validation Warnings:**

```
Warning: A-End Inner VLAN Mismatch

Expected A-End inner_vlan=1100 but API returned 1200. This may
indicate API propagation delay.
```

**Important:** These are warnings, not errors. Terraform will:

- ✅ Continue with the apply operation
- ✅ Store the actual API state (not the planned state)
- ✅ On next `terraform plan`, reconcile any differences

---

### Benefits of This Approach

1. **Eliminates State Inconsistencies**

- No more "Provider produced inconsistent result" errors
- State always reflects actual API response, not planned values
- Terraform state remains trustworthy and accurate

2. **Handles API Propagation Delays**

- Automatically retries for up to 60 seconds
- Exponential backoff prevents API hammering
- Degrades gracefully with warnings instead of failing

3. **Improved User Experience**

- Single `terraform apply` completes successfully
- No need to re-run commands due to timing issues
- Clear diagnostic messages when delays occur
