### PR TITLE
docs: clarify computed field behavior during import to prevent confus…

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -579,6 +579,55 @@ data "megaport_partner" "awshc" {
 }
 ```
 
+## Importing Existing Resources
+
+When importing existing Megaport resources into Terraform, you may notice that certain computed fields appear to change from "unknown" to their actual values on the first `terraform apply` after import. **This is expected behavior and not actual configuration drift.**
+
+### Expected Import Behavior for Computed Fields
+
+The following fields are managed by the Megaport API and will populate from the API during import:
+
+#### Timestamp Fields
+- `create_date` - Set when the resource is created
+- `live_date` - Set when the resource becomes active
+- `contract_start_date` - Set when the contract begins
+- `contract_end_date` - Calculated based on contract term
+- `terminate_date` - Set when termination is scheduled
+
+#### Status Fields
+- `provisioning_status` - Current lifecycle state (e.g., CONFIGURED, LIVE, DECOMMISSIONED)
+
+### What You'll See After Import
+
+```bash
+# After importing a resource
+terraform import megaport_port.example abc123
+
+# First plan after import may show these fields changing from unknown → actual value
+terraform plan
+```
+
+Example plan output:
+```
+# megaport_port.example will be updated in-place
+~ resource "megaport_port" "example" {
+    ~ create_date          = (known after apply) -> "2024-01-15T10:30:00Z"
+    ~ live_date            = (known after apply) -> "2024-01-15T11:00:00Z"
+    ~ provisioning_status  = (known after apply) -> "LIVE"
+    # ... other attributes unchanged
+}
+```
+
+**This is normal!** These fields are being populated from the API for the first time. Run `terraform apply` to update the state, and subsequent plans will show no changes.
+
+### Best Practice for Imports
+
+1. Import the resource
+2. Run `terraform plan` - you'll see computed fields updating
+3. Review the plan to ensure it matches your expectations
+4. Run `terraform apply` to update the state
+5. Run `terraform plan` again - should show no changes
+
 ## End-of-Term Cancellation
 
 By default, when Terraform deletes resources, they are immediately cancelled in the Megaport portal. However, you may prefer to have resources marked for cancellation at the end of their current billing term instead of immediate cancellation.

--- a/docs/resources/ix.md
+++ b/docs/resources/ix.md
@@ -57,13 +57,13 @@ resource "megaport_ix" "test_ix" {
 
 ### Read-Only
 
-- `create_date` (String) The date the IX was created.
+- `create_date` (String) The date the IX was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
 - `deploy_date` (String) The date the IX was deployed.
 - `ix_peer_macro` (String) IX peer macro configuration.
 - `location_id` (Number) The ID of the location where the IX is provisioned.
 - `product_id` (Number) Numeric ID of the IX product.
 - `product_uid` (String) UID identifier of the IX product.
-- `provisioning_status` (String) The provisioning status of the IX.
+- `provisioning_status` (String) The provisioning status of the IX. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the IX lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.
 - `resources` (Attributes) Resources associated with the IX. (see [below for nested schema](#nestedatt--resources))
 - `secondary_name` (String) Secondary name for the IX.
 - `term` (Number) The term of the IX in months.

--- a/docs/resources/lag_port.md
+++ b/docs/resources/lag_port.md
@@ -58,7 +58,7 @@ resource "megaport_lag_port" "lag_port" {
 - `market` (String) The market the product is in.
 - `product_id` (Number) The numeric ID of the product.
 - `product_uid` (String) The unique identifier for the resource.
-- `provisioning_status` (String) The provisioning status of the product.
+- `provisioning_status` (String) The provisioning status of the LAG port. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the port lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.
 - `resources` (Attributes) Resources attached to port. (see [below for nested schema](#nestedatt--resources))
 - `terminate_date` (String) The date the product will be terminated.
 - `usage_algorithm` (String) The usage algorithm for the product.

--- a/docs/resources/mcr.md
+++ b/docs/resources/mcr.md
@@ -51,12 +51,12 @@ resource "megaport_mcr" "mcr" {
 - `company_uid` (String) Megaport Company UID of the product.
 - `contract_end_date` (String) Contract end date of the product.
 - `contract_start_date` (String) Contract start date of the product.
-- `create_date` (String) Date the product was created.
+- `create_date` (String) The date the MCR was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
 - `created_by` (String) User who created the product.
 - `lag_id` (Number) Numeric ID of the LAG.
 - `lag_primary` (Boolean) Whether the product is a LAG primary.
 - `last_updated` (String) Last updated by the Terraform provider.
-- `live_date` (String) Date the product went live.
+- `live_date` (String) The date the MCR went live. This value is set by the Megaport API when the MCR becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
 - `locked` (Boolean) Whether the product is locked.
 - `market` (String) Market the product is in.
 - `marketplace_visibility` (Boolean) Whether the product is visible in the Marketplace.

--- a/docs/resources/mve.md
+++ b/docs/resources/mve.md
@@ -190,12 +190,12 @@ resource "megaport_mve" "mve_sixwind_dynamic" {
 - `cancelable` (Boolean) Whether the MVE is cancelable.
 - `company_name` (String) The company name of the MVE.
 - `company_uid` (String) The company UID of the MVE.
-- `contract_end_date` (String) The contract end date of the MVE.
-- `contract_start_date` (String) The contract start date of the MVE.
-- `create_date` (String) The date the MVE was created.
+- `contract_end_date` (String) The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `contract_start_date` (String) The date the contract starts. This value is managed by the Megaport API and may be updated when the MVE is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `create_date` (String) The date the MVE was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
 - `created_by` (String) The user who created the MVE.
 - `last_updated` (String) The last time the MVE was updated by the Terraform Provider.
-- `live_date` (String) The date the MVE went live.
+- `live_date` (String) The date the MVE went live. This value is set by the Megaport API when the MVE becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
 - `locked` (Boolean) Whether the MVE is locked.
 - `market` (String) The market the MVE is in.
 - `marketplace_visibility` (Boolean) Whether the MVE is visible in the marketplace.
@@ -203,9 +203,9 @@ resource "megaport_mve" "mve_sixwind_dynamic" {
 - `product_id` (Number) The Numeric ID of the MVE.
 - `product_type` (String) The type of product (MVE).
 - `product_uid` (String) The unique identifier of the MVE.
-- `provisioning_status` (String) The provisioning status of the MVE.
+- `provisioning_status` (String) The provisioning status of the MVE. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the MVE lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.
 - `secondary_name` (String) The secondary name of the MVE.
-- `terminate_date` (String) The date the MVE will be terminated.
+- `terminate_date` (String) The date the MVE will be or was terminated. This value is set by the Megaport API when termination is scheduled or completed. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
 - `usage_algorithm` (String) The usage algorithm of the MVE.
 - `vendor` (String) The vendor of the MVE.
 - `virtual` (Boolean) Whether the MVE is virtual.

--- a/docs/resources/port.md
+++ b/docs/resources/port.md
@@ -45,19 +45,19 @@ resource "megaport_port" "port" {
 
 - `cancelable` (Boolean) Whether the product is cancelable.
 - `company_uid` (String) The unique identifier of the company.
-- `contract_end_date` (String) The date the contract ends.
-- `contract_start_date` (String) The date the contract started.
-- `create_date` (String) The date the product was created.
+- `contract_end_date` (String) The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `contract_start_date` (String) The date the contract starts. This value is managed by the Megaport API and may be updated when the port is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `create_date` (String) The date the port was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
 - `created_by` (String) The user who created the product.
 - `last_updated` (String) The last time the resource was updated.
-- `live_date` (String) The date the product went live.
+- `live_date` (String) The date the port went live. This value is set by the Megaport API when the port becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
 - `locked` (Boolean) Whether the product is locked.
 - `market` (String) The market the product is in.
 - `product_id` (Number) The numeric ID of the product.
 - `product_uid` (String) The unique identifier for the resource.
-- `provisioning_status` (String) The provisioning status of the product.
+- `provisioning_status` (String) The provisioning status of the port. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the port lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.
 - `resources` (Attributes) Resources attached to port. (see [below for nested schema](#nestedatt--resources))
-- `terminate_date` (String) The date the product will be terminated.
+- `terminate_date` (String) The date the port will be or was terminated. This value is set by the Megaport API when termination is scheduled or completed. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
 - `usage_algorithm` (String) The usage algorithm for the product.
 - `virtual` (Boolean) Whether the product is virtual.
 - `vxc_auto_approval` (Boolean) Whether VXC is auto-approved on this product.

--- a/docs/resources/vxc.md
+++ b/docs/resources/vxc.md
@@ -298,19 +298,19 @@ resource "megaport_vxc" "service_key_vxc" {
 - `cancelable` (Boolean) Whether the product is cancelable.
 - `company_name` (String) The name of the company the product is associated with.
 - `company_uid` (String) The UID of the company the product is associated with.
-- `contract_end_date` (String) The date the contract ends.
-- `contract_start_date` (String) The date the contract starts.
-- `create_date` (String) The date the product was created.
+- `contract_end_date` (String) The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `contract_start_date` (String) The date the contract starts. This value is managed by the Megaport API and may be updated when the VXC is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `create_date` (String) The date the VXC was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
 - `created_by` (String) The user who created the product.
 - `csp_connections` (Attributes List) The Cloud Service Provider (CSP) connections associated with the VXC. (see [below for nested schema](#nestedatt--csp_connections))
 - `distance_band` (String) The distance band of the product.
 - `last_updated` (String) The last time the resource was updated.
-- `live_date` (String) The date the product went live.
+- `live_date` (String) The date the VXC went live. This value is set by the Megaport API when the VXC becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior as the field is being populated from the API.
 - `locked` (Boolean) Whether the product is locked.
 - `product_id` (Number) The numeric ID of the product.
 - `product_type` (String) The type of the product.
 - `product_uid` (String) The unique identifier for the resource.
-- `provisioning_status` (String) The provisioning status of the product.
+- `provisioning_status` (String) The provisioning status of the VXC. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the VXC lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.
 - `secondary_name` (String) The secondary name of the product.
 - `service_id` (Number) The service ID of the VXC.
 - `usage_algorithm` (String) The usage algorithm of the product.

--- a/internal/provider/ix_resource.go
+++ b/internal/provider/ix_resource.go
@@ -371,11 +371,11 @@ func (r *ixResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *r
 				Optional:    true,
 			},
 			"provisioning_status": schema.StringAttribute{
-				Description: "The provisioning status of the IX.",
+				Description: "The provisioning status of the IX. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the IX lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.",
 				Computed:    true,
 			},
 			"create_date": schema.StringAttribute{
-				Description: "The date the IX was created.",
+				Description: "The date the IX was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
 				Computed:    true,
 			},
 			"term": schema.Int64Attribute{

--- a/internal/provider/lag_port_resource.go
+++ b/internal/provider/lag_port_resource.go
@@ -183,7 +183,7 @@ func (r *lagPortResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Required:    true,
 			},
 			"provisioning_status": schema.StringAttribute{
-				Description: "The provisioning status of the product.",
+				Description: "The provisioning status of the LAG port. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the port lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.",
 				Computed:    true,
 			},
 			"create_date": schema.StringAttribute{

--- a/internal/provider/mcr_resource.go
+++ b/internal/provider/mcr_resource.go
@@ -417,7 +417,7 @@ func (r *mcrResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"create_date": schema.StringAttribute{
-				Description: "Date the product was created.",
+				Description: "The date the MCR was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -445,7 +445,7 @@ func (r *mcrResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				Computed:    true,
 			},
 			"live_date": schema.StringAttribute{
-				Description: "Date the product went live.",
+				Description: "The date the MCR went live. This value is set by the Megaport API when the MCR becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
 				Computed:    true,
 			},
 			"market": schema.StringAttribute{

--- a/internal/provider/mve_resource.go
+++ b/internal/provider/mve_resource.go
@@ -374,11 +374,11 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				Required:    true,
 			},
 			"provisioning_status": schema.StringAttribute{
-				Description: "The provisioning status of the MVE.",
+				Description: "The provisioning status of the MVE. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the MVE lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.",
 				Computed:    true,
 			},
 			"create_date": schema.StringAttribute{
-				Description: "The date the MVE was created.",
+				Description: "The date the MVE was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -392,11 +392,11 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"terminate_date": schema.StringAttribute{
-				Description: "The date the MVE will be terminated.",
+				Description: "The date the MVE will be or was terminated. This value is set by the Megaport API when termination is scheduled or completed. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
 				Computed:    true,
 			},
 			"live_date": schema.StringAttribute{
-				Description: "The date the MVE went live.",
+				Description: "The date the MVE went live. This value is set by the Megaport API when the MVE becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
 				Computed:    true,
 			},
 			"diversity_zone": schema.StringAttribute{
@@ -451,11 +451,11 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"contract_start_date": schema.StringAttribute{
-				Description: "The contract start date of the MVE.",
+				Description: "The date the contract starts. This value is managed by the Megaport API and may be updated when the MVE is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
 				Computed:    true,
 			},
 			"contract_end_date": schema.StringAttribute{
-				Description: "The contract end date of the MVE.",
+				Description: "The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
 				Computed:    true,
 			},
 			"cost_centre": schema.StringAttribute{

--- a/internal/provider/single_port_resource.go
+++ b/internal/provider/single_port_resource.go
@@ -194,11 +194,11 @@ func (r *portResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				Required:    true,
 			},
 			"provisioning_status": schema.StringAttribute{
-				Description: "The provisioning status of the product.",
+				Description: "The provisioning status of the port. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the port lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.",
 				Computed:    true,
 			},
 			"create_date": schema.StringAttribute{
-				Description: "The date the product was created.",
+				Description: "The date the port was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
 				Computed:    true,
 			},
 			"created_by": schema.StringAttribute{
@@ -219,11 +219,11 @@ func (r *portResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				},
 			},
 			"terminate_date": schema.StringAttribute{
-				Description: "The date the product will be terminated.",
+				Description: "The date the port will be or was terminated. This value is set by the Megaport API when termination is scheduled or completed. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
 				Computed:    true,
 			},
 			"live_date": schema.StringAttribute{
-				Description: "The date the product went live.",
+				Description: "The date the port went live. This value is set by the Megaport API when the port becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
 				Computed:    true,
 			},
 			"market": schema.StringAttribute{
@@ -277,11 +277,11 @@ func (r *portResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				},
 			},
 			"contract_start_date": schema.StringAttribute{
-				Description: "The date the contract started.",
+				Description: "The date the contract starts. This value is managed by the Megaport API and may be updated when the port is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
 				Computed:    true,
 			},
 			"contract_end_date": schema.StringAttribute{
-				Description: "The date the contract ends.",
+				Description: "The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
 				Computed:    true,
 			},
 			"marketplace_visibility": schema.BoolAttribute{

--- a/internal/provider/vxc_resource.go
+++ b/internal/provider/vxc_resource.go
@@ -528,7 +528,7 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"provisioning_status": schema.StringAttribute{
-				Description: "The provisioning status of the product.",
+				Description: "The provisioning status of the VXC. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the VXC lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.",
 				Computed:    true,
 			},
 			"secondary_name": schema.StringAttribute{
@@ -560,11 +560,11 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"live_date": schema.StringAttribute{
-				Description: "The date the product went live.",
+				Description: "The date the VXC went live. This value is set by the Megaport API when the VXC becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior as the field is being populated from the API.",
 				Computed:    true,
 			},
 			"create_date": schema.StringAttribute{
-				Description: "The date the product was created.",
+				Description: "The date the VXC was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
 				Computed:    true,
 			},
 			"contract_term_months": schema.Int64Attribute{
@@ -868,11 +868,11 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"contract_start_date": schema.StringAttribute{
-				Description: "The date the contract starts.",
+				Description: "The date the contract starts. This value is managed by the Megaport API and may be updated when the VXC is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
 				Computed:    true,
 			},
 			"contract_end_date": schema.StringAttribute{
-				Description: "The date the contract ends.",
+				Description: "The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
 				Computed:    true,
 			},
 			"company_uid": schema.StringAttribute{

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -579,6 +579,55 @@ data "megaport_partner" "awshc" {
 }
 ```
 
+## Importing Existing Resources
+
+When importing existing Megaport resources into Terraform, you may notice that certain computed fields appear to change from "unknown" to their actual values on the first `terraform apply` after import. **This is expected behavior and not actual configuration drift.**
+
+### Expected Import Behavior for Computed Fields
+
+The following fields are managed by the Megaport API and will populate from the API during import:
+
+#### Timestamp Fields
+- `create_date` - Set when the resource is created
+- `live_date` - Set when the resource becomes active
+- `contract_start_date` - Set when the contract begins
+- `contract_end_date` - Calculated based on contract term
+- `terminate_date` - Set when termination is scheduled
+
+#### Status Fields
+- `provisioning_status` - Current lifecycle state (e.g., CONFIGURED, LIVE, DECOMMISSIONED)
+
+### What You'll See After Import
+
+```bash
+# After importing a resource
+terraform import megaport_port.example abc123
+
+# First plan after import may show these fields changing from unknown → actual value
+terraform plan
+```
+
+Example plan output:
+```
+# megaport_port.example will be updated in-place
+~ resource "megaport_port" "example" {
+    ~ create_date          = (known after apply) -> "2024-01-15T10:30:00Z"
+    ~ live_date            = (known after apply) -> "2024-01-15T11:00:00Z"
+    ~ provisioning_status  = (known after apply) -> "LIVE"
+    # ... other attributes unchanged
+}
+```
+
+**This is normal!** These fields are being populated from the API for the first time. Run `terraform apply` to update the state, and subsequent plans will show no changes.
+
+### Best Practice for Imports
+
+1. Import the resource
+2. Run `terraform plan` - you'll see computed fields updating
+3. Review the plan to ensure it matches your expectations
+4. Run `terraform apply` to update the state
+5. Run `terraform plan` again - should show no changes
+
 ## End-of-Term Cancellation
 
 By default, when Terraform deletes resources, they are immediately cancelled in the Megaport portal. However, you may prefer to have resources marked for cancellation at the end of their current billing term instead of immediate cancellation.


### PR DESCRIPTION
…ion about configuration drift

### User-Facing Summary

**Improved Documentation for Computed Fields During Import**

We've enhanced the documentation to clarify the expected behavior when importing existing Megaport resources into Terraform. Users will no longer be confused by apparent "configuration drift" on computed fields.

**What Changed:**

1. **Enhanced Field Descriptions** - All computed fields (like `provisioning_status`, `create_date`, `live_date`, `contract_start_date`, `contract_end_date`, and `terminate_date`) now include clear explanations that they are managed by the Megaport API and will populate during import operations.

2. **New Import Guide** - Added a comprehensive "Importing Existing Resources" section to the documentation that explains:
   - Which fields are API-managed and will show as changing from "unknown" to their actual values
   - What to expect in your `terraform plan` output after import
   - Step-by-step best practices for importing resources
   - Clear messaging that this behavior is normal and not actual configuration drift

**Why This Matters:**

When you import existing Megaport resources (Ports, VXCs, MCRs, MVEs, IXs), Terraform shows these computed fields transitioning from "unknown" to their actual values on the first apply. This is **expected behavior** - the fields are simply being populated from the API for the first time. Previously, this could be misinterpreted as configuration drift, causing unnecessary concern.

**Affected Resources:**
- Ports (Single and LAG)
- Virtual Cross Connects (VXCs)
- Megaport Cloud Routers (MCRs)
- Megaport Virtual Edges (MVEs)
- Internet Exchanges (IX)

No functional changes were made to the provider - only documentation improvements to help users understand the import process better.

---

### Type of Change

- [ ] 🚀 New Feature
- [ ] ✨ Enhancement
- [ ] 🐛 Bug Fix
- [x] 📚 Documentation Update
- [ ] 🏗️ Chore / Other

---
