### PR TITLE
fix: change field to use ID in vxc test because of location rename

### DIFF
--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -2336,7 +2336,7 @@ func (suite *VXCCSPProviderTestSuite) TestMVE_AWS_VXC() {
 				  }
 
 				  data "megaport_location" "syd_gs" {
-					name = "Global Switch Sydney West"
+					id = %d
 				  }
 
 				  data "megaport_partner" "aws_port" {
@@ -2413,7 +2413,7 @@ func (suite *VXCCSPProviderTestSuite) TestMVE_AWS_VXC() {
 					}
 				  }
 
-                  `, VXCLocationID1, portName, costCentreName, mveName, mveName, mveName, awsVXCName, awsVXCName),
+                  `, VXCLocationID1, VXCLocationID2, portName, costCentreName, mveName, mveName, mveName, awsVXCName, awsVXCName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("megaport_vxc.aws_vxc", "product_uid"),
 					resource.TestCheckResourceAttr("megaport_vxc.aws_vxc", "b_end_partner_config.aws_config.name", awsVXCName),


### PR DESCRIPTION
### User-Facing Summary
Changes field in VXC Acceptance test to use the ID instead of name, as it has changed in the API.
---

### Type of Change

- [ ] 🚀 New Feature
- [ ] ✨ Enhancement
- [x] 🐛 Bug Fix
- [ ] 📚 Documentation Update
- [ ] 🏗️ Chore / Other
