### PR TITLE
ci: harden GitHub Actions workflows (SHA pins + Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,12 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # Wait for releases to bake before opening bump PRs — mitigates the
+    # window where a freshly-pushed (potentially compromised) version is
+    # picked up automatically.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -19,3 +25,10 @@ updates:
       # Major bumps land as deliberate human decisions; minor/patch only.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    # Same rationale as gomod above — delay adoption of fresh action
+    # releases (incl. SHA-pinned bumps) so a compromised tag has time to
+    # be flagged by the wider community before we pick it up. Note: the
+    # github-actions ecosystem only supports `default-days` (semver-*-days
+    # keys are gomod/npm/etc. only); majors are already ignored above.
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    ignore:
+      # Major bumps land as deliberate human decisions; minor/patch only.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,22 +17,22 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           # Allow goreleaser to access older tag information.
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
           go-version-file: 'go.mod'
           cache: true
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec  # v6.3.0
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811  # v5.1.0
         with:
           args: release --clean
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,15 +24,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
           go-version-file: 'go.mod'
           cache: true
       - run: go mod download
       - run: go build -v .
       - name: Run linters
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8.0.0
         with:
           version: 'v2.3.1' # Use golangci-lint v2 to match config version
           args: --timeout=10m
@@ -43,7 +43,7 @@ jobs:
       # Retry once if it fails
       - name: Run linters (retry)
         if: steps.lint.outcome == 'failure'
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8.0.0
         with:
           version: 'v2.3.1' # Use golangci-lint v2 to match config version
           args: --timeout=10m
@@ -53,8 +53,8 @@ jobs:
     name: Generate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -77,8 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -96,8 +96,8 @@ jobs:
         tofu-version:
           - '1.6.0' # Latest stable OpenTofu version
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
           go-version-file: 'go.mod'
           cache: true


### PR DESCRIPTION
## Summary

Hardens both CI workflows (`test.yaml`, `release.yaml`) against the GitHub Actions script-injection / token-theft class actively exploited in 2025 (HackerBot Claw; same class discussed alongside CVE-2026-3854).

- **SHA-pin all third-party actions** (with version comment) instead of mutable major-version tags. Mutable `@v5`/`@v6` references can be silently re-pointed by a compromised maintainer — a high-value target on the **release workflow**, which holds `GPG_PRIVATE_KEY` and `PASSPHRASE`.
  - `test.yaml`: `actions/checkout` v4.3.1, `actions/setup-go` v5.6.0, `golangci/golangci-lint-action` v8.0.0
  - `release.yaml`: `actions/checkout` v4.3.1, `actions/setup-go` v5.6.0, `crazy-max/ghaction-import-gpg` v6.3.0, `goreleaser/goreleaser-action` v5.1.0
  - `hashicorp/setup-terraform` was already SHA-pinned — no change.
- **Add `.github/dependabot.yml`** covering both `gomod` and `github-actions` ecosystems so SHA bumps land as reviewable weekly PRs, grouped, minor/patch only (major bumps stay human decisions). The repo had no Dependabot config before.
- **Cooldown on bump PRs** (`default-days: 7`, plus `semver-major-days: 14` on gomod). Delays adoption of newly-tagged versions so a compromised release has time to be flagged by the wider community before it gets picked up automatically. Complements the SHA pinning above: SHA pins make refs immutable; cooldown adds a delay before adopting any new SHA at all.

## What this does *not* change

- No workflow logic, no permissions changes (test.yaml already had `contents: read`; release.yaml needs `contents: write` for asset upload).
- Same Go version, same lint config, same goreleaser invocation.

## Threat-model context

The repo's `pull_request` workflows do not use `pull_request_target` and do not unwrap PR-controlled strings (title/body/branch) into `run:` blocks, so there were no live injection findings. This PR closes the surrounding hardening gap on the privileged tag-triggered release pipeline.

| Gap | Before | After |
|---|---|---|
| Action references (test) | `@v4`/`@v5`/`@v8` | `@<sha>  # v...` |
| Action references (release) | `@v4`/`@v5`/`@v6` | `@<sha>  # v...` |
| Action update visibility | none | weekly grouped Dependabot PRs |
| Dependabot coverage | none | gomod + github-actions |
| Bump-PR cooldown | none | 7d default / 14d gomod major |

## Org-policy interaction (blocks CI until paired change lands)

The org's `allowed_actions.tf` (in `megaport/github-iac`) uses `selected` actions with literal `@vN` patterns plus `verified_allowed = true` and `github_owned_allowed = true`. SHA refs satisfy the verified/GitHub-owned paths automatically (empirically: `hashicorp/setup-terraform` is already SHA-pinned on `main` without a pattern entry and CI passes), but **two of the third-party actions pinned in this PR are *not* verified creators on Marketplace** — `golangci/golangci-lint-action` and `crazy-max/ghaction-import-gpg`. They currently flow through literal `@v8`/`@v6` pattern entries, which a SHA won't fnmatch.

Companion PR: megaport/github-iac#115 — adds the two SHA entries (`golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9`, `crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec`) to `patterns_allowed` in `megaport/github-iac`. Until that lands, this PR's CI will sit in `startup_failure` from the actions-policy admission.

## Test plan

- [ ] Companion `megaport/github-iac` PR adding the two SHA entries lands first
- [ ] CI passes (build, generate, unit tests, OpenTofu compatibility) on this PR
- [ ] After merge: confirm Dependabot opens the first `github-actions` group PR within a week
- [ ] Next tagged release runs cleanly (no behaviour change in pinned action versions)

