### PR TITLE
fix: fix VXC replacement when A/B-end product UID changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.30.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
-	github.com/megaport/megaportgo v1.4.9
+	github.com/megaport/megaportgo v1.7.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/megaport/megaportgo v1.4.9 h1:3xIcgD7pDlkBJ50O03VenSBhAtKz6q+SXAN+NNm+dPY=
-github.com/megaport/megaportgo v1.4.9/go.mod h1:KgHDAyT1uVg93qBaW/z0M63sQlPvipB04vab4F88dGA=
+github.com/megaport/megaportgo v1.7.0 h1:TUvFsMnSKX2ALl5WthXxiqJsUFPOpi1ueeY2xfs6XkA=
+github.com/megaport/megaportgo v1.7.0/go.mod h1:KgHDAyT1uVg93qBaW/z0M63sQlPvipB04vab4F88dGA=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=

--- a/internal/provider/mcrs_data_source_test.go
+++ b/internal/provider/mcrs_data_source_test.go
@@ -102,6 +102,14 @@ func (m *MockMCRService) UpdateMCRResourceTags(ctx context.Context, mcrID string
 	return nil
 }
 
+func (m *MockMCRService) UpdateMCRWithAddOn(ctx context.Context, mcrID string, req megaport.MCRAddOnRequest) error {
+	return nil
+}
+
+func (m *MockMCRService) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, addOnUID string, tunnelCount int) error {
+	return nil
+}
+
 func (m *MockMCRService) GetMCRPrefixFilterLists(ctx context.Context, mcrId string) ([]*megaport.PrefixFilterList, error) {
 	return nil, nil
 }

--- a/internal/provider/vxc_resource.go
+++ b/internal/provider/vxc_resource.go
@@ -933,18 +933,24 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 					"requested_product_uid": schema.StringAttribute{
 						Description: "The Product UID requested by the user for the A-End configuration. Note: For cloud provider connections, the actual Product UID may differ from the requested UID due to Megaport's automatic port assignment for partner ports. This is expected behavior and ensures proper connectivity.",
 						Required:    true,
-						// PlanModifiers: []planmodifier.String{
-						// 	stringplanmodifier.RequiresReplaceIf(
-						// 		func(ctx context.Context, sr planmodifier.StringRequest, rrifr *stringplanmodifier.RequiresReplaceIfFuncResponse) {
-						// 			if sr.PlanValue.IsUnknown() {
-						// 				rrifr.RequiresReplace = true
-						// 			}
-						// 		},
-						// 		"This modifier will replace the VXC if the new `requested_product_uid` is unknown. This allows the provider to better handle situations when the connected product (Port, MVE, MCR) is being replaced. To avoid replacement, make sure the new `requested_product_uid` is a known value (i.e. an existing product in the state).",
-						// 		"This modifier will replace the VXC if the new `requested_product_uid` is unknown. This allows the provider to better handle situations when the connected product (Port, MVE, MCR) is being replaced. To avoid replacement, make sure the new `requested_product_uid` is a known value (i.e. an existing product in the state).",
-						// 	),
-						// 	stringplanmodifier.UseStateForUnknown(),
-						// },
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplaceIf(
+								func(_ context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+									if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+										return
+									}
+									if req.PlanValue.IsUnknown() {
+										resp.RequiresReplace = true
+										return
+									}
+									if !req.StateValue.Equal(req.PlanValue) {
+										resp.RequiresReplace = true
+									}
+								},
+								"Replacing the connected product (Port, MVE, MCR) requires the VXC to be recreated. Partner port rotation (where Megaport reassigns to a different port) will not trigger replacement as it only changes current_product_uid, not requested_product_uid.",
+								"Replacing the connected product requires the VXC to be recreated.",
+							),
+						},
 					},
 					"current_product_uid": schema.StringAttribute{
 						Description: "The current product UID of the A-End configuration. The Megaport API may change a Partner Port from the Requested Port to a different Port in the same location and diversity zone.",
@@ -1017,18 +1023,24 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 						Description: "The Product UID requested by the user for the B-End configuration. Note: For cloud provider connections, the actual Product UID may differ from the requested UID due to Megaport's automatic port assignment for partner ports. This is expected behavior and ensures proper connectivity.",
 						Optional:    true,
 						Computed:    true,
-						// PlanModifiers: []planmodifier.String{
-						// 	stringplanmodifier.RequiresReplaceIf(
-						// 		func(ctx context.Context, sr planmodifier.StringRequest, rrifr *stringplanmodifier.RequiresReplaceIfFuncResponse) {
-						// 			if sr.PlanValue.IsUnknown() {
-						// 				rrifr.RequiresReplace = true
-						// 			}
-						// 		},
-						// 		"This modifier will replace the VXC if the new `requested_product_uid` is unknown. This allows the provider to better handle situations when the connected product (Port, MVE, MCR) is being replaced. To avoid replacement, make sure the new `requested_product_uid` is a known value (i.e. an existing product in the state).",
-						// 		"This modifier will replace the VXC if the new `requested_product_uid` is unknown. This allows the provider to better handle situations when the connected product (Port, MVE, MCR) is being replaced. To avoid replacement, make sure the new `requested_product_uid` is a known value (i.e. an existing product in the state).",
-						// 	),
-						// 	stringplanmodifier.UseStateForUnknown(),
-						// },
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplaceIf(
+								func(_ context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+									if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+										return
+									}
+									if req.PlanValue.IsUnknown() {
+										resp.RequiresReplace = true
+										return
+									}
+									if !req.StateValue.Equal(req.PlanValue) {
+										resp.RequiresReplace = true
+									}
+								},
+								"Replacing the connected product (Port, MVE, MCR) requires the VXC to be recreated. Partner port rotation (where Megaport reassigns to a different port) will not trigger replacement as it only changes current_product_uid, not requested_product_uid.",
+								"Replacing the connected product requires the VXC to be recreated.",
+							),
+						},
 					},
 					"current_product_uid": schema.StringAttribute{
 						Description: "The current product UID of the B-End configuration. The Megaport API may change a Partner Port on the end configuration from the Requested Port UID to a different Port in the same location and diversity zone.",


### PR DESCRIPTION
### User-Facing Summary

When updating `a_end.requested_product_uid` or `b_end.requested_product_uid` to move a VXC from one product to another (e.g. MVE replacement), the provider now correctly triggers a destroy+recreate instead of attempting an in-place update that the API rejects with HTTP 400.

Partner port rotation (where Megaport reassigns `current_product_uid` behind the scenes) is unaffected and will not trigger unnecessary replacement.

Also fixes a pre-existing lint failure by adding missing `UpdateMCRWithAddOn` and `UpdateMCRIPsecAddOn` stubs to `MockMCRService`.

---

### Type of Change

- [x] 🐛 Bug Fix

---

### Related Issues

Reported by customer — VXC move from old MVEs to replacement MVEs failed with: `virtual router service has a different linked interface, Service must be correctly provisioned to update`

---

### How to Test

1. Create a `megaport_vxc` resource connected to an MVE via `a_end.requested_product_uid`
2. Change `a_end.requested_product_uid` to a different MVE UID
3. Run `terraform plan` — should show destroy+recreate, not an in-place update
4. Verify that a VXC where `current_product_uid` differs from `requested_product_uid` (partner port rotation) does NOT show replacement in the plan

Unit tests: `go test -v -timeout=30m ./internal/provider/`
Lint: `golangci-lint run --timeout=10m` (0 issues)

---