### PR TITLE
ci: group gomod Dependabot updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      gomod:
+        patterns:
+          - "*"
     # Wait for releases to bake before opening bump PRs — mitigates the
     # window where a freshly-pushed (potentially compromised) version is
     # picked up automatically.


### PR DESCRIPTION
## Summary
- Add a `groups` block to the `gomod` Dependabot ecosystem so weekly Go module bumps land as a single consolidated PR instead of one PR per dependency.
- Mirrors the existing pattern already used for the `github-actions` ecosystem in this file.
- Cooldown windows (7 days default / 14 days semver-major) are unchanged, so the supply-chain bake-in still applies.

## Test plan
- [ ] Wait for Dependabot's next scheduled run and confirm gomod bumps arrive as one grouped PR rather than several.