### PR TITLE
chore: add @juzsal as a codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @megaport/esd-go-reviewers
+* @megaport/esd-go-reviewers @juzsal


### PR DESCRIPTION
Adds `@juzsal` alongside `@megaport/esd-go-reviewers` on the wildcard rule in `.github/CODEOWNERS`, so they will be requested as a reviewer on all PRs in this repo.

## Test plan
- [ ] GitHub recognises the updated CODEOWNERS file (no syntax warnings on the PR)
- [ ] `@juzsal` is auto-requested for review on subsequent PRs