### PR TITLE
fix: promo_code inconsistent result after apply

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.30.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
-	github.com/megaport/megaportgo v1.7.0
+	github.com/megaport/megaportgo v1.8.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/megaport/megaportgo v1.7.0 h1:TUvFsMnSKX2ALl5WthXxiqJsUFPOpi1ueeY2xfs6XkA=
-github.com/megaport/megaportgo v1.7.0/go.mod h1:KgHDAyT1uVg93qBaW/z0M63sQlPvipB04vab4F88dGA=
+github.com/megaport/megaportgo v1.8.0 h1:R274kNpl7Pc3nXB1khlzvIFi0eVpovlsEwQsh+M9dpc=
+github.com/megaport/megaportgo v1.8.0/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=

--- a/internal/provider/ix_resource.go
+++ b/internal/provider/ix_resource.go
@@ -159,7 +159,6 @@ func (orm *ixResourceModel) fromAPI(ctx context.Context, ix *megaport.IX) {
 	orm.ASN = types.Int64Value(int64(ix.ASN))
 	orm.RateLimit = types.Int64Value(int64(ix.RateLimit))
 	orm.VLAN = types.Int64Value(int64(ix.VLAN))
-	orm.PromoCode = types.StringValue(ix.PromoCode)
 	orm.PublicGraph = types.BoolValue(ix.PublicGraph)
 	orm.ProvisioningStatus = types.StringValue(ix.ProvisioningStatus)
 	orm.Term = types.Int64Value(int64(ix.Term))
@@ -167,12 +166,6 @@ func (orm *ixResourceModel) fromAPI(ctx context.Context, ix *megaport.IX) {
 	orm.SecondaryName = types.StringValue(ix.SecondaryName)
 	orm.IXPeerMacro = types.StringValue(ix.IXPeerMacro)
 	orm.UsageAlgorithm = types.StringValue(ix.UsageAlgorithm)
-
-	if ix.PromoCode != "" {
-		orm.PromoCode = types.StringValue(ix.PromoCode)
-	} else {
-		orm.PromoCode = types.StringNull()
-	}
 
 	// Handle dates
 	if ix.CreateDate != nil {
@@ -713,6 +706,7 @@ func (r *ixResource) Update(ctx context.Context, req resource.UpdateRequest, res
 
 	// Update the state with the IX info
 	state.fromAPI(ctx, updatedIX)
+	state.PromoCode = plan.PromoCode
 
 	// Persist the new state
 	diags := resp.State.Set(ctx, &state)

--- a/internal/provider/ix_resource_test.go
+++ b/internal/provider/ix_resource_test.go
@@ -117,7 +117,7 @@ func TestAccMegaportIX_PromoCode(t *testing.T) {
 	locationID, _ := findPortTestLocation(t, 1000)
 	ixName := RandomTestName()
 	portName := RandomTestName()
-	const initialPromo = "tf-acc-test-promo-initial"
+	initialPromo := testPromoCode()
 	const otherPromo = "tf-acc-test-promo-other"
 
 	configFor := func(promoLine string) string {

--- a/internal/provider/ix_resource_test.go
+++ b/internal/provider/ix_resource_test.go
@@ -108,3 +108,64 @@ resource "megaport_ix" "test_ix" {
 		},
 	})
 }
+
+// TestAccMegaportIX_PromoCode exercises promo_code on megaport_ix against
+// the v1.8.0 ordering endpoint. State tracks the config-supplied value.
+func TestAccMegaportIX_PromoCode(t *testing.T) {
+	t.Parallel()
+	defer acquireAccTestSlot(t)()
+	locationID, _ := findPortTestLocation(t, 1000)
+	ixName := RandomTestName()
+	portName := RandomTestName()
+	const initialPromo = "tf-acc-test-promo-initial"
+	const otherPromo = "tf-acc-test-promo-other"
+
+	configFor := func(promoLine string) string {
+		return fmt.Sprintf(`
+resource "megaport_port" "test_port" {
+    product_name           = "%s"
+    location_id            = %d
+    port_speed             = 1000
+    marketplace_visibility = false
+    contract_term_months   = 1
+}
+
+resource "megaport_ix" "test_ix" {
+    product_name          = "%s"
+    requested_product_uid = megaport_port.test_port.product_uid
+    network_service_type  = "Sydney IX"
+    asn                   = 12345
+    mac_address           = "00:CA:FE:BA:BE:01"
+    rate_limit            = 500
+    vlan                  = 2001
+    shutdown              = false
+    %s
+}
+`, portName, locationID, ixName, promoLine)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: configFor(fmt.Sprintf(`promo_code = "%s"`, initialPromo)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_ix.test_ix", "promo_code", initialPromo),
+					resource.TestCheckResourceAttrSet("megaport_ix.test_ix", "product_uid"),
+				),
+			},
+			{
+				Config: configFor(fmt.Sprintf(`promo_code = "%s"`, otherPromo)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_ix.test_ix", "promo_code", otherPromo),
+				),
+			},
+			{
+				Config: configFor(""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("megaport_ix.test_ix", "promo_code"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/lag_port_resource.go
+++ b/internal/provider/lag_port_resource.go
@@ -628,6 +628,7 @@ func (r *lagPortResource) Update(ctx context.Context, req resource.UpdateRequest
 	// Update the state
 	state.fromAPIPort(ctx, port, tags)
 	state.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
+	state.PromoCode = plan.PromoCode
 
 	// Set state to fully populated data
 	diags := resp.State.Set(ctx, &state)

--- a/internal/provider/lag_port_resource_test.go
+++ b/internal/provider/lag_port_resource_test.go
@@ -165,6 +165,58 @@ func TestAccMegaportLAGPort_CostCentreRemoval(t *testing.T) {
 	})
 }
 
+// TestAccMegaportLAGPort_PromoCode exercises promo_code against the v1.8.0
+// ordering endpoint. State tracks the config-supplied value.
+func TestAccMegaportLAGPort_PromoCode(t *testing.T) {
+	t.Parallel()
+	defer acquireAccTestSlot(t)()
+	locationID, _ := findPortTestLocation(t, 10000)
+	portName := RandomTestName()
+	const initialPromo = "tf-acc-test-promo-initial"
+	const otherPromo = "tf-acc-test-promo-other"
+
+	configFor := func(promoLine string) string {
+		return providerConfig + fmt.Sprintf(`
+		data "megaport_location" "test_location" {
+			id = %d
+		}
+		resource "megaport_lag_port" "lag_port" {
+			product_name           = "%s"
+			port_speed             = 10000
+			location_id            = data.megaport_location.test_location.id
+			contract_term_months   = 1
+			marketplace_visibility = false
+			lag_count              = 1
+			%s
+		}`, locationID, portName, promoLine)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: configFor(fmt.Sprintf(`promo_code = "%s"`, initialPromo)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_lag_port.lag_port", "promo_code", initialPromo),
+					resource.TestCheckResourceAttrSet("megaport_lag_port.lag_port", "product_uid"),
+				),
+			},
+			{
+				Config: configFor(fmt.Sprintf(`promo_code = "%s"`, otherPromo)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_lag_port.lag_port", "promo_code", otherPromo),
+				),
+			},
+			{
+				Config: configFor(""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("megaport_lag_port.lag_port", "promo_code"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccMegaportLAGPort_ContractTermUpdate(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()

--- a/internal/provider/lag_port_resource_test.go
+++ b/internal/provider/lag_port_resource_test.go
@@ -172,7 +172,7 @@ func TestAccMegaportLAGPort_PromoCode(t *testing.T) {
 	defer acquireAccTestSlot(t)()
 	locationID, _ := findPortTestLocation(t, 10000)
 	portName := RandomTestName()
-	const initialPromo = "tf-acc-test-promo-initial"
+	initialPromo := testPromoCode()
 	const otherPromo = "tf-acc-test-promo-other"
 
 	configFor := func(promoLine string) string {

--- a/internal/provider/mcr_resource.go
+++ b/internal/provider/mcr_resource.go
@@ -1244,6 +1244,7 @@ func (r *mcrResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	// Update the state with the new values
 	state.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
+	state.PromoCode = plan.PromoCode
 
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/mcr_resource_test.go
+++ b/internal/provider/mcr_resource_test.go
@@ -400,6 +400,56 @@ func TestAccMegaportMCR_CostCentreRemoval(t *testing.T) {
 	})
 }
 
+// TestAccMegaportMCR_PromoCode exercises promo_code against the v1.8.0
+// ordering endpoint. State tracks the config-supplied value.
+func TestAccMegaportMCR_PromoCode(t *testing.T) {
+	t.Parallel()
+	defer acquireAccTestSlot(t)()
+	locationID, _ := findMCRTestLocation(t, 1000)
+	mcrName := RandomTestName()
+	const initialPromo = "tf-acc-test-promo-initial"
+	const otherPromo = "tf-acc-test-promo-other"
+
+	configFor := func(promoLine string) string {
+		return providerConfig + fmt.Sprintf(`
+		data "megaport_location" "test_location" {
+			id = %d
+		}
+		resource "megaport_mcr" "mcr" {
+			product_name         = "%s"
+			port_speed            = 1000
+			location_id          = data.megaport_location.test_location.id
+			contract_term_months = 1
+			%s
+		}`, locationID, mcrName, promoLine)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: configFor(fmt.Sprintf(`promo_code = "%s"`, initialPromo)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_mcr.mcr", "promo_code", initialPromo),
+					resource.TestCheckResourceAttrSet("megaport_mcr.mcr", "product_uid"),
+				),
+			},
+			{
+				Config: configFor(fmt.Sprintf(`promo_code = "%s"`, otherPromo)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_mcr.mcr", "promo_code", otherPromo),
+				),
+			},
+			{
+				Config: configFor(""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("megaport_mcr.mcr", "promo_code"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccMegaportMCR_ContractTermUpdate(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()

--- a/internal/provider/mcr_resource_test.go
+++ b/internal/provider/mcr_resource_test.go
@@ -407,7 +407,7 @@ func TestAccMegaportMCR_PromoCode(t *testing.T) {
 	defer acquireAccTestSlot(t)()
 	locationID, _ := findMCRTestLocation(t, 1000)
 	mcrName := RandomTestName()
-	const initialPromo = "tf-acc-test-promo-initial"
+	initialPromo := testPromoCode()
 	const otherPromo = "tf-acc-test-promo-other"
 
 	configFor := func(promoLine string) string {

--- a/internal/provider/mve_resource.go
+++ b/internal/provider/mve_resource.go
@@ -961,6 +961,7 @@ func (r *mveResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	resp.Diagnostics = append(resp.Diagnostics, apiDiags...)
 
 	state.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
+	state.PromoCode = plan.PromoCode
 
 	diags := resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/mve_resource_test.go
+++ b/internal/provider/mve_resource_test.go
@@ -307,6 +307,82 @@ func TestAccMegaportMVEAruba_CostCentreRemoval(t *testing.T) {
 	})
 }
 
+// TestAccMegaportMVEAruba_PromoCode exercises promo_code on megaport_mve
+// against the v1.8.0 ordering endpoint. State tracks the config-supplied
+// value.
+func TestAccMegaportMVEAruba_PromoCode(t *testing.T) {
+	t.Parallel()
+	defer acquireAccTestSlot(t)()
+	locationID, _ := findMVETestLocation(t, 2)
+	mveName := RandomTestName()
+	mveKey := RandomTestName()
+	const initialPromo = "tf-acc-test-promo-initial"
+	const otherPromo = "tf-acc-test-promo-other"
+
+	configFor := func(promoLine string) string {
+		return providerConfig + fmt.Sprintf(`
+		data "megaport_location" "test_location" {
+			id = %d
+		}
+		data "megaport_mve_images" "aruba" {
+			vendor_filter = "Aruba"
+			id_filter = %d
+		}
+		resource "megaport_mve" "mve" {
+			product_name         = "%s"
+			location_id          = data.megaport_location.test_location.id
+			contract_term_months = 1
+			%s
+			vendor_config = {
+				vendor       = "aruba"
+				product_size = "SMALL"
+				mve_label    = "MVE 2/8"
+				image_id     = data.megaport_mve_images.aruba.mve_images.0.id
+				account_name = "%s"
+				account_key  = "%s"
+				system_tag   = "Preconfiguration-aruba-test-1"
+			}
+			vnics = [{
+				description = "Data Plane"
+			},
+			{
+				description = "Control Plane"
+			},
+			{
+				description = "Management Plane"
+			},
+			{
+				description = "Extra Plane"
+			}]
+		}`, locationID, MVEArubaImageIDMVE, mveName, promoLine, mveName, mveKey)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: configFor(fmt.Sprintf(`promo_code = "%s"`, initialPromo)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_mve.mve", "promo_code", initialPromo),
+					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_uid"),
+				),
+			},
+			{
+				Config: configFor(fmt.Sprintf(`promo_code = "%s"`, otherPromo)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_mve.mve", "promo_code", otherPromo),
+				),
+			},
+			{
+				Config: configFor(""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("megaport_mve.mve", "promo_code"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccMegaportMVEAruba_ContractTermUpdate(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()

--- a/internal/provider/mve_resource_test.go
+++ b/internal/provider/mve_resource_test.go
@@ -316,7 +316,7 @@ func TestAccMegaportMVEAruba_PromoCode(t *testing.T) {
 	locationID, _ := findMVETestLocation(t, 2)
 	mveName := RandomTestName()
 	mveKey := RandomTestName()
-	const initialPromo = "tf-acc-test-promo-initial"
+	initialPromo := testPromoCode()
 	const otherPromo = "tf-acc-test-promo-other"
 
 	configFor := func(promoLine string) string {

--- a/internal/provider/single_port_resource.go
+++ b/internal/provider/single_port_resource.go
@@ -598,6 +598,7 @@ func (r *portResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	// Update the state
 	state.fromAPIPort(ctx, port, tags)
 	state.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
+	state.PromoCode = plan.PromoCode
 
 	// Set state to fully populated data
 	diags := resp.State.Set(ctx, &state)

--- a/internal/provider/single_port_resource_test.go
+++ b/internal/provider/single_port_resource_test.go
@@ -163,6 +163,59 @@ func TestAccMegaportSinglePort_CostCentreRemoval(t *testing.T) {
 	})
 }
 
+// TestAccMegaportSinglePort_PromoCode exercises the promo_code attribute
+// against the v1.8.0 ordering endpoint. promo_code is sent to the API at
+// create time and stored in state as the user-supplied value; the Megaport
+// API does not round-trip it, so state simply tracks config.
+func TestAccMegaportSinglePort_PromoCode(t *testing.T) {
+	t.Parallel()
+	defer acquireAccTestSlot(t)()
+	locationID, _ := findPortTestLocation(t, 1000)
+	portName := RandomTestName()
+	const initialPromo = "tf-acc-test-promo-initial"
+	const otherPromo = "tf-acc-test-promo-other"
+
+	configFor := func(promoLine string) string {
+		return providerConfig + fmt.Sprintf(`
+		data "megaport_location" "test_location" {
+			id = %d
+		}
+		resource "megaport_port" "port" {
+			product_name           = "%s"
+			port_speed             = 1000
+			location_id            = data.megaport_location.test_location.id
+			contract_term_months   = 1
+			marketplace_visibility = false
+			%s
+		}`, locationID, portName, promoLine)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: configFor(fmt.Sprintf(`promo_code = "%s"`, initialPromo)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_port.port", "promo_code", initialPromo),
+					resource.TestCheckResourceAttrSet("megaport_port.port", "product_uid"),
+				),
+			},
+			{
+				Config: configFor(fmt.Sprintf(`promo_code = "%s"`, otherPromo)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_port.port", "promo_code", otherPromo),
+				),
+			},
+			{
+				Config: configFor(""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("megaport_port.port", "promo_code"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccMegaportSinglePort_ContractTermUpdate(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()

--- a/internal/provider/single_port_resource_test.go
+++ b/internal/provider/single_port_resource_test.go
@@ -172,7 +172,7 @@ func TestAccMegaportSinglePort_PromoCode(t *testing.T) {
 	defer acquireAccTestSlot(t)()
 	locationID, _ := findPortTestLocation(t, 1000)
 	portName := RandomTestName()
-	const initialPromo = "tf-acc-test-promo-initial"
+	initialPromo := testPromoCode()
 	const otherPromo = "tf-acc-test-promo-other"
 
 	configFor := func(promoLine string) string {

--- a/internal/provider/test_helpers_test.go
+++ b/internal/provider/test_helpers_test.go
@@ -1265,3 +1265,18 @@ func TestCleanupOrphanedResources(t *testing.T) {
 	t.Logf("orphaned test resources (live): %d VXC, %d MVE, %d MCR, %d Port", vxcLive, mveLive, mcrLive, portLive)
 	t.Skip("cleanup scan complete")
 }
+
+// testPromoCode returns the promo code string to use in promo_code acceptance
+// tests. Set MEGAPORT_TEST_PROMO_CODE to a live staging code to verify the
+// code is persisted on the billing record (j_billable.promocode_id). When
+// unset, tests use a placeholder — the staging API accepts unknown codes
+// silently, so tests still exercise the provider contract but skip backend
+// verification. Staging promo codes are short-lived (daily DB refresh), so
+// hardcoding a real code would cause the tests to silently stop verifying
+// anything real.
+func testPromoCode() string {
+	if v := os.Getenv("MEGAPORT_TEST_PROMO_CODE"); v != "" {
+		return v
+	}
+	return "tf-acc-test-promo-initial"
+}

--- a/internal/provider/vxc_resource.go
+++ b/internal/provider/vxc_resource.go
@@ -2389,6 +2389,7 @@ func (r *vxcResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	// In Update, pass plan to preserve user-only configuration values
 	apiDiags := state.fromAPIVXC(ctx, vxc, tags, &plan)
 	state.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
+	state.PromoCode = plan.PromoCode
 	resp.Diagnostics.Append(apiDiags...)
 
 	// Set refreshed state

--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -436,6 +436,81 @@ func TestAccMegaportVXC_CostCentreRemoval(t *testing.T) {
 	})
 }
 
+// TestAccMegaportVXC_PromoCode exercises promo_code on megaport_vxc against
+// the v1.8.0 ordering endpoint. State tracks the config-supplied value.
+func TestAccMegaportVXC_PromoCode(t *testing.T) {
+	t.Parallel()
+	defer acquireAccTestSlot(t)()
+	locs := findVXCPortTestLocations(t, 1)
+	portName1 := RandomTestName()
+	portName2 := RandomTestName()
+	vxcName := RandomTestName()
+	const initialPromo = "tf-acc-test-promo-initial"
+	const otherPromo = "tf-acc-test-promo-other"
+
+	configFor := func(promoLine string) string {
+		return providerConfig + fmt.Sprintf(`
+		data "megaport_location" "loc" {
+			id = %d
+		}
+		resource "megaport_port" "port_1" {
+			product_name           = "%s"
+			port_speed             = 1000
+			location_id            = data.megaport_location.loc.id
+			contract_term_months   = 1
+			marketplace_visibility = false
+		}
+		resource "megaport_port" "port_2" {
+			product_name           = "%s"
+			port_speed             = 1000
+			location_id            = data.megaport_location.loc.id
+			contract_term_months   = 1
+			marketplace_visibility = false
+		}
+		resource "megaport_vxc" "vxc" {
+			product_name         = "%s"
+			rate_limit           = 200
+			contract_term_months = 1
+			%s
+			a_end = {
+				requested_product_uid = megaport_port.port_1.product_uid
+				ordered_vlan          = 100
+				inner_vlan            = 300
+			}
+			b_end = {
+				requested_product_uid = megaport_port.port_2.product_uid
+				ordered_vlan          = 101
+				inner_vlan            = 301
+			}
+		}`, locs[0], portName1, portName2, vxcName, promoLine)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: configFor(fmt.Sprintf(`promo_code = "%s"`, initialPromo)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_vxc.vxc", "promo_code", initialPromo),
+					resource.TestCheckResourceAttrSet("megaport_vxc.vxc", "product_uid"),
+				),
+			},
+			{
+				Config: configFor(fmt.Sprintf(`promo_code = "%s"`, otherPromo)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_vxc.vxc", "promo_code", otherPromo),
+				),
+			},
+			{
+				Config: configFor(""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("megaport_vxc.vxc", "promo_code"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccMegaportVXC_ContractTermUpdate(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()

--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -445,7 +445,7 @@ func TestAccMegaportVXC_PromoCode(t *testing.T) {
 	portName1 := RandomTestName()
 	portName2 := RandomTestName()
 	vxcName := RandomTestName()
-	const initialPromo = "tf-acc-test-promo-initial"
+	initialPromo := testPromoCode()
 	const otherPromo = "tf-acc-test-promo-other"
 
 	configFor := func(promoLine string) string {


### PR DESCRIPTION
### User-Facing Summary

Fixes `Provider produced inconsistent result after apply` errors on `promo_code` across `megaport_port`, `megaport_lag_port`, `megaport_mcr`, `megaport_mve`, `megaport_ix`, and `megaport_vxc`. State now tracks the config-supplied `promo_code` on create, update, and removal — users can add, change, or clear `promo_code` without provider errors, matching the behaviour reporters expect.

Note: the Megaport API does not round-trip `promo_code` on an existing service, so a promo code is only ever acted on at order time. Changing `promo_code` on an existing resource updates Terraform state but has no effect on the backend service.

Depends on the `megaportgo` v1.8.0 changes that moved the provider onto the `/v4/networkdesign/buy` product-ordering endpoint (bumped in `go.mod` as part of this PR).


---

### Type of Change

- [ ] 🚀 New Feature
- [ ] ✨ Enhancement
- [x] 🐛 Bug Fix
- [ ] 📚 Documentation Update
- [ ] 🏗️ Chore / Other

---

### Related Issues

Resolves https://github.com/megaport/terraform-provider-megaport/issues/362

---

### How to Test

Automated (acceptance tests, all passing against staging):

```
TF_ACC=1 go test -v -timeout=30m \
  -run 'TestAccMegaport(SinglePort|MCR|LAGPort|IX|MVEAruba|VXC)_PromoCode' \
  ./internal/provider/
```

Each test exercises three lifecycle steps:

1. Create with `promo_code` set.
2. Update the `promo_code` value.
3. Remove the `promo_code` attribute from config.

State is asserted to match config at every step. No `inconsistent result after apply` errors are produced.

#### Optional: backend verification with a real staging code

Staging promo codes are wiped by the daily DB refresh, so the tests use a placeholder by default (`tf-acc-test-promo-initial`) — the staging API silently accepts unknown codes, so the provider contract is still exercised end-to-end. To additionally verify `j_billable.promocode_id` is populated on the billing record, create a fresh staging code in the admin portal and pass it via `MEGAPORT_TEST_PROMO_CODE`:

```
MEGAPORT_TEST_PROMO_CODE=your-fresh-staging-code \
TF_ACC=1 go test -v -run TestAccMegaportSinglePort_PromoCode ./internal/provider/
```

Then query `megadb` with the SQL above using the resulting `product_uid`.

Manual reproduction of the reported scenario (issue #362):

1. Apply a config with `promo_code = "some-promo"` on a port/MCR/etc.
2. Change to `promo_code = ""` (or remove the attribute) and re-apply.
3. Previously: `Provider produced inconsistent result after apply`. Now: clean apply, state updates to match config.