### PR TITLE
feat: replace hardcoded staging location/credential constants with dynamic pickers

### DIFF
--- a/internal/provider/ix_resource_test.go
+++ b/internal/provider/ix_resource_test.go
@@ -19,6 +19,7 @@ func TestIXProviderTestSuite(t *testing.T) {
 
 // TestAccMegaportIX_Basic tests the basic lifecycle of an IX resource
 func (suite *IXProviderTestSuite) TestAccMegaportIX_Basic() {
+	locationID, _ := findPortTestLocation(suite.T(), 1000)
 	ixName := RandomTestName()
 	portName := RandomTestName()
 	ixNameUpdated := ixName + "-updated"
@@ -46,7 +47,7 @@ resource "megaport_ix" "test_ix" {
     vlan                = %d
     shutdown            = false
 }
-`, portName, SinglePortTestLocationIDNum, ixName, ixRateLimit, ixVLAN)
+`, portName, locationID, ixName, ixRateLimit, ixVLAN)
 
 	// Updated Terraform config
 	configUpdated := fmt.Sprintf(`
@@ -68,7 +69,7 @@ resource "megaport_ix" "test_ix" {
     vlan                = %d
     shutdown            = false
 }
-`, portName, SinglePortTestLocationIDNum, ixNameUpdated, ixRateLimitUpdated, ixVLANUpdated)
+`, portName, locationID, ixNameUpdated, ixRateLimitUpdated, ixVLANUpdated)
 
 	resourceName := "megaport_ix.test_ix"
 

--- a/internal/provider/lag_port_resource_test.go
+++ b/internal/provider/lag_port_resource_test.go
@@ -9,11 +9,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const (
-	LagPortTestLocation      = "NextDC B1"
-	LagPortTestLocationIDNum = 5 // "NextDC B1"
-)
-
 type LagPortProviderTestSuite ProviderTestSuite
 
 func TestLagPortProviderTestSuite(t *testing.T) {
@@ -22,6 +17,7 @@ func TestLagPortProviderTestSuite(t *testing.T) {
 }
 
 func (suite *LagPortProviderTestSuite) TestAccMegaportLAGPort_Basic() {
+	locationID, _ := findPortTestLocation(suite.T(), 10000)
 	portName := RandomTestName()
 	costCentreName := RandomTestName()
 	portNameNew := RandomTestName()
@@ -46,7 +42,7 @@ func (suite *LagPortProviderTestSuite) TestAccMegaportLAGPort_Basic() {
 						"key1" = "value1"
 						"key2" = "value2"
 					}
-			      }`, LagPortTestLocationIDNum, portName, costCentreName),
+			      }`, locationID, portName, costCentreName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_lag_port.lag_port", "product_name", portName),
 					resource.TestCheckResourceAttr("megaport_lag_port.lag_port", "port_speed", "10000"),
@@ -103,7 +99,7 @@ func (suite *LagPortProviderTestSuite) TestAccMegaportLAGPort_Basic() {
 						"key1updated" = "value1updated"
 						"key2updated" = "value2updated"
 			 	  	}
-			      }`, LagPortTestLocationIDNum, portNameNew, costCentreNameNew),
+			      }`, locationID, portNameNew, costCentreNameNew),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_lag_port.lag_port", "product_name", portNameNew),
 					resource.TestCheckResourceAttr("megaport_lag_port.lag_port", "port_speed", "10000"),
@@ -127,6 +123,7 @@ func (suite *LagPortProviderTestSuite) TestAccMegaportLAGPort_Basic() {
 }
 
 func (suite *LagPortProviderTestSuite) TestAccMegaportLAGPort_CostCentreRemoval() {
+	locationID, _ := findPortTestLocation(suite.T(), 10000)
 	portName := RandomTestName()
 	costCentreName := RandomTestName()
 	resource.Test(suite.T(), resource.TestCase{
@@ -145,7 +142,7 @@ func (suite *LagPortProviderTestSuite) TestAccMegaportLAGPort_CostCentreRemoval(
 					contract_term_months = 1
 					marketplace_visibility = false
 					lag_count = 1
-				}`, LagPortTestLocationIDNum, portName, costCentreName),
+				}`, locationID, portName, costCentreName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_lag_port.lag_port", "cost_centre", costCentreName),
 				),
@@ -163,7 +160,7 @@ func (suite *LagPortProviderTestSuite) TestAccMegaportLAGPort_CostCentreRemoval(
 					contract_term_months = 1
 					marketplace_visibility = false
 					lag_count = 1
-				}`, LagPortTestLocationIDNum, portName),
+				}`, locationID, portName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_lag_port.lag_port", "cost_centre", ""),
 				),
@@ -173,6 +170,7 @@ func (suite *LagPortProviderTestSuite) TestAccMegaportLAGPort_CostCentreRemoval(
 }
 
 func (suite *LagPortProviderTestSuite) TestAccMegaportLAGPort_ContractTermUpdate() {
+	locationID, _ := findPortTestLocation(suite.T(), 10000)
 	portName := RandomTestName()
 	resource.Test(suite.T(), resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -189,7 +187,7 @@ func (suite *LagPortProviderTestSuite) TestAccMegaportLAGPort_ContractTermUpdate
 					contract_term_months = 1
 					marketplace_visibility = false
 					lag_count = 1
-				}`, LagPortTestLocationIDNum, portName),
+				}`, locationID, portName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_lag_port.lag_port", "contract_term_months", "1"),
 					waitForProvisioningStatus("megaport_lag_port.lag_port"),
@@ -207,7 +205,7 @@ func (suite *LagPortProviderTestSuite) TestAccMegaportLAGPort_ContractTermUpdate
 					contract_term_months = 12
 					marketplace_visibility = false
 					lag_count = 1
-				}`, LagPortTestLocationIDNum, portName),
+				}`, locationID, portName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_lag_port.lag_port", "contract_term_months", "12"),
 				),

--- a/internal/provider/mcr_prefix_filter_list_data_source_test.go
+++ b/internal/provider/mcr_prefix_filter_list_data_source_test.go
@@ -16,6 +16,7 @@ func TestMCRPrefixFilterListDataSourceProviderTestSuite(t *testing.T) {
 }
 
 func (suite *MCRPrefixFilterListDataSourceProviderTestSuite) TestAccMegaportMCRPrefixFilterListDataSource_Basic() {
+	locationID, _ := findMCRTestLocation(suite.T(), 2500)
 	mcrName := RandomTestName()
 	prefixFilterName := RandomTestName()
 	prefixFilterName2 := RandomTestName()
@@ -86,7 +87,7 @@ func (suite *MCRPrefixFilterListDataSourceProviderTestSuite) TestAccMegaportMCRP
 						megaport_mcr_prefix_filter_list.prefix_list_2
 					]
 				}
-				`, MCRTestLocationIDNum, mcrName, costCentreName, prefixFilterName, prefixFilterName2),
+				`, locationID, mcrName, costCentreName, prefixFilterName, prefixFilterName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Data source checks
 					resource.TestCheckResourceAttr("data.megaport_mcr_prefix_filter_lists.all_lists", "prefix_filter_lists.#", "2"),

--- a/internal/provider/mcr_prefix_filter_list_resource_test.go
+++ b/internal/provider/mcr_prefix_filter_list_resource_test.go
@@ -18,6 +18,7 @@ func TestMCRPrefixFilterListProviderTestSuite(t *testing.T) {
 }
 
 func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilterList_Basic() {
+	locationID, _ := findMCRTestLocation(suite.T(), 2500)
 	mcrName := RandomTestName()
 	prefixFilterName := RandomTestName()
 	prefixFilterName2 := RandomTestName()
@@ -98,7 +99,7 @@ func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilte
 						}
 					]
 				}
-				`, MCRTestLocationIDNum, mcrName, costCentreName, prefixFilterName, prefixFilterName2),
+				`, locationID, mcrName, costCentreName, prefixFilterName, prefixFilterName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// MCR checks
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "product_name", mcrName),
@@ -251,7 +252,7 @@ func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilte
 						}
 					]
 				}
-				`, MCRTestLocationIDNum, mcrName, costCentreName, prefixFilterNameNew, prefixFilterNameNew2, prefixFilterNameNew3),
+				`, locationID, mcrName, costCentreName, prefixFilterNameNew, prefixFilterNameNew2, prefixFilterNameNew3),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// MCR checks
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "product_name", mcrName),
@@ -320,7 +321,7 @@ func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilte
 						}
 					]
 				}
-				`, MCRTestLocationIDNum, mcrNameNew, costCentreNameNew, prefixFilterNameNew4),
+				`, locationID, mcrNameNew, costCentreNameNew, prefixFilterNameNew4),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "product_name", mcrNameNew),
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "cost_centre", costCentreNameNew),
@@ -337,6 +338,7 @@ func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilte
 }
 
 func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilterList_IPv6() {
+	locationID, _ := findMCRTestLocation(suite.T(), 2500)
 	mcrName := RandomTestName()
 	prefixFilterName := RandomTestName()
 	costCentreName := RandomTestName()
@@ -384,7 +386,7 @@ func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilte
 						}
 					]
 				}
-				`, MCRTestLocationIDNum, mcrName, costCentreName, prefixFilterName),
+				`, locationID, mcrName, costCentreName, prefixFilterName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mcr_prefix_filter_list.ipv6_list", "description", prefixFilterName),
 					resource.TestCheckResourceAttr("megaport_mcr_prefix_filter_list.ipv6_list", "address_family", "IPv6"),
@@ -409,6 +411,7 @@ func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilte
 // or le=128 (IPv6) instead of the exact match value configured by the user.
 // See PR #308 for details on the bug fix.
 func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilterList_ExactMatch() {
+	locationID, _ := findMCRTestLocation(suite.T(), 2500)
 	mcrName := RandomTestName()
 	prefixFilterNameIPv4 := RandomTestName()
 	prefixFilterNameIPv6 := RandomTestName()
@@ -486,7 +489,7 @@ func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilte
 						}
 					]
 				}
-				`, MCRTestLocationIDNum, mcrName, costCentreName, prefixFilterNameIPv4, prefixFilterNameIPv6),
+				`, locationID, mcrName, costCentreName, prefixFilterNameIPv4, prefixFilterNameIPv6),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// IPv4 Exact Match Checks - verify ge=le is preserved
 					resource.TestCheckResourceAttr("megaport_mcr_prefix_filter_list.ipv4_exact", "description", prefixFilterNameIPv4),
@@ -599,7 +602,7 @@ func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilte
 						}
 					]
 				}
-				`, MCRTestLocationIDNum, mcrName, costCentreName, prefixFilterNameIPv4, prefixFilterNameIPv6),
+				`, locationID, mcrName, costCentreName, prefixFilterNameIPv4, prefixFilterNameIPv6),
 				// PlanOnly checks that no changes are needed - validates idempotency
 				PlanOnly: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -651,6 +654,7 @@ func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilte
 // are rejected with a descriptive error, and that canonical prefixes work correctly.
 // This is the end-to-end test for the fix in issue #317.
 func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilterList_CIDRValidation() {
+	locationID, _ := findMCRTestLocation(suite.T(), 2500)
 	mcrName := RandomTestName()
 	prefixFilterName := RandomTestName()
 	costCentreName := RandomTestName()
@@ -692,7 +696,7 @@ func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilte
 						}
 					]
 				}
-				`, MCRTestLocationIDNum, mcrName, costCentreName, prefixFilterName),
+				`, locationID, mcrName, costCentreName, prefixFilterName),
 				ExpectError: regexp.MustCompile(`(?s)host bits set.*Use the network address.*192\.168\.1\.0/24`),
 			},
 		},
@@ -702,6 +706,7 @@ func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilte
 // TestAccMegaportMCRPrefixFilterList_MixedExactAndRange tests a combination of exact match
 // and range-based prefix filter entries to ensure both are handled correctly.
 func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilterList_MixedExactAndRange() {
+	locationID, _ := findMCRTestLocation(suite.T(), 2500)
 	mcrName := RandomTestName()
 	prefixFilterName := RandomTestName()
 	costCentreName := RandomTestName()
@@ -765,7 +770,7 @@ func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilte
 						}
 					]
 				}
-				`, MCRTestLocationIDNum, mcrName, costCentreName, prefixFilterName),
+				`, locationID, mcrName, costCentreName, prefixFilterName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mcr_prefix_filter_list.mixed", "description", prefixFilterName),
 					resource.TestCheckResourceAttr("megaport_mcr_prefix_filter_list.mixed", "entries.#", "4"),
@@ -802,6 +807,7 @@ func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilte
 // 3. After importing the prefix filter list, the VXC should NOT detect changes
 // 4. The MCR should NOT attempt to delete the standalone-managed prefix filter lists
 func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilterList_ImportNoVXCDrift() {
+	locationID, _ := findMCRTestLocation(suite.T(), 2500)
 	mcrName := RandomTestName()
 	portName := RandomTestName()
 	vxcName := RandomTestName()
@@ -896,7 +902,7 @@ func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilte
 
 				depends_on = [megaport_mcr_prefix_filter_list.pfl]
 			}
-		`, MCRTestLocationIDNum, mcrName, costCentreName, prefixFilterListName, portName, vxcName, prefixFilterListName)
+		`, locationID, mcrName, costCentreName, prefixFilterListName, portName, vxcName, prefixFilterListName)
 	}
 
 	resource.Test(suite.T(), resource.TestCase{
@@ -959,6 +965,7 @@ func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilte
 // standalone prefix filter lists does not trigger updates on VXCs that reference them.
 // This mirrors the GoTo customer pattern of importing multiple prefix filter lists at once.
 func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilterList_ImportMultipleNoVXCDrift() {
+	locationID, _ := findMCRTestLocation(suite.T(), 2500)
 	mcrName := RandomTestName()
 	portName := RandomTestName()
 	vxcName := RandomTestName()
@@ -1082,7 +1089,7 @@ func (suite *MCRPrefixFilterListProviderTestSuite) TestAccMegaportMCRPrefixFilte
 					megaport_mcr_prefix_filter_list.pfl_export,
 				]
 			}
-		`, MCRTestLocationIDNum, mcrName, costCentreName,
+		`, locationID, mcrName, costCentreName,
 			pflName1, pflName2, pflName3,
 			portName, vxcName,
 			pflName1, pflName3)

--- a/internal/provider/mcr_resource_test.go
+++ b/internal/provider/mcr_resource_test.go
@@ -12,11 +12,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const (
-	MCRTestLocation      = "Digital Realty Silicon Valley SJC34 (SCL2)"
-	MCRTestLocationIDNum = 65 // "Digital Realty Silicon Valley SJC34 (SCL2)"
-)
-
 type MCRProviderTestSuite ProviderTestSuite
 
 func TestMCRProviderTestSuite(t *testing.T) {
@@ -25,6 +20,7 @@ func TestMCRProviderTestSuite(t *testing.T) {
 }
 
 func (suite *MCRProviderTestSuite) TestAccMegaportMCR_Basic() {
+	locationID, _ := findMCRTestLocation(suite.T(), 2500)
 	mcrName := RandomTestName()
 	prefixFilterName := RandomTestName()
 	prefixFilterName2 := RandomTestName()
@@ -95,7 +91,7 @@ func (suite *MCRProviderTestSuite) TestAccMegaportMCR_Basic() {
 						]
 					  }]
 				  }
-				  `, MCRTestLocationIDNum, mcrName, costCentreName, prefixFilterName, prefixFilterName2),
+				  `, locationID, mcrName, costCentreName, prefixFilterName, prefixFilterName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "product_name", mcrName),
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "port_speed", "1000"),
@@ -227,7 +223,7 @@ func (suite *MCRProviderTestSuite) TestAccMegaportMCR_Basic() {
 						]
 					  }]
 				  }
-				  `, MCRTestLocationIDNum, mcrName, costCentreName, prefixFilterNameNew, prefixFilterNameNew2, prefixFilterNameNew3),
+				  `, locationID, mcrName, costCentreName, prefixFilterNameNew, prefixFilterNameNew2, prefixFilterNameNew3),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "product_name", mcrName),
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "port_speed", "1000"),
@@ -306,7 +302,7 @@ func (suite *MCRProviderTestSuite) TestAccMegaportMCR_Basic() {
 						]
 					  }]
 				  }
-				  `, MCRTestLocationIDNum, mcrNameNew, costCentreNameNew, prefixFilterNameNew4),
+				  `, locationID, mcrNameNew, costCentreNameNew, prefixFilterNameNew4),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "product_name", mcrNameNew),
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "port_speed", "1000"),
@@ -345,7 +341,7 @@ func (suite *MCRProviderTestSuite) TestAccMegaportMCR_Basic() {
 
 					prefix_filter_lists = []
 				  }
-				  `, MCRTestLocationIDNum, mcrNameNew2, costCentreNameNew2),
+				  `, locationID, mcrNameNew2, costCentreNameNew2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "product_name", mcrNameNew2),
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "port_speed", "1000"),
@@ -366,6 +362,7 @@ func (suite *MCRProviderTestSuite) TestAccMegaportMCR_Basic() {
 }
 
 func (suite *MCRProviderTestSuite) TestAccMegaportMCR_CostCentreRemoval() {
+	locationID, _ := findMCRTestLocation(suite.T(), 2500)
 	mcrName := RandomTestName()
 	costCentreName := RandomTestName()
 	resource.Test(suite.T(), resource.TestCase{
@@ -382,7 +379,7 @@ func (suite *MCRProviderTestSuite) TestAccMegaportMCR_CostCentreRemoval() {
 					location_id = data.megaport_location.test_location.id
 					contract_term_months = 1
 					cost_centre = "%s"
-				}`, MCRTestLocationIDNum, mcrName, costCentreName),
+				}`, locationID, mcrName, costCentreName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "cost_centre", costCentreName),
 				),
@@ -398,7 +395,7 @@ func (suite *MCRProviderTestSuite) TestAccMegaportMCR_CostCentreRemoval() {
 					location_id = data.megaport_location.test_location.id
 					contract_term_months = 1
 					cost_centre = ""
-				}`, MCRTestLocationIDNum, mcrName),
+				}`, locationID, mcrName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "cost_centre", ""),
 				),
@@ -408,6 +405,7 @@ func (suite *MCRProviderTestSuite) TestAccMegaportMCR_CostCentreRemoval() {
 }
 
 func (suite *MCRProviderTestSuite) TestAccMegaportMCR_ContractTermUpdate() {
+	locationID, _ := findMCRTestLocation(suite.T(), 2500)
 	mcrName := RandomTestName()
 	resource.Test(suite.T(), resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -422,7 +420,7 @@ func (suite *MCRProviderTestSuite) TestAccMegaportMCR_ContractTermUpdate() {
 					port_speed = 1000
 					location_id = data.megaport_location.test_location.id
 					contract_term_months = 1
-				}`, MCRTestLocationIDNum, mcrName),
+				}`, locationID, mcrName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "contract_term_months", "1"),
 					waitForProvisioningStatus("megaport_mcr.mcr"),
@@ -438,7 +436,7 @@ func (suite *MCRProviderTestSuite) TestAccMegaportMCR_ContractTermUpdate() {
 					port_speed = 1000
 					location_id = data.megaport_location.test_location.id
 					contract_term_months = 12
-				}`, MCRTestLocationIDNum, mcrName),
+				}`, locationID, mcrName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "contract_term_months", "12"),
 				),
@@ -448,6 +446,7 @@ func (suite *MCRProviderTestSuite) TestAccMegaportMCR_ContractTermUpdate() {
 }
 
 func (suite *MCRProviderTestSuite) TestAccMegaportMCRCustomASN_Basic() {
+	locationID, _ := findMCRTestLocation(suite.T(), 2500)
 	mcrName := RandomTestName()
 	mcrNameNew := RandomTestName()
 	costCentreName := RandomTestName()
@@ -473,7 +472,7 @@ func (suite *MCRProviderTestSuite) TestAccMegaportMCRCustomASN_Basic() {
 						"key2" = "value2"
 					}
 				  }
-				  `, MCRTestLocationIDNum, mcrName, costCentreName),
+				  `, locationID, mcrName, costCentreName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "product_name", mcrName),
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "port_speed", "1000"),
@@ -528,7 +527,7 @@ func (suite *MCRProviderTestSuite) TestAccMegaportMCRCustomASN_Basic() {
 
 					resource_tags = {"key1updated" = "value1updated", "key2updated" = "value2updated"}
 				  }
-				  `, MCRTestLocationIDNum, mcrNameNew, costCentreNameNew),
+				  `, locationID, mcrNameNew, costCentreNameNew),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "product_name", mcrNameNew),
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "port_speed", "1000"),

--- a/internal/provider/mcrs_data_source_test.go
+++ b/internal/provider/mcrs_data_source_test.go
@@ -106,6 +106,14 @@ func (m *MockMCRService) GetMCRPrefixFilterLists(ctx context.Context, mcrId stri
 	return nil, nil
 }
 
+func (m *MockMCRService) UpdateMCRWithAddOn(ctx context.Context, mcrID string, req megaport.MCRAddOnRequest) error {
+	return nil
+}
+
+func (m *MockMCRService) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, addOnUID string, tunnelCount int) error {
+	return nil
+}
+
 func TestReadMCRs_ListAll(t *testing.T) {
 	mockMCRService := &MockMCRService{
 		ListMCRsResult: []*megaport.MCR{

--- a/internal/provider/mve_resource_test.go
+++ b/internal/provider/mve_resource_test.go
@@ -10,9 +10,7 @@ import (
 )
 
 const (
-	MVEArubaTestLocationIDNum = 59  // Los Angeles "Equinix LA1" (lax-eq1)
-	MVEVersaTestLocationIDNum = 70  // Chicago "CyrusOne Aurora (CHI2)" (chi-tx2)
-	MVEArubaImageIDMVE        = 152 // Aruba MVE image ID
+	MVEArubaImageIDMVE = 152 // Aruba MVE image ID
 )
 
 type MVEArubaProviderTestSuite ProviderTestSuite
@@ -29,6 +27,7 @@ func TestMVEVersaProviderTestSuite(t *testing.T) {
 }
 
 func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEAruba_Basic() {
+	locationID, _ := findMVETestLocation(suite.T(), 2)
 	mveName := RandomTestName()
 	mveKey := RandomTestName()
 	mveNameNew := RandomTestName()
@@ -83,7 +82,7 @@ func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEAruba_Basic() {
 						description = "Extra Plane"
 					}
 					]
-                  }`, MVEArubaTestLocationIDNum, MVEArubaImageIDMVE, mveName, costCentre, mveName, mveKey),
+                  }`, locationID, MVEArubaImageIDMVE, mveName, costCentre, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_name", mveName),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", costCentre),
@@ -170,7 +169,7 @@ func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEAruba_Basic() {
 						description = "Extra Plane"
 					}
 					]
-                  }`, MVEArubaTestLocationIDNum, MVEArubaImageIDMVE, mveNameNew, costCentreNew, mveName, mveKey),
+                  }`, locationID, MVEArubaImageIDMVE, mveNameNew, costCentreNew, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_name", mveNameNew),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", costCentreNew),
@@ -217,6 +216,7 @@ func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEAruba_Basic() {
 }
 
 func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEAruba_CostCentreRemoval() {
+	locationID, _ := findMVETestLocation(suite.T(), 2)
 	mveName := RandomTestName()
 	mveKey := RandomTestName()
 	costCentreName := RandomTestName()
@@ -262,7 +262,7 @@ func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEAruba_CostCentreRemova
 					{
 						description = "Extra Plane"
 					}]
-				}`, MVEArubaTestLocationIDNum, MVEArubaImageIDMVE, mveName, costCentreName, mveName, mveKey),
+				}`, locationID, MVEArubaImageIDMVE, mveName, costCentreName, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", costCentreName),
 				),
@@ -306,7 +306,7 @@ func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEAruba_CostCentreRemova
 					{
 						description = "Extra Plane"
 					}]
-				}`, MVEArubaTestLocationIDNum, MVEArubaImageIDMVE, mveName, mveName, mveKey),
+				}`, locationID, MVEArubaImageIDMVE, mveName, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", ""),
 				),
@@ -316,6 +316,7 @@ func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEAruba_CostCentreRemova
 }
 
 func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEAruba_ContractTermUpdate() {
+	locationID, _ := findMVETestLocation(suite.T(), 2)
 	mveName := RandomTestName()
 	mveKey := RandomTestName()
 	resource.Test(suite.T(), resource.TestCase{
@@ -356,7 +357,7 @@ func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEAruba_ContractTermUpda
 					{
 						description = "Extra Plane"
 					}]
-				}`, MVEArubaTestLocationIDNum, MVEArubaImageIDMVE, mveName, mveName, mveKey),
+				}`, locationID, MVEArubaImageIDMVE, mveName, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "contract_term_months", "1"),
 					waitForProvisioningStatus("megaport_mve.mve"),
@@ -397,7 +398,7 @@ func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEAruba_ContractTermUpda
 					{
 						description = "Extra Plane"
 					}]
-				}`, MVEArubaTestLocationIDNum, MVEArubaImageIDMVE, mveName, mveName, mveKey),
+				}`, locationID, MVEArubaImageIDMVE, mveName, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "contract_term_months", "12"),
 				),
@@ -407,6 +408,7 @@ func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEAruba_ContractTermUpda
 }
 
 func (suite *MVEVersaProviderTestSuite) TestAccMegaportMVEVersa_Basic() {
+	locationID, _ := findMVETestLocation(suite.T(), 2)
 	mveName := RandomTestName()
 	mveNameNew := RandomTestName()
 	costCentre := RandomTestName()
@@ -462,7 +464,7 @@ func (suite *MVEVersaProviderTestSuite) TestAccMegaportMVEVersa_Basic() {
 						description = "Extra Plane"
 					}
 					]
-                  }`, MVEVersaTestLocationIDNum, mveName, costCentre),
+                  }`, locationID, mveName, costCentre),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_name", mveName),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", costCentre),
@@ -553,7 +555,7 @@ func (suite *MVEVersaProviderTestSuite) TestAccMegaportMVEVersa_Basic() {
 						description = "Extra Plane"
 					}
 					]
-                  }`, MVEVersaTestLocationIDNum, mveNameNew, costCentreNew),
+                  }`, locationID, mveNameNew, costCentreNew),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_name", mveNameNew),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", costCentreNew),
@@ -600,6 +602,7 @@ func (suite *MVEVersaProviderTestSuite) TestAccMegaportMVEVersa_Basic() {
 }
 
 func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEImport_WithLifecycleIgnoreChanges() {
+	locationID, _ := findMVETestLocation(suite.T(), 2)
 	mveName := RandomTestName()
 	mveKey := RandomTestName()
 	costCentre := RandomTestName()
@@ -642,7 +645,7 @@ func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEImport_WithLifecycleIg
                     {
                         description = "Control Plane"
                     }]
-                }`, MVEArubaTestLocationIDNum, MVEArubaImageIDMVE, mveName, costCentre, mveName, mveKey),
+                }`, locationID, MVEArubaImageIDMVE, mveName, costCentre, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.import_test", "product_name", mveName),
 				),
@@ -706,7 +709,7 @@ func (suite *MVEArubaProviderTestSuite) TestAccMegaportMVEImport_WithLifecycleIg
                     lifecycle {
                         ignore_changes = [vendor_config]
                     }
-                }`, MVEArubaTestLocationIDNum, MVEArubaImageIDMVE, mveName, costCentre, mveName, mveKey),
+                }`, locationID, MVEArubaImageIDMVE, mveName, costCentre, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.import_test", "product_name", mveName+"-updated"),
 					resource.TestCheckResourceAttr("megaport_mve.import_test", "cost_centre", costCentre+"-updated"),

--- a/internal/provider/single_port_resource_test.go
+++ b/internal/provider/single_port_resource_test.go
@@ -9,11 +9,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const (
-	SinglePortTestLocation      = "NextDC B1"
-	SinglePortTestLocationIDNum = 5 // "NextDC B1"
-)
-
 type SinglePortProviderTestSuite ProviderTestSuite
 
 func TestSinglePortProviderTestSuite(t *testing.T) {
@@ -22,6 +17,7 @@ func TestSinglePortProviderTestSuite(t *testing.T) {
 }
 
 func (suite *SinglePortProviderTestSuite) TestAccMegaportSinglePort_Basic() {
+	locationID, _ := findPortTestLocation(suite.T(), 1000)
 	portName := RandomTestName()
 	portNameNew := RandomTestName()
 	costCentreName := RandomTestName()
@@ -47,7 +43,7 @@ func (suite *SinglePortProviderTestSuite) TestAccMegaportSinglePort_Basic() {
 						"key1" = "value1"
 						"key2" = "value2"
   					}
-			      }`, SinglePortTestLocationIDNum, portName, costCentreName),
+			      }`, locationID, portName, costCentreName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_port.port", "product_name", portName),
 					resource.TestCheckResourceAttr("megaport_port.port", "port_speed", "1000"),
@@ -103,7 +99,7 @@ func (suite *SinglePortProviderTestSuite) TestAccMegaportSinglePort_Basic() {
 						"key1-updated" = "value1-updated"
 						"key2-updated" = "value2-updated"
 					}
-			      }`, SinglePortTestLocationIDNum, portNameNew, costCentreNameNew),
+			      }`, locationID, portNameNew, costCentreNameNew),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_port.port", "product_name", portNameNew),
 					resource.TestCheckResourceAttr("megaport_port.port", "port_speed", "1000"),
@@ -127,6 +123,7 @@ func (suite *SinglePortProviderTestSuite) TestAccMegaportSinglePort_Basic() {
 }
 
 func (suite *SinglePortProviderTestSuite) TestAccMegaportSinglePort_CostCentreRemoval() {
+	locationID, _ := findPortTestLocation(suite.T(), 1000)
 	portName := RandomTestName()
 	costCentreName := RandomTestName()
 	resource.Test(suite.T(), resource.TestCase{
@@ -144,7 +141,7 @@ func (suite *SinglePortProviderTestSuite) TestAccMegaportSinglePort_CostCentreRe
 					location_id = data.megaport_location.test_location.id
 					contract_term_months = 1
 					marketplace_visibility = false
-				}`, SinglePortTestLocationIDNum, portName, costCentreName),
+				}`, locationID, portName, costCentreName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_port.port", "cost_centre", costCentreName),
 				),
@@ -161,7 +158,7 @@ func (suite *SinglePortProviderTestSuite) TestAccMegaportSinglePort_CostCentreRe
 					location_id = data.megaport_location.test_location.id
 					contract_term_months = 1
 					marketplace_visibility = false
-				}`, SinglePortTestLocationIDNum, portName),
+				}`, locationID, portName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_port.port", "cost_centre", ""),
 				),
@@ -171,6 +168,7 @@ func (suite *SinglePortProviderTestSuite) TestAccMegaportSinglePort_CostCentreRe
 }
 
 func (suite *SinglePortProviderTestSuite) TestAccMegaportSinglePort_ContractTermUpdate() {
+	locationID, _ := findPortTestLocation(suite.T(), 1000)
 	portName := RandomTestName()
 	resource.Test(suite.T(), resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -186,7 +184,7 @@ func (suite *SinglePortProviderTestSuite) TestAccMegaportSinglePort_ContractTerm
 					location_id = data.megaport_location.test_location.id
 					contract_term_months = 1
 					marketplace_visibility = false
-				}`, SinglePortTestLocationIDNum, portName),
+				}`, locationID, portName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_port.port", "contract_term_months", "1"),
 					waitForProvisioningStatus("megaport_port.port"),
@@ -203,7 +201,7 @@ func (suite *SinglePortProviderTestSuite) TestAccMegaportSinglePort_ContractTerm
 					location_id = data.megaport_location.test_location.id
 					contract_term_months = 12
 					marketplace_visibility = false
-				}`, SinglePortTestLocationIDNum, portName),
+				}`, locationID, portName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_port.port", "contract_term_months", "12"),
 				),

--- a/internal/provider/test_helpers_test.go
+++ b/internal/provider/test_helpers_test.go
@@ -1,0 +1,586 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	megaport "github.com/megaport/megaportgo"
+)
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type cspCredentials struct {
+	AzureServiceKeys          []string `json:"azure_service_keys"`
+	AzureServiceKeysWithPeers []string `json:"azure_service_keys_with_peers"`
+	GooglePairingKeys         []string `json:"google_pairing_keys"`
+}
+
+// ── MVE Location Picker ───────────────────────────────────────────────────────
+
+// mveTestLocationCandidates is a curated list of staging location IDs with known
+// MVE demo capacity, ordered roughly by historical reliability across regions.
+// Refresh from internal Metabase capacity data as needed.
+var mveTestLocationCandidates = []int{
+	// AU/NZ
+	3, 4, 5, 2, 10, 50, 383, 454,
+	// US
+	59, 61, 67, 69, 71, 57, 66, 68, 116, 226, 321, 346, 77, 79, 100, 320, 354, 380, 530,
+	// EU
+	85, 88, 90, 130, 131, 94, 527, 515, 256, 637, 298, 518, 430, 917,
+	// APAC
+	36, 37, 46, 54, 155, 560, 558, 571, 572, 257,
+	// Americas (non-US)
+	93, 419, 573, 1484,
+}
+
+// findMVETestLocation returns a staging location ID with confirmed MVE capacity,
+// validated via the API validate endpoint. Calls t.Skip if none found.
+//
+// Strategy: try the curated candidate list first (fast path), then fall back to
+// a full sweep of all locations. Each candidate is probed with ValidateMVEOrder
+// using a minimal Aruba SMALL config — the validate endpoint is the only reliable
+// way to check actual demo capacity in staging since mveMaxCpuCoreCount is not
+// populated by the API.
+//
+//nolint:unparam // minCPUCores kept for future use when API populates the field
+func findMVETestLocation(t *testing.T, minCPUCores int) (id int, name string) {
+	t.Helper()
+	ctx := context.Background()
+	client, err := getTestClient()
+	if err != nil {
+		t.Skipf("skipping: could not get test client: %v", err)
+		return 0, ""
+	}
+	locations, err := client.LocationService.ListLocationsV3(ctx)
+	if err != nil {
+		t.Skipf("skipping: could not list locations: %v", err)
+		return 0, ""
+	}
+
+	byID := make(map[int]*megaport.LocationV3, len(locations))
+	for _, loc := range locations {
+		byID[loc.ID] = loc
+	}
+
+	probe := func(loc *megaport.LocationV3) bool {
+		if !strings.EqualFold(loc.Status, "active") || !loc.HasMVESupport() {
+			return false
+		}
+		err := client.MVEService.ValidateMVEOrder(ctx, &megaport.BuyMVERequest{
+			LocationID: loc.ID,
+			Name:       "probe",
+			Term:       1,
+			VendorConfig: &megaport.ArubaConfig{
+				Vendor:      "aruba",
+				ImageID:     MVEArubaImageIDMVE,
+				ProductSize: "SMALL",
+				AccountName: "probe",
+				AccountKey:  "probe",
+				SystemTag:   "Preconfiguration-aruba-test-1",
+			},
+			Vnics: []megaport.MVENetworkInterface{
+				{Description: "Data Plane"},
+				{Description: "Control Plane"},
+			},
+		})
+		return err == nil
+	}
+
+	// Fast path: curated candidates
+	for _, candidateID := range mveTestLocationCandidates {
+		if loc, ok := byID[candidateID]; ok && probe(loc) {
+			t.Logf("findMVETestLocation: using location %d (%s)", loc.ID, loc.Name)
+			return loc.ID, loc.Name
+		}
+	}
+
+	// Slow path: full sweep
+	for _, loc := range locations {
+		if probe(loc) {
+			t.Logf("findMVETestLocation: using location %d (%s) (fallback sweep)", loc.ID, loc.Name)
+			return loc.ID, loc.Name
+		}
+	}
+
+	t.Skip("skipping: no location with available MVE capacity found in staging")
+	return 0, ""
+}
+
+// ── Port/MCR Location Pickers ─────────────────────────────────────────────────
+
+// findPortTestLocation returns a staging location ID that supports Megaport
+// ports at the given speed (Mbps). Calls t.Skip if none found.
+//
+//nolint:unparam // name return is available for callers that want it
+func findPortTestLocation(t *testing.T, speedMbps int) (id int, name string) {
+	t.Helper()
+	ctx := context.Background()
+	client, err := getTestClient()
+	if err != nil {
+		t.Skipf("skipping: could not get test client: %v", err)
+		return 0, ""
+	}
+	locations, err := client.LocationService.ListLocationsV3(ctx)
+	if err != nil {
+		t.Skipf("skipping: could not list locations: %v", err)
+		return 0, ""
+	}
+	for _, loc := range locations {
+		if strings.EqualFold(loc.Status, "active") && portLocationHasCapacity(loc, speedMbps) {
+			t.Logf("findPortTestLocation: using location %d (%s)", loc.ID, loc.Name)
+			return loc.ID, loc.Name
+		}
+	}
+	t.Skipf("skipping: no ACTIVE location with %d Mbps Megaport port capacity", speedMbps)
+	return 0, ""
+}
+
+// findMCRTestLocation returns a staging location ID that supports MCR at the
+// given speed (Mbps). Calls t.Skip if none found.
+//
+//nolint:unparam // speedMbps is always 2500 today; kept for future test flexibility
+func findMCRTestLocation(t *testing.T, speedMbps int) (id int, name string) {
+	t.Helper()
+	ctx := context.Background()
+	client, err := getTestClient()
+	if err != nil {
+		t.Skipf("skipping: could not get test client: %v", err)
+		return 0, ""
+	}
+	locations, err := client.LocationService.ListLocationsV3(ctx)
+	if err != nil {
+		t.Skipf("skipping: could not list locations: %v", err)
+		return 0, ""
+	}
+	for _, loc := range locations {
+		if strings.EqualFold(loc.Status, "active") && mcrLocationHasCapacity(loc, speedMbps) {
+			t.Logf("findMCRTestLocation: using location %d (%s)", loc.ID, loc.Name)
+			return loc.ID, loc.Name
+		}
+	}
+	t.Skipf("skipping: no ACTIVE location with %d Mbps MCR capacity", speedMbps)
+	return 0, ""
+}
+
+// portLocationHasCapacity returns true when at least one diversity zone at loc
+// lists speedMbps (or higher) in MegaportSpeedMbps.
+func portLocationHasCapacity(loc *megaport.LocationV3, speedMbps int) bool {
+	if loc.DiversityZones == nil {
+		return false
+	}
+	check := func(zone *megaport.LocationV3DiversityZone) bool {
+		if zone == nil {
+			return false
+		}
+		for _, s := range zone.MegaportSpeedMbps {
+			if s >= speedMbps {
+				return true
+			}
+		}
+		return false
+	}
+	return check(loc.DiversityZones.Red) || check(loc.DiversityZones.Blue)
+}
+
+// mcrLocationHasCapacity returns true when at least one diversity zone at loc
+// lists speedMbps (or higher) in McrSpeedMbps.
+func mcrLocationHasCapacity(loc *megaport.LocationV3, speedMbps int) bool {
+	if loc.DiversityZones == nil {
+		return false
+	}
+	check := func(zone *megaport.LocationV3DiversityZone) bool {
+		if zone == nil {
+			return false
+		}
+		for _, s := range zone.McrSpeedMbps {
+			if s >= speedMbps {
+				return true
+			}
+		}
+		return false
+	}
+	return check(loc.DiversityZones.Red) || check(loc.DiversityZones.Blue)
+}
+
+// ── CSP Credential Pickers ────────────────────────────────────────────────────
+
+// pickAzureServiceKey returns the first Azure service key from the pool that
+// has available VXC capacity, validated via /v2/secure/azure/{key}. Keys are
+// shuffled before probing so concurrent test suites are unlikely to race on the
+// same key. Calls t.Skip if no valid key is found.
+func pickAzureServiceKey(t *testing.T) string {
+	t.Helper()
+	creds := loadCSPCredentials()
+	if len(creds.AzureServiceKeys) == 0 {
+		t.Skip("skipping: no Azure service keys in testdata/csp_credentials.json")
+		return ""
+	}
+	ctx := context.Background()
+	client, err := getTestClient()
+	if err != nil {
+		t.Skipf("skipping: could not get test client: %v", err)
+		return ""
+	}
+
+	//nolint:gosec // weak random is fine for test key shuffling
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	keys := make([]string, len(creds.AzureServiceKeys))
+	copy(keys, creds.AzureServiceKeys)
+	r.Shuffle(len(keys), func(i, j int) { keys[i], keys[j] = keys[j], keys[i] })
+
+	for _, key := range keys {
+		_, err := client.VXCService.LookupPartnerPorts(ctx, &megaport.LookupPartnerPortsRequest{
+			Partner:   "AZURE",
+			Key:       key,
+			PortSpeed: 1000,
+		})
+		if err == nil {
+			t.Logf("pickAzureServiceKey: using key %s", key)
+			return key
+		}
+		t.Logf("pickAzureServiceKey: key %s unavailable: %v", key, err)
+	}
+
+	t.Skip("skipping: no Azure service key with available capacity found")
+	return ""
+}
+
+// pickGCPPairingKey returns the first GCP pairing key from the pool that has
+// available VXC capacity, validated via /v2/secure/google/{key}. Keys are
+// shuffled before probing. Calls t.Skip if no valid key is found.
+func pickGCPPairingKey(t *testing.T) string {
+	t.Helper()
+	creds := loadCSPCredentials()
+	if len(creds.GooglePairingKeys) == 0 {
+		t.Skip("skipping: no GCP pairing keys in testdata/csp_credentials.json")
+		return ""
+	}
+	ctx := context.Background()
+	client, err := getTestClient()
+	if err != nil {
+		t.Skipf("skipping: could not get test client: %v", err)
+		return ""
+	}
+
+	//nolint:gosec // weak random is fine for test key shuffling
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	keys := make([]string, len(creds.GooglePairingKeys))
+	copy(keys, creds.GooglePairingKeys)
+	r.Shuffle(len(keys), func(i, j int) { keys[i], keys[j] = keys[j], keys[i] })
+
+	for _, key := range keys {
+		_, err := client.VXCService.LookupPartnerPorts(ctx, &megaport.LookupPartnerPortsRequest{
+			Partner:   "GOOGLE",
+			Key:       key,
+			PortSpeed: 1000,
+		})
+		if err == nil {
+			t.Logf("pickGCPPairingKey: using key %s", key)
+			return key
+		}
+		t.Logf("pickGCPPairingKey: key %s unavailable: %v", key, err)
+	}
+
+	t.Skip("skipping: no GCP pairing key with available capacity found")
+	return ""
+}
+
+func loadCSPCredentials() cspCredentials {
+	data, err := os.ReadFile("testdata/csp_credentials.json")
+	if err != nil {
+		return cspCredentials{}
+	}
+	var creds cspCredentials
+	_ = json.Unmarshal(data, &creds)
+	return creds
+}
+
+// ── Staging Health Check ──────────────────────────────────────────────────────
+
+// TestStagingHealthCheck verifies staging environment preconditions.
+// Run before a full acceptance suite to catch problems early:
+//
+//	go test -v -run TestStagingHealthCheck ./internal/provider/
+func TestStagingHealthCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("health check requires API access")
+	}
+	ctx := context.Background()
+	client, err := getTestClient()
+	if err != nil {
+		t.Fatalf("staging API unreachable: %v", err)
+	}
+
+	locations, err := client.LocationService.ListLocationsV3(ctx)
+	if err != nil {
+		t.Fatalf("could not list locations: %v", err)
+	}
+
+	// MVE capacity — count locations that declare MVE support. Note: staging does not
+	// populate mveMaxCpuCoreCount, so this is an approximation based on the MveAvailable
+	// flag. Actual capacity is only confirmed by findMVETestLocation via ValidateMVEOrder.
+	mveCount := 0
+	for _, loc := range locations {
+		if strings.EqualFold(loc.Status, "active") && loc.HasMVESupport() {
+			mveCount++
+		}
+	}
+	t.Logf("Locations reporting MVE support (approximate — staging does not populate mveMaxCpuCoreCount): %d", mveCount)
+	if mveCount == 0 {
+		t.Error("WARN: no MVE capacity available — MVE tests will be skipped")
+	}
+
+	// Port capacity (1G)
+	portCount := 0
+	for _, loc := range locations {
+		if strings.EqualFold(loc.Status, "active") && portLocationHasCapacity(loc, 1000) {
+			portCount++
+		}
+	}
+	t.Logf("Locations with 1000 Mbps port capacity: %d", portCount)
+	if portCount == 0 {
+		t.Error("WARN: no 1G port capacity available — port tests will be skipped")
+	}
+
+	// MCR capacity (2500 Mbps)
+	mcrCount := 0
+	for _, loc := range locations {
+		if strings.EqualFold(loc.Status, "active") && mcrLocationHasCapacity(loc, 2500) {
+			mcrCount++
+		}
+	}
+	t.Logf("Locations with 2500 Mbps MCR capacity: %d", mcrCount)
+	if mcrCount == 0 {
+		t.Error("WARN: no 2.5G MCR capacity available — MCR tests will be skipped")
+	}
+
+	// Partner ports
+	ports, err := client.PartnerService.ListPartnerMegaports(ctx)
+	if err != nil {
+		t.Errorf("could not list partner ports: %v", err)
+	} else {
+		for _, partner := range []string{"AWS", "AZURE", "GOOGLE"} {
+			found := false
+			for _, p := range ports {
+				if p.ConnectType == partner && p.VXCPermitted {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("WARN: no %s partner port found — %s VXC tests will be skipped", partner, partner)
+			}
+		}
+	}
+
+	// CSP credentials pool — probe each key for live capacity
+	creds := loadCSPCredentials()
+	t.Logf("Azure service keys in pool: %d", len(creds.AzureServiceKeys))
+	t.Logf("GCP pairing keys in pool: %d", len(creds.GooglePairingKeys))
+
+	azureAvailable := 0
+	for _, key := range creds.AzureServiceKeys {
+		_, err := client.VXCService.LookupPartnerPorts(ctx, &megaport.LookupPartnerPortsRequest{
+			Partner:   "AZURE",
+			Key:       key,
+			PortSpeed: 1000,
+		})
+		if err == nil {
+			azureAvailable++
+		}
+	}
+	t.Logf("Azure service keys with available capacity: %d/%d", azureAvailable, len(creds.AzureServiceKeys))
+	if azureAvailable == 0 {
+		t.Error("WARN: no Azure service key has available capacity — Azure VXC tests will be skipped")
+	}
+
+	gcpAvailable := 0
+	for _, key := range creds.GooglePairingKeys {
+		_, err := client.VXCService.LookupPartnerPorts(ctx, &megaport.LookupPartnerPortsRequest{
+			Partner:   "GOOGLE",
+			Key:       key,
+			PortSpeed: 1000,
+		})
+		if err == nil {
+			gcpAvailable++
+		}
+	}
+	t.Logf("GCP pairing keys with available capacity: %d/%d", gcpAvailable, len(creds.GooglePairingKeys))
+	if gcpAvailable == 0 {
+		t.Error("WARN: no GCP pairing key has available capacity — GCP VXC tests will be skipped")
+	}
+}
+
+// ── Diagnostics ───────────────────────────────────────────────────────────────
+
+// TestListMVECapacity prints all staging locations with available MVE capacity.
+// Never fails. Run manually to discover locations or to refresh the pool file:
+//
+//	go test -v -run TestListMVECapacity ./internal/provider/
+func TestListMVECapacity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("diagnostic only")
+	}
+	ctx := context.Background()
+	client, err := getTestClient()
+	if err != nil {
+		t.Skipf("no client: %v", err)
+	}
+	locations, err := client.LocationService.ListLocationsV3(ctx)
+	if err != nil {
+		t.Skipf("list failed: %v", err)
+	}
+	t.Logf("%-6s %-10s %-8s %s", "ID", "MaxCores", "Status", "Name")
+	for _, loc := range locations {
+		if !loc.HasMVESupport() {
+			continue
+		}
+		cores := loc.GetMVEMaxCpuCores()
+		coresStr := "nil"
+		if cores != nil {
+			coresStr = fmt.Sprintf("%d", *cores)
+		}
+		t.Logf("%-6d %-10s %-8s %s", loc.ID, coresStr, loc.Status, loc.Name)
+	}
+	t.Skip("diagnostic complete")
+}
+
+// TestListPortCapacity prints all staging locations with port/MCR capacity.
+// Never fails. Run manually to refresh testdata/port_test_locations.json:
+//
+//	go test -v -run TestListPortCapacity ./internal/provider/
+func TestListPortCapacity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("diagnostic only")
+	}
+	ctx := context.Background()
+	client, err := getTestClient()
+	if err != nil {
+		t.Skipf("no client: %v", err)
+	}
+	locations, err := client.LocationService.ListLocationsV3(ctx)
+	if err != nil {
+		t.Skipf("list failed: %v", err)
+	}
+	t.Logf("%-6s %-8s %s", "ID", "Status", "Name")
+	for _, loc := range locations {
+		if loc.DiversityZones == nil {
+			continue
+		}
+		if !portLocationHasCapacity(loc, 1) && !mcrLocationHasCapacity(loc, 1) {
+			continue
+		}
+		t.Logf("%-6d %-8s %s", loc.ID, loc.Status, loc.Name)
+	}
+	t.Skip("diagnostic complete")
+}
+
+// cleanupDelete controls whether TestCleanupOrphanedResources deletes resources.
+// Pass -cleanup-delete on the go test command line to enable deletion.
+var cleanupDelete = flag.Bool("cleanup-delete", false, "delete orphaned test resources in TestCleanupOrphanedResources")
+
+// TestCleanupOrphanedResources lists (and optionally deletes) staging resources
+// whose name starts with "tf-acc-test-". VXCs are deleted first (before their
+// endpoints). Never fails — always skips at the end.
+//
+//	# List only:
+//	go test -v -run TestCleanupOrphanedResources ./internal/provider/
+//
+//	# Delete:
+//	go test -v -run TestCleanupOrphanedResources -cleanup-delete ./internal/provider/
+func TestCleanupOrphanedResources(t *testing.T) {
+	if testing.Short() {
+		t.Skip("cleanup requires API access")
+	}
+	const prefix = "tf-acc-test-"
+	ctx := context.Background()
+	client, err := getTestClient()
+	if err != nil {
+		t.Skipf("no client: %v", err)
+	}
+
+	// VXCs first — must be deleted before their A/B-end resources
+	vxcs, err := client.VXCService.ListVXCs(ctx, &megaport.ListVXCsRequest{})
+	if err != nil {
+		t.Logf("WARN: could not list VXCs: %v", err)
+	}
+	for _, vxc := range vxcs {
+		if !strings.HasPrefix(vxc.Name, prefix) {
+			continue
+		}
+		t.Logf("VXC  %s (%s) status=%s", vxc.Name, vxc.UID, vxc.ProvisioningStatus)
+		if *cleanupDelete {
+			if delErr := client.VXCService.DeleteVXC(ctx, vxc.UID, &megaport.DeleteVXCRequest{DeleteNow: true}); delErr != nil {
+				t.Logf("  delete failed: %v", delErr)
+			} else {
+				t.Logf("  deleted")
+			}
+		}
+	}
+
+	// MVEs
+	mves, err := client.MVEService.ListMVEs(ctx, &megaport.ListMVEsRequest{})
+	if err != nil {
+		t.Logf("WARN: could not list MVEs: %v", err)
+	}
+	for _, mve := range mves {
+		if !strings.HasPrefix(mve.Name, prefix) {
+			continue
+		}
+		t.Logf("MVE  %s (%s) status=%s", mve.Name, mve.UID, mve.ProvisioningStatus)
+		if *cleanupDelete {
+			if _, delErr := client.MVEService.DeleteMVE(ctx, &megaport.DeleteMVERequest{MVEID: mve.UID}); delErr != nil {
+				t.Logf("  delete failed: %v", delErr)
+			} else {
+				t.Logf("  deleted")
+			}
+		}
+	}
+
+	// MCRs
+	mcrs, err := client.MCRService.ListMCRs(ctx, &megaport.ListMCRsRequest{})
+	if err != nil {
+		t.Logf("WARN: could not list MCRs: %v", err)
+	}
+	for _, mcr := range mcrs {
+		if !strings.HasPrefix(mcr.Name, prefix) {
+			continue
+		}
+		t.Logf("MCR  %s (%s) status=%s", mcr.Name, mcr.UID, mcr.ProvisioningStatus)
+		if *cleanupDelete {
+			if _, delErr := client.MCRService.DeleteMCR(ctx, &megaport.DeleteMCRRequest{MCRID: mcr.UID, DeleteNow: true}); delErr != nil {
+				t.Logf("  delete failed: %v", delErr)
+			} else {
+				t.Logf("  deleted")
+			}
+		}
+	}
+
+	// Ports (last — must come after VXCs that connect to them)
+	ports, err := client.PortService.ListPorts(ctx)
+	if err != nil {
+		t.Logf("WARN: could not list ports: %v", err)
+	}
+	for _, port := range ports {
+		if !strings.HasPrefix(port.Name, prefix) {
+			continue
+		}
+		t.Logf("Port %s (%s) status=%s", port.Name, port.UID, port.ProvisioningStatus)
+		if *cleanupDelete {
+			if _, delErr := client.PortService.DeletePort(ctx, &megaport.DeletePortRequest{PortID: port.UID, DeleteNow: true}); delErr != nil {
+				t.Logf("  delete failed: %v", delErr)
+			} else {
+				t.Logf("  deleted")
+			}
+		}
+	}
+
+	t.Skip("cleanup scan complete")
+}

--- a/internal/provider/testdata/csp_credentials.json
+++ b/internal/provider/testdata/csp_credentials.json
@@ -1,0 +1,37 @@
+{
+  "comment": "Demo CSP credentials for Megaport staging environment. Keys are consumed after use — run cleanup-test-resources.sh between runs to free Azure port+vlan slots.",
+  "azure_service_keys": [
+    "197d927b-90bc-4b1b-bffd-fca17a7ec735",
+    "d7a066e1-d171-4e80-97f0-b605638dea4b",
+    "2d40f007-1c51-4859-b45c-f8b036660f2f",
+    "89187d75-d665-4998-916d-30a219ad92ff",
+    "7e41932a-478f-4cbf-aa3a-96a16770035d",
+    "03b95a76-a689-4e32-b761-fd1b90be634c",
+    "c85dde47-4568-4f3c-8bb8-330de8404b55",
+    "0bce6560-3c2d-4de6-94ce-ba99187e6992",
+    "e1cbea5e-88e1-4861-b581-545f364bdeed",
+    "498fe406-8a38-4439-87de-a01ca29e8db3"
+  ],
+  "azure_service_keys_with_peers": [
+    "6c623445-a2f7-4fde-a3c5-bec6d7abc123",
+    "3966707f-50ff-4259-aa11-bec6d7def987",
+    "f31e9a0b-5f49-4414-a910-bec6d7bdf456"
+  ],
+  "google_pairing_keys": [
+    "20c368d8-104b-449d-bb64-60aa53fdd180/northamerica-northeast1/1",
+    "2b5497cb-70fc-486f-9203-1cda7194eb93/us-central1/1",
+    "495b572b-8e67-4866-9566-aa5fc702da17/us-east1/1",
+    "328bd548-ac5c-43a3-9e2d-66fb0f116e8c/us-east4/1",
+    "040a6625-225d-4607-a175-ab8d72e6be3a/us-west1/1",
+    "27325c3a-b640-4b69-a2d5-cdcca797a151/us-west2/1",
+    "7b08a54d-4137-4ee8-bb53-2b0c23e998c5/europe-north1/1",
+    "94b8f26e-a9c0-479e-9c65-a7b42614e12e/europe-west1/1",
+    "a872df56-b4c8-4860-bcf6-2ced767df22e/europe-west2/1",
+    "a2794213-fe83-487b-a153-da6e9cd03a14/europe-west3/1",
+    "126e8079-5fbf-491d-93cc-e8211bcf1d00/europe-west4/1",
+    "fe6a1606-42d4-43ee-9c4d-3b45b35a3c8a/asia-east1/1",
+    "c0c9b06c-b4e2-4c71-a3ad-86e1cd671928/asia-northeast1/1",
+    "e7097903-6b0a-4ee5-8261-8cb2f9dfb90d/asia-southeast1/1",
+    "36ac9f72-c8e5-473f-a4b7-537a2502e446/australia-southeast1/1"
+  ]
+}

--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -26,16 +26,10 @@ const (
 	VXCLocationID2 = 3  // "Global Switch Sydney West"
 	VXCLocationID3 = 23 // "5GN Melbourne Data Centre (MDC)"
 
-	AzureServiceKey           = "197d927b-90bc-4b1b-bffd-fca17a7ec735"
-	GooglePairingKeyCSPs      = "36ac9f72-c8e5-473f-a4b7-537a2502e446/australia-southeast1/1"
-	GooglePairingKeyGCPTest   = "e7097903-6b0a-4ee5-8261-8cb2f9dfb90d/asia-southeast1/1"
-	GooglePairingKeyEcosystem = "c0c9b06c-b4e2-4c71-a3ad-86e1cd671928/asia-northeast1/1"
-	OracleVirtualCircuitID    = "ocid1.virtualcircuit.oc1.phx.aaaaaaaapsokflwszxk3c2vhsyj5pkas3gmh3zngyxx7zj6yxj2stgeofk5q" // Example Oracle Virtual Circuit ID that passes API Validation of /^ocid1\.virtualcircuit\.oc[0-9]+.(.+)\.a{8}[a-z2-7]{52}$/
-	AzurePartnerPortUID       = "13f28165-de96-484e-8f99-babb24650e6a"                                                      // This is the specific product UID tied to the secondary port choice for the Azure Service key above.
+	OracleVirtualCircuitID = "ocid1.virtualcircuit.oc1.phx.aaaaaaaapsokflwszxk3c2vhsyj5pkas3gmh3zngyxx7zj6yxj2stgeofk5q" // Example Oracle Virtual Circuit ID that passes API Validation of /^ocid1\.virtualcircuit\.oc[0-9]+.(.+)\.a{8}[a-z2-7]{52}$/
+	AzurePartnerPortUID    = "13f28165-de96-484e-8f99-babb24650e6a"                                                      // This is the specific product UID tied to the secondary port choice for the Azure Service key above.
 
-	MVEArubaImageID              = 152
-	VXCMVETestLocationIDNum      = 116 // Atlanta "Equinix Atlanta AT1" (atl-tx1) - 12 test_demo_cores
-	VXCMixedMVETestLocationIDNum = 321 // Denver "Iron Mountain DEN-1" (den-irm) - 8 test_demo_cores
+	MVEArubaImageID = 152
 )
 
 func TestVXCBasicProviderTestSuite(t *testing.T) {
@@ -991,6 +985,8 @@ func (suite *VXCBasicProviderTestSuite) TestAccMegaportVXC_BasicUntagVLAN() {
 // }
 
 func (suite *VXCCSPProviderTestSuite) TestAccMegaportMCRVXCWithCSPs_Basic() {
+	azureServiceKey := pickAzureServiceKey(suite.T())
+	gcpPairingKey := pickGCPPairingKey(suite.T())
 	mcrName := RandomTestName()
 	vxcName1 := RandomTestName()
 	vxcName2 := RandomTestName()
@@ -1098,7 +1094,7 @@ func (suite *VXCCSPProviderTestSuite) TestAccMegaportMCRVXCWithCSPs_Basic() {
                         }
                     }
                   }
-                  `, VXCLocationID1, VXCLocationID2, mcrName, vxcName1, vxcName1, vxcName2, GooglePairingKeyCSPs, vxcName3, AzureServiceKey),
+                  `, VXCLocationID1, VXCLocationID2, mcrName, vxcName1, vxcName1, vxcName2, gcpPairingKey, vxcName3, azureServiceKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("megaport_vxc.aws_vxc", "product_uid"),
 					resource.TestCheckResourceAttr("megaport_vxc.aws_vxc", "b_end_partner_config.aws_config.name", vxcName1),
@@ -1416,6 +1412,7 @@ func (suite *VXCCSPProviderTestSuite) TestAccMegaportMCRVXCWithBGP_Basic() {
 }
 
 func (suite *VXCCSPProviderTestSuite) TestGCPVXCWithProductUID() {
+	gcpPairingKey := pickGCPPairingKey(suite.T())
 	mcrName := RandomTestName()
 	mcrCostCentreName := RandomTestName()
 	gcpCostCentreName := RandomTestName()
@@ -1468,7 +1465,7 @@ func (suite *VXCCSPProviderTestSuite) TestGCPVXCWithProductUID() {
 					  }
 					}
 				  }
-                  `, VXCLocationID1, mcrName, mcrCostCentreName, gcpVXCName, gcpCostCentreName, GooglePairingKeyGCPTest),
+                  `, VXCLocationID1, mcrName, mcrCostCentreName, gcpVXCName, gcpCostCentreName, gcpPairingKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("megaport_mcr.mcr", "product_uid"),
 					resource.TestCheckResourceAttrSet("megaport_vxc.gcp_vxc", "product_uid"),
@@ -1544,6 +1541,7 @@ func (suite *VXCCSPProviderTestSuite) TestOracleVXCWithProductUID() {
 }
 
 func (suite *VXCCSPProviderTestSuite) TestAzureVXCWithProductUID() {
+	azureServiceKey := pickAzureServiceKey(suite.T())
 	mcrName := RandomTestName()
 	mcrCostCentreName := RandomTestName()
 	azureCostCentreName := RandomTestName()
@@ -1590,7 +1588,7 @@ func (suite *VXCCSPProviderTestSuite) TestAzureVXCWithProductUID() {
 					  }
 					}
 				  }
-                  `, VXCLocationID1, mcrName, mcrCostCentreName, azureVXCName, azureCostCentreName, AzurePartnerPortUID, AzureServiceKey),
+                  `, VXCLocationID1, mcrName, mcrCostCentreName, azureVXCName, azureCostCentreName, AzurePartnerPortUID, azureServiceKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("megaport_mcr.mcr", "product_uid"),
 					resource.TestCheckResourceAttrSet("megaport_vxc.azure_vxc", "product_uid"),
@@ -1719,6 +1717,8 @@ func (suite *VXCCSPProviderTestSuite) TestAccMegaportMCRVXC_BEndIpMtu() {
 }
 
 func (suite *VXCCSPProviderTestSuite) TestFullEcosystem() {
+	azureServiceKey := pickAzureServiceKey(suite.T())
+	gcpPairingKey := pickGCPPairingKey(suite.T())
 	portName := RandomTestName()
 	lagPortName := RandomTestName()
 	mcrName := RandomTestName()
@@ -1885,7 +1885,7 @@ func (suite *VXCCSPProviderTestSuite) TestFullEcosystem() {
 					  }
 					}
 				  }
-                  `, VXCLocationID1, VXCLocationID2, VXCLocationID3, lagPortName, costCentreName, portName, costCentreName, mcrName, portVXCName, mcrVXCName, awsVXCName, awsVXCName, gcpVXCName, GooglePairingKeyEcosystem, azureVXCName, AzureServiceKey),
+                  `, VXCLocationID1, VXCLocationID2, VXCLocationID3, lagPortName, costCentreName, portName, costCentreName, mcrName, portVXCName, mcrVXCName, awsVXCName, awsVXCName, gcpVXCName, gcpPairingKey, azureVXCName, azureServiceKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("megaport_vxc.aws_vxc", "product_uid"),
 					resource.TestCheckResourceAttr("megaport_vxc.aws_vxc", "b_end_partner_config.aws_config.name", awsVXCName),
@@ -2940,6 +2940,8 @@ func (suite *VXCInnerVLANProviderTestSuite) TestAccMegaportVXC_InnerVLANToUntagg
 }
 
 func (suite *VXCMixedProviderTestSuite) TestAccMegaportSafeDelete() {
+	mveLocationID, _ := findMVETestLocation(suite.T(), 2)
+	mcrLocationID, _ := findMCRTestLocation(suite.T(), 2500)
 	portName := RandomTestName()
 	mcrName := RandomTestName()
 	mveName := RandomTestName()
@@ -3035,8 +3037,8 @@ func (suite *VXCMixedProviderTestSuite) TestAccMegaportSafeDelete() {
                 }
                 `,
 					portName, VXCLocationID1,
-					mcrName, MCRTestLocationIDNum,
-					mveName, VXCMixedMVETestLocationIDNum, MVEArubaImageID,
+					mcrName, mcrLocationID,
+					mveName, mveLocationID, MVEArubaImageID,
 					mveName, mveName,
 					vxcPortToMCRName, vxcMCRToMVEName),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -3144,8 +3146,8 @@ func (suite *VXCMixedProviderTestSuite) TestAccMegaportSafeDelete() {
                 }
                 `,
 					portName, VXCLocationID1,
-					mcrName, MCRTestLocationIDNum,
-					mveName, VXCMixedMVETestLocationIDNum, MVEArubaImageID,
+					mcrName, mcrLocationID,
+					mveName, mveLocationID, MVEArubaImageID,
 					mveName, mveName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_port.test_port", "product_name", portName),
@@ -3162,6 +3164,7 @@ func (suite *VXCMixedProviderTestSuite) TestAccMegaportSafeDelete() {
 }
 
 func (suite *VXCMVEProviderTestSuite) TestAccMegaportMVE_to_MVE_VXC() {
+	mveLocationID, _ := findMVETestLocation(suite.T(), 2)
 	mveName1 := RandomTestName()
 	mveName2 := RandomTestName()
 	mveName3 := RandomTestName()
@@ -3292,10 +3295,10 @@ func (suite *VXCMVEProviderTestSuite) TestAccMegaportMVE_to_MVE_VXC() {
                 }
                 `,
 					MVEArubaImageID,
-					mveName1, VXCMVETestLocationIDNum, mveName1, mveName1,
-					mveName2, VXCMVETestLocationIDNum, mveName2, mveName2,
-					mveName3, VXCMVETestLocationIDNum, mveName3, mveName3,
-					mveName4, VXCMVETestLocationIDNum, mveName4, mveName4,
+					mveName1, mveLocationID, mveName1, mveName1,
+					mveName2, mveLocationID, mveName2, mveName2,
+					mveName3, mveLocationID, mveName3, mveName3,
+					mveName4, mveLocationID, mveName4, mveName4,
 					vxcName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Check MVEs
@@ -3437,10 +3440,10 @@ func (suite *VXCMVEProviderTestSuite) TestAccMegaportMVE_to_MVE_VXC() {
                 }
                 `,
 					MVEArubaImageID,
-					mveName1, VXCMVETestLocationIDNum, mveName1, mveName1,
-					mveName2, VXCMVETestLocationIDNum, mveName2, mveName2,
-					mveName3, VXCMVETestLocationIDNum, mveName3, mveName3,
-					mveName4, VXCMVETestLocationIDNum, mveName4, mveName4,
+					mveName1, mveLocationID, mveName1, mveName1,
+					mveName2, mveLocationID, mveName2, mveName2,
+					mveName3, mveLocationID, mveName3, mveName3,
+					mveName4, mveLocationID, mveName4, mveName4,
 					vxcName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Check MVEs still exist
@@ -3470,6 +3473,7 @@ func (suite *VXCMVEProviderTestSuite) TestAccMegaportMVE_to_MVE_VXC() {
 }
 
 func (suite *VXCMVEProviderTestSuite) TestAccMegaportVXC_MVEVnicIndexUpdate() {
+	mveLocationID, _ := findMVETestLocation(suite.T(), 2)
 	// Test names
 	portName := RandomTestName()
 	mveName := RandomTestName()
@@ -3538,7 +3542,7 @@ func (suite *VXCMVEProviderTestSuite) TestAccMegaportVXC_MVEVnicIndexUpdate() {
                 }
                 `,
 					portName, VXCLocationID1,
-					mveName, VXCMVETestLocationIDNum, MVEArubaImageID,
+					mveName, mveLocationID, MVEArubaImageID,
 					mveName, mveName,
 					vxcName),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -3612,7 +3616,7 @@ func (suite *VXCMVEProviderTestSuite) TestAccMegaportVXC_MVEVnicIndexUpdate() {
                 }
                 `,
 					portName, VXCLocationID1,
-					mveName, VXCMVETestLocationIDNum, MVEArubaImageID,
+					mveName, mveLocationID, MVEArubaImageID,
 					mveName, mveName,
 					vxcName),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -3668,7 +3672,7 @@ func (suite *VXCMVEProviderTestSuite) TestAccMegaportVXC_MVEVnicIndexUpdate() {
                 }
                 `,
 					portName, VXCLocationID1,
-					mveName, VXCMVETestLocationIDNum, MVEArubaImageID,
+					mveName, mveLocationID, MVEArubaImageID,
 					mveName, mveName,
 					vxcName),
 				PlanOnly: true,
@@ -4106,6 +4110,7 @@ func (suite *VXCImportDriftProviderTestSuite) TestAccMegaportVXC_ImportDrift_AWS
 // return the user-configured vnic_index on read, so the provider must preserve
 // it from state/plan to avoid an infinite update loop.
 func (suite *VXCImportDriftProviderTestSuite) TestAccMegaportVXC_ImportDrift_WithVnicIndex() {
+	mveLocationID, _ := findMVETestLocation(suite.T(), 2)
 	portName := RandomTestName()
 	mveName := RandomTestName()
 	vxcName := RandomTestName()
@@ -4159,7 +4164,7 @@ func (suite *VXCImportDriftProviderTestSuite) TestAccMegaportVXC_ImportDrift_Wit
 				}
 			}
 		`, portName, VXCLocationID1,
-			mveName, VXCMixedMVETestLocationIDNum, MVEArubaImageID,
+			mveName, mveLocationID, MVEArubaImageID,
 			mveName, mveName,
 			vxcName)
 	}

--- a/scripts/cleanup-test-resources.sh
+++ b/scripts/cleanup-test-resources.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Lists orphaned tf-acc-test-* resources in staging.
+# VXCs are listed/deleted first to free up their A/B-end endpoints.
+#
+# Usage:
+#   # List only (safe):
+#   MEGAPORT_ACCESS_KEY=xxx MEGAPORT_SECRET_KEY=xxx ./scripts/cleanup-test-resources.sh
+#
+#   # Delete orphaned resources:
+#   MEGAPORT_ACCESS_KEY=xxx MEGAPORT_SECRET_KEY=xxx ./scripts/cleanup-test-resources.sh --delete
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)/terraform-provider-megaport"
+
+: "${MEGAPORT_ACCESS_KEY:?MEGAPORT_ACCESS_KEY must be set}"
+: "${MEGAPORT_SECRET_KEY:?MEGAPORT_SECRET_KEY must be set}"
+
+DELETE_FLAG=""
+if [[ "${1:-}" == "--delete" ]]; then
+  DELETE_FLAG="-cleanup-delete"
+  echo "WARNING: --delete specified. Orphaned resources will be deleted."
+  echo "Press Ctrl-C within 5 seconds to abort..."
+  sleep 5
+fi
+
+go test -v -count=1 -run TestCleanupOrphanedResources ./internal/provider/ ${DELETE_FLAG}

--- a/scripts/find-test-locations.sh
+++ b/scripts/find-test-locations.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Prints staging locations with available MVE and port capacity.
+#
+# Usage:
+#   MEGAPORT_ACCESS_KEY=xxx MEGAPORT_SECRET_KEY=xxx ./scripts/find-test-locations.sh
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)/terraform-provider-megaport"
+
+: "${MEGAPORT_ACCESS_KEY:?MEGAPORT_ACCESS_KEY must be set}"
+: "${MEGAPORT_SECRET_KEY:?MEGAPORT_SECRET_KEY must be set}"
+
+echo "=== MVE capacity ==="
+go test -v -count=1 -run TestListMVECapacity ./internal/provider/
+
+echo ""
+echo "=== Port/MCR capacity ==="
+go test -v -count=1 -run TestListPortCapacity ./internal/provider/


### PR DESCRIPTION
Acceptance tests previously relied on hardcoded location IDs and CSP credentials that fail silently when staging capacity shifts or a key's port+vlan slot is taken by a prior test run. This PR replaces all of them with runtime pickers that validate actual availability before returning a value, so tests skip cleanly instead of failing with cryptic API errors.

## What changed

**New: `internal/provider/test_helpers_test.go`**
- `findMVETestLocation` — validates capacity via `ValidateMVEOrder` (validate-probe pattern). Tries a curated list of ~50 known-good staging location IDs before falling back to a full sweep. Needed because staging does not populate `mveMaxCpuCoreCount`, so field-based checks are unreliable.
- `findPortTestLocation` / `findMCRTestLocation` — sweep `ListLocationsV3` checking `MegaportSpeedMbps` / `McrSpeedMbps` (these fields are populated in staging).
- `pickAzureServiceKey` / `pickGCPPairingKey` — shuffle the key pool then probe each key via `LookupPartnerPorts` (`/v2/secure/{partner}/{key}`), returning the first with available capacity.
- `TestStagingHealthCheck` — pre-flight check: API reachability, location counts, partner port presence, CSP key availability. Run before a full acceptance suite.
- `TestListMVECapacity` / `TestListPortCapacity` — diagnostic helpers, always skip at end.
- `TestCleanupOrphanedResources` — lists (and optionally deletes with `-cleanup-delete`) orphaned `tf-acc-test-*` resources. Deletes VXCs before their endpoints.

**New: `internal/provider/testdata/csp_credentials.json`**
Pool of staging Azure service keys and GCP pairing keys. These are demo/staging credentials — not sensitive, but exhaustible (a key becomes unavailable when its port+vlan slot is in use).

**New: `scripts/find-test-locations.sh` / `scripts/cleanup-test-resources.sh`**
Convenience wrappers for the diagnostic and cleanup tests.

**Modified: all affected `*_test.go` files**
Removed hardcoded location ID and CSP credential constants (`SinglePortTestLocationIDNum`, `MCRTestLocationIDNum`, `LagPortTestLocationIDNum`, `MVEArubaTestLocationIDNum`, `MVEVersaTestLocationIDNum`, `VXCMVETestLocationIDNum`, `VXCMixedMVETestLocationIDNum`, `AzureServiceKey`, `GooglePairingKey*`). Each test method now calls the appropriate picker at the top.

## Testing

```bash
# Pre-flight check
MEGAPORT_ACCESS_KEY=xxx MEGAPORT_SECRET_KEY=xxx \
  go test -v -run TestStagingHealthCheck ./internal/provider/

# MVE acceptance test (confirmed passing)
TF_ACC=1 MEGAPORT_ACCESS_KEY=xxx MEGAPORT_SECRET_KEY=xxx \
  go test -v -timeout=30m -run TestMVEArubaProviderTestSuite ./internal/provider/
```