### PR TITLE
V2: Update Go module path to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/megaport/terraform-provider-megaport
+module github.com/megaport/terraform-provider-megaport/v2
 
 go 1.24.0
 

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/megaport/terraform-provider-megaport/internal/provider"
+	"github.com/megaport/terraform-provider-megaport/v2/internal/provider"
 )
 
 // Run "go generate" to format example terraform files and generate the docs for the registry/website


### PR DESCRIPTION
Go module versioning requires that v2+ modules append `/v2` to the module path in `go.mod`. This is the required first step for any major version bump — without it, consumers cannot differentiate between v1 and v2, and the Go toolchain will refuse to treat it as a proper major version.

This PR updates the module declaration and all internal import paths accordingly.

## Changes

- `go.mod`: module line changed from `github.com/megaport/terraform-provider-megaport` to `github.com/megaport/terraform-provider-megaport/v2`
- `main.go`: internal import path updated to include `/v2`

## Verification

- `go build -v ./...` passes
- `go test -v -timeout=30m ./internal/provider/` passes (all unit tests)
- No other files changed