### PR TITLE
docs: specify SHA-256 crypt format for Palo Alto MVE admin_password_h…

### DIFF
--- a/docs/resources/mve.md
+++ b/docs/resources/mve.md
@@ -149,7 +149,7 @@ Optional:
 
 - `account_key` (String) The account key for the vendor config. Enter the Account Key from Aruba Orchestrator. The key is linked to the Account Name. Required for Aruba MVE.
 - `account_name` (String) The account name for the vendor config. Enter the Account Name from Aruba Orchestrator. To view your Account Name, log in to Orchestrator and choose Orchestrator > Licensing | Cloud Portal. Required for Aruba MVE.
-- `admin_password_hash` (String) The admin password hash for the vendor config. Required for Palo Alto MVE.
+- `admin_password_hash` (String) The admin password hash for the vendor config. Required for Palo Alto MVE. Must be a SHA-256 crypt hash in the format "$5$<salt>$<hash>" (e.g., "$5$2833ea35$Pdyc6dKE8N/UBRge3QWDJJyotG3I59pxLJWVmcSQDdC"). On Linux/macOS, you can generate this using: "mkpasswd -m sha-256 'your_password'".
 - `admin_ssh_public_key` (String) The admin SSH public key for the vendor config. Required for Cisco, Fortinet, and Vmware MVEs.
 - `cloud_init` (String) The Base64 encoded cloud init file for the vendor config. The bootstrap configuration file. Required for Aviatrix and Cisco C8000v.
 - `controller_address` (String) The controldler address for the vendor config. A FQDN (Fully Qualified Domain Name) or IPv4 address of your Versa Controller. Required for Versa MVE.

--- a/internal/provider/mve_resource.go
+++ b/internal/provider/mve_resource.go
@@ -642,7 +642,7 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 						Optional:    true,
 					},
 					"admin_password_hash": schema.StringAttribute{
-						Description: "The admin password hash for the vendor config. Required for Palo Alto MVE.",
+						Description: `The admin password hash for the vendor config. Required for Palo Alto MVE. Must be a SHA-256 crypt hash in the format "$5$<salt>$<hash>" (e.g., "$5$2833ea35$Pdyc6dKE8N/UBRge3QWDJJyotG3I59pxLJWVmcSQDdC"). On Linux/macOS, you can generate this using: "mkpasswd -m sha-256 'your_password'".`,
 						Optional:    true,
 					},
 					"director_address": schema.StringAttribute{


### PR DESCRIPTION
### User Facing Summary

**Improved Palo Alto MVE Password Hash Documentation**

The `admin_password_hash` field documentation for Palo Alto MVE has been updated to clearly specify the required format and how to generate it.

**What changed:**
- Documented that the field requires SHA-256 crypt format (`$5$<salt>$<hash>`)
- Added a practical example hash for reference
- Included command to generate the hash: `mkpasswd -m sha-256 'your_password'`

**Impact:**
Users will no longer need to guess which hash algorithm to use when configuring Palo Alto MVE. The documentation now provides clear instructions for generating the correct password hash format.

---

### Type of Change

- [ ] 🚀 New Feature
- [ ] ✨ Enhancement
- [ ] 🐛 Bug Fix
- [x] 📚 Documentation Update
- [ ] 🏗️ Chore / Other