### PR TITLE
ESD-1183: Remove Terminate Later option for Ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,29 +577,11 @@ data "megaport_partner" "awshc" {
 }
 ```
 
-## End-of-Term Cancellation
+## Resource Cancellation
 
-By default, when Terraform deletes resources, they are immediately cancelled in the Megaport portal. However, you may prefer to have resources marked for cancellation at the end of their current billing term instead of immediate cancellation.
+When Terraform deletes a Megaport resource, the provider issues an immediate cancellation (`CANCEL_NOW`) to the Megaport API. Resources are removed from Terraform state as soon as the API call returns successfully.
 
-The provider supports this with the `cancel_at_end_of_term` configuration option:
-
-```terraform
-provider "megaport" {
-  environment           = "production"
-  access_key            = "your-access-key"
-  secret_key            = "your-secret-key"
-  accept_purchase_terms = true
-  cancel_at_end_of_term = true  # Mark resources for end-of-term cancellation
-}
-```
-
-**Important notes:**
-
-- This feature is currently only supported for Single Ports and LAG Ports
-- For other resource types, the option will be ignored and immediate cancellation will occur
-- When `cancel_at_end_of_term` is set to `true`, resources will show as "CANCELLING" in the Megaport portal until the end of their billing term
-- Resources are removed from Terraform state as soon as the API call returns successfully, regardless of whether immediate or end-of-term cancellation is used
-- If you reapply your configuration after a resource has been deleted, Terraform will create a new resource, even if the original resource is still visible in the Megaport portal with "CANCELLING" status
+Delayed cancellation (cancel-at-end-of-term) is not supported by the provider. The previously available `cancel_at_end_of_term` provider option has been removed because the Megaport API no longer accepts delayed cancellation for Ports or LAG Ports.
 
 ## Importing Existing Resources
 

--- a/README.md
+++ b/README.md
@@ -583,6 +583,8 @@ When Terraform deletes a Megaport resource, the provider issues an immediate can
 
 Delayed cancellation (cancel-at-end-of-term) is not supported by the provider. The previously available `cancel_at_end_of_term` provider option has been removed because the Megaport API no longer accepts delayed cancellation for Ports or LAG Ports.
 
+**Upgrade note:** If your existing Terraform configuration still sets `cancel_at_end_of_term` in the `provider "megaport"` block, Terraform will report it as an unsupported provider argument. Remove that setting before planning or applying with this version.
+
 ## Importing Existing Resources
 
 When importing existing Megaport resources into Terraform, you may notice that certain computed fields appear to change from "unknown" to their actual values on the first `terraform apply` after import. **This is expected behavior and not actual configuration drift.**

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ data "megaport_partner" "awshc" {
 
 ## Resource Cancellation
 
-When Terraform deletes a Megaport resource, the provider issues an immediate cancellation (`CANCEL_NOW`) to the Megaport API. Resources are removed from Terraform state as soon as the API call returns successfully.
+When Terraform deletes a Megaport resource, the provider issues an immediate cancellation or deletion request to the Megaport API. Resources are removed from Terraform state as soon as the API call returns successfully. For Ports and LAG Ports specifically, this is always a `CANCEL_NOW` action against the Megaport Products API.
 
 Delayed cancellation (cancel-at-end-of-term) is not supported by the provider. The previously available `cancel_at_end_of_term` provider option has been removed because the Megaport API no longer accepts delayed cancellation for Ports or LAG Ports.
 

--- a/README.md
+++ b/README.md
@@ -583,6 +583,8 @@ When Terraform deletes a Megaport resource, the provider issues an immediate can
 
 Delayed cancellation (cancel-at-end-of-term) is not supported by the provider. The previously available `cancel_at_end_of_term` provider option has been removed because the Megaport API no longer accepts delayed cancellation for Ports or LAG Ports.
 
+**Billing impact:** Cancelling a Megaport resource before the end of its committed minimum term may incur early termination charges. Review your contract terms before destroying resources, especially in production.
+
 **Upgrade note:** If your existing Terraform configuration still sets `cancel_at_end_of_term` in the `provider "megaport"` block, Terraform will report it as an unsupported provider argument. Remove that setting before planning or applying with this version.
 
 ## Importing Existing Resources

--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ When Terraform deletes a Megaport resource, the provider issues an immediate can
 
 Delayed cancellation (cancel-at-end-of-term) is not supported by the provider. The previously available `cancel_at_end_of_term` provider option has been removed because the Megaport API no longer accepts delayed cancellation for Ports or LAG Ports.
 
-**Billing impact:** Cancelling a Megaport resource before the end of its committed minimum term may incur early termination charges. Review your contract terms before destroying resources, especially in production.
+**Billing impact:** Cancelling a Megaport resource before the end of its committed minimum term may incur early termination charges. Review your contract terms before destroying resources in production.
 
 **Upgrade note:** If your existing Terraform configuration still sets `cancel_at_end_of_term` in the `provider "megaport"` block, Terraform will report it as an unsupported provider argument. Remove that setting before planning or applying with this version.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -628,26 +628,8 @@ Example plan output:
 4. Run `terraform apply` to update the state
 5. Run `terraform plan` again - should show no changes
 
-## End-of-Term Cancellation
+## Resource Cancellation
 
-By default, when Terraform deletes resources, they are immediately cancelled in the Megaport portal. However, you may prefer to have resources marked for cancellation at the end of their current billing term instead of immediate cancellation.
+When Terraform deletes a Megaport resource, the provider issues an immediate cancellation (`CANCEL_NOW`) to the Megaport API. Resources are removed from Terraform state as soon as the API call returns successfully.
 
-The provider supports this with the `cancel_at_end_of_term` configuration option:
-
-```terraform
-provider "megaport" {
-  environment           = "production"
-  access_key            = "your-access-key"
-  secret_key            = "your-secret-key"
-  accept_purchase_terms = true
-  cancel_at_end_of_term = true  # Mark resources for end-of-term cancellation
-}
-```
-
-**Important notes:**
-
-- This feature is currently only supported for Single Ports and LAG Ports
-- For other resource types, the option will be ignored and immediate cancellation will occur
-- When `cancel_at_end_of_term` is set to `true`, resources will show as "CANCELLING" in the Megaport portal until the end of their billing term
-- Resources are removed from Terraform state as soon as the API call returns successfully, regardless of whether immediate or end-of-term cancellation is used
-- If you reapply your configuration after a resource has been deleted, Terraform will create a new resource, even if the original resource is still visible in the Megaport portal with "CANCELLING" status
+Delayed cancellation (cancel-at-end-of-term) is not supported by the provider. The previously available `cancel_at_end_of_term` provider option has been removed because the Megaport API no longer accepts delayed cancellation for Ports or LAG Ports.

--- a/docs/index.md
+++ b/docs/index.md
@@ -634,4 +634,6 @@ When Terraform deletes a Megaport resource, the provider issues an immediate can
 
 Delayed cancellation (cancel-at-end-of-term) is not supported by the provider. The previously available `cancel_at_end_of_term` provider option has been removed because the Megaport API no longer accepts delayed cancellation for Ports or LAG Ports.
 
+**Billing impact:** Cancelling a Megaport resource before the end of its committed minimum term may incur early termination charges. Review your contract terms before destroying resources, especially in production.
+
 **Upgrade note:** If your existing Terraform configuration still sets `cancel_at_end_of_term` in the `provider "megaport"` block, Terraform will report it as an unsupported provider argument. Remove that setting before planning or applying with this version.

--- a/docs/index.md
+++ b/docs/index.md
@@ -633,3 +633,5 @@ Example plan output:
 When Terraform deletes a Megaport resource, the provider issues an immediate cancellation or deletion request to the Megaport API. Resources are removed from Terraform state as soon as the API call returns successfully. For Ports and LAG Ports specifically, this is always a `CANCEL_NOW` action against the Megaport Products API.
 
 Delayed cancellation (cancel-at-end-of-term) is not supported by the provider. The previously available `cancel_at_end_of_term` provider option has been removed because the Megaport API no longer accepts delayed cancellation for Ports or LAG Ports.
+
+**Upgrade note:** If your existing Terraform configuration still sets `cancel_at_end_of_term` in the `provider "megaport"` block, Terraform will report it as an unsupported provider argument. Remove that setting before planning or applying with this version.

--- a/docs/index.md
+++ b/docs/index.md
@@ -630,6 +630,6 @@ Example plan output:
 
 ## Resource Cancellation
 
-When Terraform deletes a Megaport resource, the provider issues an immediate cancellation (`CANCEL_NOW`) to the Megaport API. Resources are removed from Terraform state as soon as the API call returns successfully.
+When Terraform deletes a Megaport resource, the provider issues an immediate cancellation or deletion request to the Megaport API. Resources are removed from Terraform state as soon as the API call returns successfully. For Ports and LAG Ports specifically, this is always a `CANCEL_NOW` action against the Megaport Products API.
 
 Delayed cancellation (cancel-at-end-of-term) is not supported by the provider. The previously available `cancel_at_end_of_term` provider option has been removed because the Megaport API no longer accepts delayed cancellation for Ports or LAG Ports.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
-	github.com/megaport/megaportgo v1.10.3
+	github.com/megaport/megaportgo v1.11.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/megaport/megaportgo v1.10.3 h1:/VfzT7faS4QQrGBqDF6+SxBYy4RNKBMcvTVokDRIHbo=
-github.com/megaport/megaportgo v1.10.3/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
+github.com/megaport/megaportgo v1.11.0 h1:cSfopzOQLs3yWlLmSPZYGDNE7IErZD7wWEb92IFccDs=
+github.com/megaport/megaportgo v1.11.0/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=

--- a/internal/provider/lag_port_resource.go
+++ b/internal/provider/lag_port_resource.go
@@ -649,7 +649,7 @@ func (r *lagPortResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	// Delete existing order. LAG ports only support immediate cancellation
 	// (CANCEL_NOW); delayed cancellation was removed in megaportgo and the
-	// API now rejects DeleteNow=false for ports.
+	// API now rejects DeleteNow=false for LAG ports.
 	err := retryTransientDelete(ctx, 3, func() error {
 		_, deleteErr := r.client.PortService.DeletePort(ctx, &megaport.DeletePortRequest{
 			PortID:     state.UID.ValueString(),

--- a/internal/provider/lag_port_resource.go
+++ b/internal/provider/lag_port_resource.go
@@ -146,8 +146,7 @@ func NewLagPortResource() resource.Resource {
 
 // lagPortResource is the resource implementation.
 type lagPortResource struct {
-	client            *megaport.Client
-	cancelAtEndOfTerm bool
+	client *megaport.Client
 }
 
 // Metadata returns the resource type name.
@@ -648,11 +647,13 @@ func (r *lagPortResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	// Delete existing order
+	// Delete existing order. LAG ports only support immediate cancellation
+	// (CANCEL_NOW); delayed cancellation was removed in megaportgo and the
+	// API now rejects DeleteNow=false for ports.
 	err := retryTransientDelete(ctx, 3, func() error {
 		_, deleteErr := r.client.PortService.DeletePort(ctx, &megaport.DeletePortRequest{
 			PortID:     state.UID.ValueString(),
-			DeleteNow:  !r.cancelAtEndOfTerm,
+			DeleteNow:  true,
 			SafeDelete: true,
 		})
 		return deleteErr
@@ -682,11 +683,7 @@ func (r *lagPortResource) Configure(_ context.Context, req resource.ConfigureReq
 		return
 	}
 
-	client := data.client
-
-	r.client = client
-	r.cancelAtEndOfTerm = data.cancelAtEndOfTerm
-
+	r.client = data.client
 }
 
 func (r *lagPortResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/port_resource_delete_test.go
+++ b/internal/provider/port_resource_delete_test.go
@@ -23,9 +23,11 @@ func TestPortDeleteAlwaysUsesCancelNow(t *testing.T) {
 
 	const portUID = "test-port-uid"
 
-	var receivedPath string
+	// Buffered channel synchronises the handler goroutine's write of the
+	// observed path with the test goroutine's read — safe under -race.
+	pathCh := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		receivedPath = r.URL.Path
+		pathCh <- r.URL.Path
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"message":"ok","data":{}}`))
 	}))
@@ -46,6 +48,13 @@ func TestPortDeleteAlwaysUsesCancelNow(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("DeletePort returned error: %v", err)
+	}
+
+	var receivedPath string
+	select {
+	case receivedPath = <-pathCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("DeletePort handler was not invoked within timeout")
 	}
 
 	wantPath := "/v3/product/" + portUID + "/action/CANCEL_NOW"

--- a/internal/provider/port_resource_delete_test.go
+++ b/internal/provider/port_resource_delete_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	megaport "github.com/megaport/megaportgo"
+)
+
+// TestPortDeleteAlwaysUsesCancelNow asserts that the SDK contract used by
+// both the Single Port and LAG Port resource Delete methods — calling
+// DeletePort with DeleteNow=true — results in a CANCEL_NOW action against
+// the products API. Delayed cancellation (CANCEL) was removed for ports in
+// megaportgo PR #155, and the provider must never issue it.
+func TestPortDeleteAlwaysUsesCancelNow(t *testing.T) {
+	t.Parallel()
+
+	const portUID = "test-port-uid"
+
+	var receivedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"ok","data":{}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := megaport.New(nil,
+		megaport.WithBaseURL(server.URL),
+		megaport.WithAccessToken("test-token", time.Now().Add(time.Hour)),
+	)
+	if err != nil {
+		t.Fatalf("megaport.New: %v", err)
+	}
+
+	_, err = client.PortService.DeletePort(context.Background(), &megaport.DeletePortRequest{
+		PortID:     portUID,
+		DeleteNow:  true,
+		SafeDelete: true,
+	})
+	if err != nil {
+		t.Fatalf("DeletePort returned error: %v", err)
+	}
+
+	wantPath := "/v3/product/" + portUID + "/action/CANCEL_NOW"
+	if receivedPath != wantPath {
+		t.Fatalf("DeletePort hit unexpected path: got %q want %q", receivedPath, wantPath)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -27,12 +27,11 @@ var waitForTime time.Duration
 
 // megaportProviderModel maps provider schema data to a Go type.
 type megaportProviderModel struct {
-	Environment       types.String `tfsdk:"environment"`
-	AccessKey         types.String `tfsdk:"access_key"`
-	SecretKey         types.String `tfsdk:"secret_key"`
-	TermsAccepted     types.Bool   `tfsdk:"accept_purchase_terms"`
-	WaitTime          types.Int64  `tfsdk:"wait_time"`
-	CancelAtEndOfTerm types.Bool   `tfsdk:"cancel_at_end_of_term"`
+	Environment   types.String `tfsdk:"environment"`
+	AccessKey     types.String `tfsdk:"access_key"`
+	SecretKey     types.String `tfsdk:"secret_key"`
+	TermsAccepted types.Bool   `tfsdk:"accept_purchase_terms"`
+	WaitTime      types.Int64  `tfsdk:"wait_time"`
 }
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -58,8 +57,7 @@ type megaportProvider struct {
 }
 
 type megaportProviderData struct {
-	client            *megaport.Client
-	cancelAtEndOfTerm bool
+	client *megaport.Client
 }
 
 // Metadata returns the provider type name.
@@ -97,10 +95,6 @@ func (p *megaportProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 				},
-			},
-			"cancel_at_end_of_term": schema.BoolAttribute{
-				Optional:    true,
-				Description: "When true, resources will be marked for cancellation at the end of their billing term rather than immediately. Default is false (immediate cancellation). Please note that this is only applicable to resources that support cancellation at the end of the term, which is currently only the case for Single Ports and LAG Ports. For other resources, this attribute will be ignored.",
 			},
 		},
 	}
@@ -190,11 +184,6 @@ func (p *megaportProvider) Configure(ctx context.Context, req provider.Configure
 
 	if !config.WaitTime.IsNull() {
 		waitTime = int(config.WaitTime.ValueInt64())
-	}
-
-	cancelAtEndOfTerm := false
-	if !config.CancelAtEndOfTerm.IsNull() {
-		cancelAtEndOfTerm = config.CancelAtEndOfTerm.ValueBool()
 	}
 
 	ctx = tflog.SetField(ctx, "environment", environment)
@@ -297,8 +286,7 @@ func (p *megaportProvider) Configure(ctx context.Context, req provider.Configure
 	// Make the Megaport client available during DataSource and Resource
 	// type Configure methods.
 	providerData := &megaportProviderData{
-		client:            megaportClient,
-		cancelAtEndOfTerm: cancelAtEndOfTerm,
+		client: megaportClient,
 	}
 
 	resp.DataSourceData = providerData

--- a/internal/provider/single_port_resource.go
+++ b/internal/provider/single_port_resource.go
@@ -157,8 +157,7 @@ func NewPortResource() resource.Resource {
 
 // portResource is the resource implementation.
 type portResource struct {
-	client            *megaport.Client
-	cancelAtEndOfTerm bool
+	client *megaport.Client
 }
 
 // Metadata returns the resource type name.
@@ -619,11 +618,13 @@ func (r *portResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	// Delete existing order
+	// Delete existing order. Ports only support immediate cancellation
+	// (CANCEL_NOW); delayed cancellation was removed in megaportgo and the
+	// API now rejects DeleteNow=false for ports.
 	err := retryTransientDelete(ctx, 3, func() error {
 		_, deleteErr := r.client.PortService.DeletePort(ctx, &megaport.DeletePortRequest{
 			PortID:     state.UID.ValueString(),
-			DeleteNow:  !r.cancelAtEndOfTerm,
+			DeleteNow:  true,
 			SafeDelete: true,
 		})
 		return deleteErr
@@ -653,10 +654,7 @@ func (r *portResource) Configure(_ context.Context, req resource.ConfigureReques
 		return
 	}
 
-	client := data.client
-
-	r.client = client
-	r.cancelAtEndOfTerm = data.cancelAtEndOfTerm
+	r.client = data.client
 }
 
 func (r *portResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -628,26 +628,8 @@ Example plan output:
 4. Run `terraform apply` to update the state
 5. Run `terraform plan` again - should show no changes
 
-## End-of-Term Cancellation
+## Resource Cancellation
 
-By default, when Terraform deletes resources, they are immediately cancelled in the Megaport portal. However, you may prefer to have resources marked for cancellation at the end of their current billing term instead of immediate cancellation.
+When Terraform deletes a Megaport resource, the provider issues an immediate cancellation (`CANCEL_NOW`) to the Megaport API. Resources are removed from Terraform state as soon as the API call returns successfully.
 
-The provider supports this with the `cancel_at_end_of_term` configuration option:
-
-```terraform
-provider "megaport" {
-  environment           = "production"
-  access_key            = "your-access-key"
-  secret_key            = "your-secret-key"
-  accept_purchase_terms = true
-  cancel_at_end_of_term = true  # Mark resources for end-of-term cancellation
-}
-```
-
-**Important notes:**
-
-- This feature is currently only supported for Single Ports and LAG Ports
-- For other resource types, the option will be ignored and immediate cancellation will occur
-- When `cancel_at_end_of_term` is set to `true`, resources will show as "CANCELLING" in the Megaport portal until the end of their billing term
-- Resources are removed from Terraform state as soon as the API call returns successfully, regardless of whether immediate or end-of-term cancellation is used
-- If you reapply your configuration after a resource has been deleted, Terraform will create a new resource, even if the original resource is still visible in the Megaport portal with "CANCELLING" status
+Delayed cancellation (cancel-at-end-of-term) is not supported by the provider. The previously available `cancel_at_end_of_term` provider option has been removed because the Megaport API no longer accepts delayed cancellation for Ports or LAG Ports.

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -634,4 +634,6 @@ When Terraform deletes a Megaport resource, the provider issues an immediate can
 
 Delayed cancellation (cancel-at-end-of-term) is not supported by the provider. The previously available `cancel_at_end_of_term` provider option has been removed because the Megaport API no longer accepts delayed cancellation for Ports or LAG Ports.
 
+**Billing impact:** Cancelling a Megaport resource before the end of its committed minimum term may incur early termination charges. Review your contract terms before destroying resources, especially in production.
+
 **Upgrade note:** If your existing Terraform configuration still sets `cancel_at_end_of_term` in the `provider "megaport"` block, Terraform will report it as an unsupported provider argument. Remove that setting before planning or applying with this version.

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -633,3 +633,5 @@ Example plan output:
 When Terraform deletes a Megaport resource, the provider issues an immediate cancellation or deletion request to the Megaport API. Resources are removed from Terraform state as soon as the API call returns successfully. For Ports and LAG Ports specifically, this is always a `CANCEL_NOW` action against the Megaport Products API.
 
 Delayed cancellation (cancel-at-end-of-term) is not supported by the provider. The previously available `cancel_at_end_of_term` provider option has been removed because the Megaport API no longer accepts delayed cancellation for Ports or LAG Ports.
+
+**Upgrade note:** If your existing Terraform configuration still sets `cancel_at_end_of_term` in the `provider "megaport"` block, Terraform will report it as an unsupported provider argument. Remove that setting before planning or applying with this version.

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -630,6 +630,6 @@ Example plan output:
 
 ## Resource Cancellation
 
-When Terraform deletes a Megaport resource, the provider issues an immediate cancellation (`CANCEL_NOW`) to the Megaport API. Resources are removed from Terraform state as soon as the API call returns successfully.
+When Terraform deletes a Megaport resource, the provider issues an immediate cancellation or deletion request to the Megaport API. Resources are removed from Terraform state as soon as the API call returns successfully. For Ports and LAG Ports specifically, this is always a `CANCEL_NOW` action against the Megaport Products API.
 
 Delayed cancellation (cancel-at-end-of-term) is not supported by the provider. The previously available `cancel_at_end_of_term` provider option has been removed because the Megaport API no longer accepts delayed cancellation for Ports or LAG Ports.


### PR DESCRIPTION
## Summary

Remove the "Terminate Later" (delayed cancellation) option for Single Ports and LAG Ports, mirroring [megaportgo PR #155](https://github.com/megaport/megaportgo/pull/155). The Megaport API no longer accepts delayed cancellation for ports — only immediate cancellation (`CANCEL_NOW`) is allowed.

### Code changes

- Remove the provider-level `cancel_at_end_of_term` configuration attribute (it was previously documented as applying only to Single Ports and LAG Ports).
- Hard-code `DeleteNow: true` in `portResource.Delete` (`internal/provider/single_port_resource.go`) and `lagPortResource.Delete` (`internal/provider/lag_port_resource.go`).
- Drop the now-dead `cancelAtEndOfTerm` field from `megaportProviderData`, `portResource`, and `lagPortResource`.
- Replace the "End-of-Term Cancellation" section in `README.md`, `docs/index.md`, and `templates/index.md.tmpl` with a brief note that cancellation is always immediate.
- Add a unit test (`internal/provider/port_resource_delete_test.go`) asserting the SDK contract used by both port resources hits `/v3/product/{id}/action/CANCEL_NOW`.

## Breaking change

This is a **breaking change for HCL configs** that previously set `cancel_at_end_of_term = true` on the `provider "megaport"` block — Terraform will reject the unknown attribute. Users will need to remove that line from their configuration. There is no behaviour change for users who left the attribute at its default (`false`).

The `RestorePort` SDK method remains in megaportgo for any ports already scheduled for cancellation under the old behaviour; nothing in this provider PR depends on that.

## Dependencies

- **Depends on [megaportgo PR #155](https://github.com/megaport/megaportgo/pull/155)** merging and a new tagged release being published.
- **Requires a `go.mod` version bump for `github.com/megaport/megaportgo`** — this will be added as a follow-up commit on this PR once the new megaportgo tag is available. Do not merge before that bump lands.

## Test plan

- [x] `GOWORK=off go build -v ./...` — clean
- [x] `GOWORK=off go vet ./...` — clean
- [x] `GOWORK=off go test ./internal/provider/... -run '^Test[^A].*'` — passes, including new `TestPortDeleteAlwaysUsesCancelNow`
- [x] `golangci-lint run ./...` — 0 issues
- [x] Confirm `docs/index.md` and `templates/index.md.tmpl` stay in sync (`diff` returns no differences)
- [ ] Acceptance tests (`TF_ACC=1`) — to be run after the megaportgo bump lands on this branch
- [ ] Manual smoke test: apply + destroy a `megaport_port` resource against staging after the SDK bump