### PR TITLE
Fix VXC replacement when A/B-end product UID changes

### DIFF
--- a/internal/provider/mcrs_data_source_test.go
+++ b/internal/provider/mcrs_data_source_test.go
@@ -102,6 +102,14 @@ func (m *MockMCRService) UpdateMCRResourceTags(ctx context.Context, mcrID string
 	return nil
 }
 
+func (m *MockMCRService) UpdateMCRWithAddOn(ctx context.Context, mcrID string, req megaport.MCRAddOnRequest) error {
+	return nil
+}
+
+func (m *MockMCRService) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, addOnUID string, tunnelCount int) error {
+	return nil
+}
+
 func (m *MockMCRService) GetMCRPrefixFilterLists(ctx context.Context, mcrId string) ([]*megaport.PrefixFilterList, error) {
 	return nil, nil
 }

--- a/internal/provider/vxc_resource.go
+++ b/internal/provider/vxc_resource.go
@@ -933,18 +933,24 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 					"requested_product_uid": schema.StringAttribute{
 						Description: "The Product UID requested by the user for the A-End configuration. Note: For cloud provider connections, the actual Product UID may differ from the requested UID due to Megaport's automatic port assignment for partner ports. This is expected behavior and ensures proper connectivity.",
 						Required:    true,
-						// PlanModifiers: []planmodifier.String{
-						// 	stringplanmodifier.RequiresReplaceIf(
-						// 		func(ctx context.Context, sr planmodifier.StringRequest, rrifr *stringplanmodifier.RequiresReplaceIfFuncResponse) {
-						// 			if sr.PlanValue.IsUnknown() {
-						// 				rrifr.RequiresReplace = true
-						// 			}
-						// 		},
-						// 		"This modifier will replace the VXC if the new `requested_product_uid` is unknown. This allows the provider to better handle situations when the connected product (Port, MVE, MCR) is being replaced. To avoid replacement, make sure the new `requested_product_uid` is a known value (i.e. an existing product in the state).",
-						// 		"This modifier will replace the VXC if the new `requested_product_uid` is unknown. This allows the provider to better handle situations when the connected product (Port, MVE, MCR) is being replaced. To avoid replacement, make sure the new `requested_product_uid` is a known value (i.e. an existing product in the state).",
-						// 	),
-						// 	stringplanmodifier.UseStateForUnknown(),
-						// },
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplaceIf(
+								func(_ context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+									if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+										return
+									}
+									if req.PlanValue.IsUnknown() {
+										resp.RequiresReplace = true
+										return
+									}
+									if !req.StateValue.Equal(req.PlanValue) {
+										resp.RequiresReplace = true
+									}
+								},
+								"Replacing the connected product (Port, MVE, MCR) requires the VXC to be recreated. Partner port rotation (where Megaport reassigns to a different port) will not trigger replacement as it only changes current_product_uid, not requested_product_uid.",
+								"Replacing the connected product requires the VXC to be recreated.",
+							),
+						},
 					},
 					"current_product_uid": schema.StringAttribute{
 						Description: "The current product UID of the A-End configuration. The Megaport API may change a Partner Port from the Requested Port to a different Port in the same location and diversity zone.",
@@ -1017,18 +1023,24 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 						Description: "The Product UID requested by the user for the B-End configuration. Note: For cloud provider connections, the actual Product UID may differ from the requested UID due to Megaport's automatic port assignment for partner ports. This is expected behavior and ensures proper connectivity.",
 						Optional:    true,
 						Computed:    true,
-						// PlanModifiers: []planmodifier.String{
-						// 	stringplanmodifier.RequiresReplaceIf(
-						// 		func(ctx context.Context, sr planmodifier.StringRequest, rrifr *stringplanmodifier.RequiresReplaceIfFuncResponse) {
-						// 			if sr.PlanValue.IsUnknown() {
-						// 				rrifr.RequiresReplace = true
-						// 			}
-						// 		},
-						// 		"This modifier will replace the VXC if the new `requested_product_uid` is unknown. This allows the provider to better handle situations when the connected product (Port, MVE, MCR) is being replaced. To avoid replacement, make sure the new `requested_product_uid` is a known value (i.e. an existing product in the state).",
-						// 		"This modifier will replace the VXC if the new `requested_product_uid` is unknown. This allows the provider to better handle situations when the connected product (Port, MVE, MCR) is being replaced. To avoid replacement, make sure the new `requested_product_uid` is a known value (i.e. an existing product in the state).",
-						// 	),
-						// 	stringplanmodifier.UseStateForUnknown(),
-						// },
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplaceIf(
+								func(_ context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+									if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+										return
+									}
+									if req.PlanValue.IsUnknown() {
+										resp.RequiresReplace = true
+										return
+									}
+									if !req.StateValue.Equal(req.PlanValue) {
+										resp.RequiresReplace = true
+									}
+								},
+								"Replacing the connected product (Port, MVE, MCR) requires the VXC to be recreated. Partner port rotation (where Megaport reassigns to a different port) will not trigger replacement as it only changes current_product_uid, not requested_product_uid.",
+								"Replacing the connected product requires the VXC to be recreated.",
+							),
+						},
 					},
 					"current_product_uid": schema.StringAttribute{
 						Description: "The current product UID of the B-End configuration. The Megaport API may change a Partner Port on the end configuration from the Requested Port UID to a different Port in the same location and diversity zone.",


### PR DESCRIPTION
When a user updates `a_end.requested_product_uid` or `b_end.requested_product_uid` to point to a different product (e.g. moving a VXC from one MVE to another), the provider currently sends an in-place `PUT` which the API rejects with HTTP 400: "virtual router service has a different linked interface". This change re-enables the `RequiresReplaceIf` plan modifier so that changing the endpoint UID correctly triggers a destroy+recreate instead.

Partner port rotation is unaffected — rotation only changes `current_product_uid` (computed by the API), not `requested_product_uid` (set by the user), so no unnecessary replacements are triggered.

Also fixes a pre-existing lint failure by adding missing `UpdateMCRWithAddOn` and `UpdateMCRIPsecAddOn` stubs to `MockMCRService` in `mcrs_data_source_test.go`.

## Notable changes

- `vxc_resource.go`: Uncommented and updated `RequiresReplaceIf` for both `a_end.requested_product_uid` and `b_end.requested_product_uid`
- `mcrs_data_source_test.go`: Added two missing interface method stubs to satisfy `megaport.MCRService`