### PR TITLE
ESD-1204: Surface NAT Gateway speed/session errors at plan time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
-	github.com/megaport/megaportgo v1.13.1
+	github.com/megaport/megaportgo v1.14.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/megaport/megaportgo v1.13.1 h1:oFNmSLDx4EM97BunyGbnn/xeOdd75Kpz6/KWCvRO/o4=
-github.com/megaport/megaportgo v1.13.1/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
+github.com/megaport/megaportgo v1.14.1 h1:yhR4MFLyWyF29HTUCKZaujaCUgZBcrqUYlFkNEz/SuU=
+github.com/megaport/megaportgo v1.14.1/go.mod h1:dF1MxT8/kD6FWb4/ojrklWinIUp5exn8v8xYJVUB3Zc=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=

--- a/internal/provider/nat_gateway_resource.go
+++ b/internal/provider/nat_gateway_resource.go
@@ -577,7 +577,11 @@ func (r *natGatewayResource) ImportState(ctx context.Context, req resource.Impor
 // consulting the live NAT Gateway availability matrix through the optional
 // NATGatewayMatrixValidator interface on the SDK service. Fail-open if the
 // SDK is too old to advertise the interface, the provider isn't configured
-// (e.g. terraform validate), or either value is unknown/null.
+// (e.g. terraform validate), or either value is unknown/null. Operational
+// failures from the matrix lookup (transport, auth, 5xx) are surfaced as a
+// warning rather than an error — apply will still catch invalid
+// combinations server-side, so a transient lookup failure should not block
+// terraform plan.
 func (r *natGatewayResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() {
 		return
@@ -610,6 +614,14 @@ func (r *natGatewayResource) ModifyPlan(ctx context.Context, req resource.Modify
 		return
 	}
 
+	if !isNATGatewayMatrixValidationError(err) {
+		resp.Diagnostics.AddWarning(
+			"Could not validate NAT Gateway speed / session count at plan time",
+			fmt.Sprintf("The availability matrix lookup failed: %v. Invalid combinations will still be rejected at apply.", err),
+		)
+		return
+	}
+
 	attrPath := path.Root("speed")
 	switch {
 	case errors.Is(err, megaport.ErrNATGatewaySessionCountRequired),
@@ -622,4 +634,15 @@ func (r *natGatewayResource) ModifyPlan(ctx context.Context, req resource.Modify
 		"Invalid NAT Gateway speed / session count combination",
 		err.Error(),
 	)
+}
+
+// isNATGatewayMatrixValidationError reports whether err is one of the
+// matrix validator's known validation sentinels (as opposed to a transport
+// or API failure). Used by ModifyPlan to decide between attribute error
+// (real validation failure) and warning (lookup failure).
+func isNATGatewayMatrixValidationError(err error) bool {
+	return errors.Is(err, megaport.ErrNATGatewaySpeedRequired) ||
+		errors.Is(err, megaport.ErrNATGatewaySessionCountRequired) ||
+		errors.Is(err, megaport.ErrNATGatewaySpeedNotSupported) ||
+		errors.Is(err, megaport.ErrNATGatewaySessionCountNotSupported)
 }

--- a/internal/provider/nat_gateway_resource.go
+++ b/internal/provider/nat_gateway_resource.go
@@ -30,6 +30,7 @@ var (
 	_ resource.Resource                = &natGatewayResource{}
 	_ resource.ResourceWithConfigure   = &natGatewayResource{}
 	_ resource.ResourceWithImportState = &natGatewayResource{}
+	_ resource.ResourceWithModifyPlan  = &natGatewayResource{}
 )
 
 // natGatewayResourceModel maps the resource schema data.

--- a/internal/provider/nat_gateway_resource.go
+++ b/internal/provider/nat_gateway_resource.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -569,4 +570,55 @@ func (r *natGatewayResource) Configure(_ context.Context, req resource.Configure
 
 func (r *natGatewayResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("product_uid"), req, resp)
+}
+
+// ModifyPlan rejects invalid speed/session_count combinations at plan time by
+// consulting the live NAT Gateway availability matrix through the optional
+// NATGatewayMatrixValidator interface on the SDK service. Fail-open if the
+// SDK is too old to advertise the interface, the provider isn't configured
+// (e.g. terraform validate), or either value is unknown/null.
+func (r *natGatewayResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+	var plan natGatewayResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.Speed.IsUnknown() || plan.Speed.IsNull() {
+		return
+	}
+	if plan.SessionCount.IsUnknown() || plan.SessionCount.IsNull() {
+		return
+	}
+	if r.client == nil {
+		return
+	}
+	v, ok := r.client.NATGatewayService.(megaport.NATGatewayMatrixValidator)
+	if !ok {
+		return
+	}
+
+	speed := int(plan.Speed.ValueInt64())
+	sessionCount := int(plan.SessionCount.ValueInt64())
+
+	err := v.ValidateNATGatewaySpeedSession(ctx, speed, sessionCount)
+	if err == nil {
+		return
+	}
+
+	attrPath := path.Root("speed")
+	switch {
+	case errors.Is(err, megaport.ErrNATGatewaySessionCountRequired),
+		errors.Is(err, megaport.ErrNATGatewaySessionCountNotSupported):
+		attrPath = path.Root("session_count")
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		attrPath,
+		"Invalid NAT Gateway speed / session count combination",
+		err.Error(),
+	)
 }

--- a/internal/provider/nat_gateway_resource.go
+++ b/internal/provider/nat_gateway_resource.go
@@ -578,10 +578,11 @@ func (r *natGatewayResource) ImportState(ctx context.Context, req resource.Impor
 // NATGatewayMatrixValidator interface on the SDK service. Fail-open if the
 // SDK is too old to advertise the interface, the provider isn't configured
 // (e.g. terraform validate), or either value is unknown/null. Validation
-// only runs on create or when speed/session_count are actually changing; a
-// no-op plan against an already-provisioned NAT gateway must not start
-// failing just because the matrix has dropped a previously valid pair.
-// Operational failures from the matrix lookup (transport, auth, 5xx) are
+// runs on create, on any plan that changes speed or session_count, and on
+// replacements (a change to a RequiresReplace attribute is a fresh
+// provision); pure in-place no-ops with both values unchanged are skipped
+// so a shifting matrix can't fail plan against an already-provisioned NAT
+// gateway. Operational failures from the matrix lookup (transport, auth, 5xx) are
 // surfaced as a warning rather than an error so a transient lookup failure
 // doesn't block terraform plan.
 func (r *natGatewayResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
@@ -607,7 +608,14 @@ func (r *natGatewayResource) ModifyPlan(ctx context.Context, req resource.Modify
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		if plan.Speed.Equal(state.Speed) && plan.SessionCount.Equal(state.SessionCount) {
+		// A change to any RequiresReplace attribute means the resource will
+		// be destroyed and recreated — effectively a new provision — so the
+		// new instance must still go through matrix validation even if
+		// speed/session_count match prior state. Keep this list in sync
+		// with the RequiresReplace plan modifiers in Schema.
+		requiresReplace := !plan.LocationID.Equal(state.LocationID) ||
+			!plan.PromoCode.Equal(state.PromoCode)
+		if !requiresReplace && plan.Speed.Equal(state.Speed) && plan.SessionCount.Equal(state.SessionCount) {
 			return
 		}
 	}

--- a/internal/provider/nat_gateway_resource.go
+++ b/internal/provider/nat_gateway_resource.go
@@ -639,6 +639,17 @@ func (r *natGatewayResource) ModifyPlan(ctx context.Context, req resource.Modify
 		return
 	}
 
+	if len(matrix) == 0 {
+		// Fail open: an empty-but-successful matrix would otherwise make
+		// natGatewaySpeedSessionSupported reject every plan. Treat it like a
+		// lookup failure; apply still validates server-side.
+		resp.Diagnostics.AddWarning(
+			"Could not validate NAT Gateway speed / session count at plan time",
+			"The NAT Gateway availability matrix was empty. Apply will still reject invalid combinations server-side.",
+		)
+		return
+	}
+
 	if attrPath, msg, ok := natGatewaySpeedSessionSupported(matrix, speed, sessionCount); !ok {
 		resp.Diagnostics.AddAttributeError(attrPath, "Invalid NAT Gateway speed / session count combination", msg)
 	}

--- a/internal/provider/nat_gateway_resource.go
+++ b/internal/provider/nat_gateway_resource.go
@@ -577,11 +577,13 @@ func (r *natGatewayResource) ImportState(ctx context.Context, req resource.Impor
 // consulting the live NAT Gateway availability matrix through the optional
 // NATGatewayMatrixValidator interface on the SDK service. Fail-open if the
 // SDK is too old to advertise the interface, the provider isn't configured
-// (e.g. terraform validate), or either value is unknown/null. Operational
-// failures from the matrix lookup (transport, auth, 5xx) are surfaced as a
-// warning rather than an error — apply will still catch invalid
-// combinations server-side, so a transient lookup failure should not block
-// terraform plan.
+// (e.g. terraform validate), or either value is unknown/null. Validation
+// only runs on create or when speed/session_count are actually changing; a
+// no-op plan against an already-provisioned NAT gateway must not start
+// failing just because the matrix has dropped a previously valid pair.
+// Operational failures from the matrix lookup (transport, auth, 5xx) are
+// surfaced as a warning rather than an error so a transient lookup failure
+// doesn't block terraform plan.
 func (r *natGatewayResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() {
 		return
@@ -598,6 +600,18 @@ func (r *natGatewayResource) ModifyPlan(ctx context.Context, req resource.Modify
 	if plan.SessionCount.IsUnknown() || plan.SessionCount.IsNull() {
 		return
 	}
+
+	if !req.State.Raw.IsNull() {
+		var state natGatewayResourceModel
+		resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if plan.Speed.Equal(state.Speed) && plan.SessionCount.Equal(state.SessionCount) {
+			return
+		}
+	}
+
 	if r.client == nil {
 		return
 	}
@@ -617,7 +631,7 @@ func (r *natGatewayResource) ModifyPlan(ctx context.Context, req resource.Modify
 	if !isNATGatewayMatrixValidationError(err) {
 		resp.Diagnostics.AddWarning(
 			"Could not validate NAT Gateway speed / session count at plan time",
-			fmt.Sprintf("The availability matrix lookup failed: %v. Invalid combinations will still be rejected at apply.", err),
+			fmt.Sprintf("Plan-time validation was skipped because the availability matrix lookup failed: %v. Apply will still reject invalid combinations server-side, and may surface the same lookup error if it persists.", err),
 		)
 		return
 	}

--- a/internal/provider/nat_gateway_resource.go
+++ b/internal/provider/nat_gateway_resource.go
@@ -2,9 +2,9 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -574,17 +574,18 @@ func (r *natGatewayResource) ImportState(ctx context.Context, req resource.Impor
 }
 
 // ModifyPlan rejects invalid speed/session_count combinations at plan time by
-// consulting the live NAT Gateway availability matrix through the optional
-// NATGatewayMatrixValidator interface on the SDK service. Fail-open if the
-// SDK is too old to advertise the interface, the provider isn't configured
-// (e.g. terraform validate), or either value is unknown/null. Validation
-// runs on create, on any plan that changes speed or session_count, and on
-// replacements (a change to a RequiresReplace attribute is a fresh
-// provision); pure in-place no-ops with both values unchanged are skipped
-// so a shifting matrix can't fail plan against an already-provisioned NAT
-// gateway. Operational failures from the matrix lookup (transport, auth, 5xx) are
-// surfaced as a warning rather than an error so a transient lookup failure
-// doesn't block terraform plan.
+// fetching the live NAT Gateway availability matrix from the SDK and comparing
+// locally. Fail-open if the provider isn't configured (e.g. terraform
+// validate) or either value is unknown/null. Validation runs on create, on any
+// plan that changes speed or session_count, and on replacements (a change to a
+// RequiresReplace attribute is a fresh provision); pure in-place no-ops with
+// both values unchanged are skipped so a shifting matrix can't fail plan
+// against an already-provisioned NAT gateway. A matrix lookup failure
+// (transport, auth, 5xx) is surfaced as a warning rather than an error so a
+// transient failure doesn't block terraform plan.
+//
+// The matrix is fetched once per resource instance per plan. If large configs
+// ever cause throttling, add a plan-scoped cache here in the provider.
 func (r *natGatewayResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() {
 		return
@@ -623,48 +624,47 @@ func (r *natGatewayResource) ModifyPlan(ctx context.Context, req resource.Modify
 	if r.client == nil {
 		return
 	}
-	v, ok := r.client.NATGatewayService.(megaport.NATGatewayMatrixValidator)
-	if !ok {
-		return
-	}
 
 	speed := int(plan.Speed.ValueInt64())
 	sessionCount := int(plan.SessionCount.ValueInt64())
 
-	err := v.ValidateNATGatewaySpeedSession(ctx, speed, sessionCount)
-	if err == nil {
-		return
-	}
-
-	if !isNATGatewayMatrixValidationError(err) {
+	matrix, err := r.client.NATGatewayService.ListNATGatewaySessions(ctx)
+	if err != nil {
+		// Fail open: a transient matrix lookup failure must not block plan.
+		// Apply still rejects invalid combinations server-side.
 		resp.Diagnostics.AddWarning(
 			"Could not validate NAT Gateway speed / session count at plan time",
-			fmt.Sprintf("Plan-time validation was skipped because the availability matrix lookup failed: %v. Apply will still reject invalid combinations server-side, and may surface the same lookup error if it persists.", err),
+			fmt.Sprintf("The availability matrix lookup failed: %v. Apply will still reject invalid combinations server-side, and may surface the same lookup error if it persists.", err),
 		)
 		return
 	}
 
-	attrPath := path.Root("speed")
-	switch {
-	case errors.Is(err, megaport.ErrNATGatewaySessionCountRequired),
-		errors.Is(err, megaport.ErrNATGatewaySessionCountNotSupported):
-		attrPath = path.Root("session_count")
+	if attrPath, msg, ok := natGatewaySpeedSessionSupported(matrix, speed, sessionCount); !ok {
+		resp.Diagnostics.AddAttributeError(attrPath, "Invalid NAT Gateway speed / session count combination", msg)
 	}
-
-	resp.Diagnostics.AddAttributeError(
-		attrPath,
-		"Invalid NAT Gateway speed / session count combination",
-		err.Error(),
-	)
 }
 
-// isNATGatewayMatrixValidationError reports whether err is one of the
-// matrix validator's known validation sentinels (as opposed to a transport
-// or API failure). Used by ModifyPlan to decide between attribute error
-// (real validation failure) and warning (lookup failure).
-func isNATGatewayMatrixValidationError(err error) bool {
-	return errors.Is(err, megaport.ErrNATGatewaySpeedRequired) ||
-		errors.Is(err, megaport.ErrNATGatewaySessionCountRequired) ||
-		errors.Is(err, megaport.ErrNATGatewaySpeedNotSupported) ||
-		errors.Is(err, megaport.ErrNATGatewaySessionCountNotSupported)
+// natGatewaySpeedSessionSupported reports whether the speed/sessionCount pair
+// appears in the live availability matrix. When unsupported it returns the
+// offending attribute path and a human-readable message for the diagnostic.
+func natGatewaySpeedSessionSupported(matrix []*megaport.NATGatewaySession, speed, sessionCount int) (path.Path, string, bool) {
+	supportedSpeeds := make([]int, 0, len(matrix))
+	for _, entry := range matrix {
+		if entry == nil {
+			continue
+		}
+		supportedSpeeds = append(supportedSpeeds, entry.SpeedMbps)
+		if entry.SpeedMbps != speed {
+			continue
+		}
+		if slices.Contains(entry.SessionCount, sessionCount) {
+			return path.Empty(), "", true
+		}
+		return path.Root("session_count"),
+			fmt.Sprintf("Session count %d is not supported for %d Mbps. Supported session counts: %v.", sessionCount, speed, entry.SessionCount),
+			false
+	}
+	return path.Root("speed"),
+		fmt.Sprintf("Speed %d Mbps is not supported. Supported speeds: %v.", speed, supportedSpeeds),
+		false
 }

--- a/internal/provider/nat_gateway_resource_test.go
+++ b/internal/provider/nat_gateway_resource_test.go
@@ -289,26 +289,21 @@ func TestAccMegaportNATGateway_PlanTimeRejectsInvalidSpeed(t *testing.T) {
 		t.Skipf("Skipping NAT Gateway plan-time validation test: %v", err)
 	}
 
-	// Preflight the validator the provider's ModifyPlan will use, so we
-	// only assert on the validation outcome when the matrix lookup is
-	// actually working. The provider downgrades operational lookup
-	// failures (transport, auth, 5xx) to a warning, which would leave the
-	// PlanOnly step with no error to match. Skip in that case instead of
-	// flaking.
+	// Preflight the same matrix lookup the provider's ModifyPlan will use, so
+	// we only assert on the validation outcome when the lookup is actually
+	// working. The provider downgrades operational lookup failures (transport,
+	// auth, 5xx) to a warning, which would leave the PlanOnly step with no
+	// error to match. Skip in that case instead of flaking.
 	client, err := getTestClient()
 	if err != nil {
 		t.Skipf("Skipping NAT Gateway plan-time validation test: %v", err)
 	}
-	v, ok := client.NATGatewayService.(megaport.NATGatewayMatrixValidator)
-	if !ok {
-		t.Skip("Skipping NAT Gateway plan-time validation test: SDK does not advertise NATGatewayMatrixValidator")
+	matrix, err := client.NATGatewayService.ListNATGatewaySessions(context.Background())
+	if err != nil {
+		t.Skipf("Skipping NAT Gateway plan-time validation test: matrix lookup failed operationally: %v", err)
 	}
-	preflightErr := v.ValidateNATGatewaySpeedSession(context.Background(), invalidSpeed, sessionCount)
-	switch {
-	case preflightErr == nil:
-		t.Skipf("Skipping NAT Gateway plan-time validation test: derived invalid speed %d Mbps was accepted by the validator (matrix may have changed)", invalidSpeed)
-	case !isNATGatewayMatrixValidationError(preflightErr):
-		t.Skipf("Skipping NAT Gateway plan-time validation test: matrix lookup failed operationally: %v", preflightErr)
+	if _, _, ok := natGatewaySpeedSessionSupported(matrix, invalidSpeed, sessionCount); ok {
+		t.Skipf("Skipping NAT Gateway plan-time validation test: derived invalid speed %d Mbps is supported by the matrix (matrix may have changed)", invalidSpeed)
 	}
 	// Find a location that supports the highest advertised speed (one less
 	// than invalidSpeed). The location is needed for the HCL to parse; the

--- a/internal/provider/nat_gateway_resource_test.go
+++ b/internal/provider/nat_gateway_resource_test.go
@@ -288,6 +288,28 @@ func TestAccMegaportNATGateway_PlanTimeRejectsInvalidSpeed(t *testing.T) {
 	if err != nil {
 		t.Skipf("Skipping NAT Gateway plan-time validation test: %v", err)
 	}
+
+	// Preflight the validator the provider's ModifyPlan will use, so we
+	// only assert on the validation outcome when the matrix lookup is
+	// actually working. The provider downgrades operational lookup
+	// failures (transport, auth, 5xx) to a warning, which would leave the
+	// PlanOnly step with no error to match. Skip in that case instead of
+	// flaking.
+	client, err := getTestClient()
+	if err != nil {
+		t.Skipf("Skipping NAT Gateway plan-time validation test: %v", err)
+	}
+	v, ok := client.NATGatewayService.(megaport.NATGatewayMatrixValidator)
+	if !ok {
+		t.Skip("Skipping NAT Gateway plan-time validation test: SDK does not advertise NATGatewayMatrixValidator")
+	}
+	preflightErr := v.ValidateNATGatewaySpeedSession(context.Background(), invalidSpeed, sessionCount)
+	switch {
+	case preflightErr == nil:
+		t.Skipf("Skipping NAT Gateway plan-time validation test: derived invalid speed %d Mbps was accepted by the validator (matrix may have changed)", invalidSpeed)
+	case !isNATGatewayMatrixValidationError(preflightErr):
+		t.Skipf("Skipping NAT Gateway plan-time validation test: matrix lookup failed operationally: %v", preflightErr)
+	}
 	// Find a location that supports the highest advertised speed (one less
 	// than invalidSpeed). The location is needed for the HCL to parse; the
 	// plan-only step never reaches provisioning.

--- a/internal/provider/nat_gateway_resource_test.go
+++ b/internal/provider/nat_gateway_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"slices"
 	"testing"
 
@@ -224,6 +225,53 @@ resource "megaport_nat_gateway" "test" {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckNoResourceAttr(resourceName, "promo_code"),
 				),
+			},
+		},
+	})
+}
+
+// TestAccMegaportNATGateway_PlanTimeRejectsInvalidSpeed asserts that the
+// resource's ModifyPlan hook rejects a known-invalid speed during
+// terraform plan, before any provisioning occurs. 500 Mbps is not in the
+// NAT Gateway availability matrix, so the validator should surface
+// ErrNATGatewaySpeedNotSupported as an attribute diagnostic.
+func TestAccMegaportNATGateway_PlanTimeRejectsInvalidSpeed(t *testing.T) {
+	t.Parallel()
+	defer acquireAccTestSlot(t)()
+
+	// Pick any valid speed just to find a location; the actual plan config
+	// below uses an invalid 500 Mbps speed that the matrix won't accept.
+	probeSpeed, sessionCount, err := getNATGatewayTestConfig()
+	if err != nil {
+		t.Skipf("Skipping NAT Gateway plan-time validation test: %v", err)
+	}
+	locationID, _ := findNATGatewayTestLocation(t, probeSpeed)
+	natGWName := RandomTestName()
+
+	const invalidSpeed = 500
+	config := providerConfig + fmt.Sprintf(`
+data "megaport_location" "test_location" {
+    id = %d
+}
+
+resource "megaport_nat_gateway" "test" {
+    product_name         = "%s"
+    location_id          = data.megaport_location.test_location.id
+    speed                = %d
+    session_count        = %d
+    contract_term_months = 1
+    diversity_zone       = "red"
+    asn                  = 64512
+}
+`, locationID, natGWName, invalidSpeed, sessionCount)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)not supported`),
 			},
 		},
 	})

--- a/internal/provider/nat_gateway_resource_test.go
+++ b/internal/provider/nat_gateway_resource_test.go
@@ -37,9 +37,12 @@ func getNATGatewayTestConfig() (speed, sessionCount int, err error) {
 
 // findInvalidNATGatewaySpeed derives a speed guaranteed not to be in the
 // live NAT Gateway availability matrix by returning max(SpeedMbps)+1. It
-// also returns a sample session count from the matrix so the HCL parses
-// — the validator rejects on speed before checking session count anyway.
-// Deriving the value dynamically keeps the test stable as the matrix
+// also returns any positive session count from the matrix so the HCL
+// parses and the validator's session-count pre-check passes (the test
+// targets the speed sentinel, not the session-count sentinel). The two
+// selections are independent: if the highest-speed entry has no
+// SessionCount values, we still pick a session count from another entry.
+// Deriving both values dynamically keeps the test stable as the matrix
 // evolves; a hard-coded "500 Mbps is invalid" would silently break the
 // day 500 Mbps is added.
 func findInvalidNATGatewaySpeed() (invalidSpeed, sessionCount int, err error) {
@@ -53,18 +56,26 @@ func findInvalidNATGatewaySpeed() (invalidSpeed, sessionCount int, err error) {
 	}
 	maxSpeed := 0
 	for _, s := range sessions {
-		if s == nil || s.SpeedMbps <= 0 {
+		if s == nil {
 			continue
 		}
 		if s.SpeedMbps > maxSpeed {
 			maxSpeed = s.SpeedMbps
-			if len(s.SessionCount) > 0 {
-				sessionCount = s.SessionCount[0]
+		}
+		if sessionCount == 0 {
+			for _, c := range s.SessionCount {
+				if c > 0 {
+					sessionCount = c
+					break
+				}
 			}
 		}
 	}
-	if maxSpeed == 0 {
+	if maxSpeed <= 0 {
 		return 0, 0, fmt.Errorf("no positive NAT Gateway speeds advertised")
+	}
+	if sessionCount <= 0 {
+		return 0, 0, fmt.Errorf("no positive session count advertised in NAT Gateway matrix")
 	}
 	return maxSpeed + 1, sessionCount, nil
 }
@@ -305,7 +316,7 @@ resource "megaport_nat_gateway" "test" {
 			{
 				Config:      config,
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`(?i)not supported`),
+				ExpectError: regexp.MustCompile(`Invalid NAT Gateway speed / session count combination`),
 			},
 		},
 	})

--- a/internal/provider/nat_gateway_resource_test.go
+++ b/internal/provider/nat_gateway_resource_test.go
@@ -35,6 +35,40 @@ func getNATGatewayTestConfig() (speed, sessionCount int, err error) {
 	return 0, 0, fmt.Errorf("no NAT Gateway session/speed pairs available")
 }
 
+// findInvalidNATGatewaySpeed derives a speed guaranteed not to be in the
+// live NAT Gateway availability matrix by returning max(SpeedMbps)+1. It
+// also returns a sample session count from the matrix so the HCL parses
+// — the validator rejects on speed before checking session count anyway.
+// Deriving the value dynamically keeps the test stable as the matrix
+// evolves; a hard-coded "500 Mbps is invalid" would silently break the
+// day 500 Mbps is added.
+func findInvalidNATGatewaySpeed() (invalidSpeed, sessionCount int, err error) {
+	client, err := getTestClient()
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to create test client: %w", err)
+	}
+	sessions, err := client.NATGatewayService.ListNATGatewaySessions(context.Background())
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to list NAT Gateway sessions: %w", err)
+	}
+	maxSpeed := 0
+	for _, s := range sessions {
+		if s == nil || s.SpeedMbps <= 0 {
+			continue
+		}
+		if s.SpeedMbps > maxSpeed {
+			maxSpeed = s.SpeedMbps
+			if len(s.SessionCount) > 0 {
+				sessionCount = s.SessionCount[0]
+			}
+		}
+	}
+	if maxSpeed == 0 {
+		return 0, 0, fmt.Errorf("no positive NAT Gateway speeds advertised")
+	}
+	return maxSpeed + 1, sessionCount, nil
+}
+
 // checkNATGatewayProvisioned asserts the resource's provisioning_status is
 // one of the ready states (CONFIGURED or LIVE), confirming the validate/buy
 // flow ran and the service was actually purchased.
@@ -231,24 +265,24 @@ resource "megaport_nat_gateway" "test" {
 }
 
 // TestAccMegaportNATGateway_PlanTimeRejectsInvalidSpeed asserts that the
-// resource's ModifyPlan hook rejects a known-invalid speed during
-// terraform plan, before any provisioning occurs. 500 Mbps is not in the
-// NAT Gateway availability matrix, so the validator should surface
-// ErrNATGatewaySpeedNotSupported as an attribute diagnostic.
+// resource's ModifyPlan hook rejects an invalid speed during terraform
+// plan, before any provisioning occurs. The invalid speed is derived from
+// the live availability matrix (max advertised speed + 1 Mbps) so the
+// test stays accurate as the matrix evolves.
 func TestAccMegaportNATGateway_PlanTimeRejectsInvalidSpeed(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()
 
-	// Pick any valid speed just to find a location; the actual plan config
-	// below uses an invalid 500 Mbps speed that the matrix won't accept.
-	probeSpeed, sessionCount, err := getNATGatewayTestConfig()
+	invalidSpeed, sessionCount, err := findInvalidNATGatewaySpeed()
 	if err != nil {
 		t.Skipf("Skipping NAT Gateway plan-time validation test: %v", err)
 	}
-	locationID, _ := findNATGatewayTestLocation(t, probeSpeed)
+	// Find a location that supports the highest advertised speed (one less
+	// than invalidSpeed). The location is needed for the HCL to parse; the
+	// plan-only step never reaches provisioning.
+	locationID, _ := findNATGatewayTestLocation(t, invalidSpeed-1)
 	natGWName := RandomTestName()
 
-	const invalidSpeed = 500
 	config := providerConfig + fmt.Sprintf(`
 data "megaport_location" "test_location" {
     id = %d

--- a/internal/provider/nat_gateway_speed_session_test.go
+++ b/internal/provider/nat_gateway_speed_session_test.go
@@ -1,0 +1,103 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	megaport "github.com/megaport/megaportgo"
+)
+
+func TestNATGatewaySpeedSessionSupported(t *testing.T) {
+	t.Parallel()
+
+	// Synthetic matrix; values are illustrative, not real availability data.
+	matrix := []*megaport.NATGatewaySession{
+		{SpeedMbps: 1000, SessionCount: []int{16000, 32000}},
+		{SpeedMbps: 2000, SessionCount: []int{32000, 64000}},
+		nil, // must be skipped without panicking
+		{SpeedMbps: 5000, SessionCount: []int{128000}},
+	}
+
+	cases := []struct {
+		name            string
+		matrix          []*megaport.NATGatewaySession
+		speed           int
+		sessionCount    int
+		wantOK          bool
+		wantPath        path.Path // checked only when wantOK is false
+		wantMsgContains []string
+	}{
+		{
+			name:         "valid speed and session",
+			matrix:       matrix,
+			speed:        1000,
+			sessionCount: 32000,
+			wantOK:       true,
+		},
+		{
+			name:         "nil entries are skipped",
+			matrix:       matrix,
+			speed:        5000,
+			sessionCount: 128000,
+			wantOK:       true,
+		},
+		{
+			name:            "unsupported speed lists every supported speed",
+			matrix:          matrix,
+			speed:           500,
+			sessionCount:    16000,
+			wantOK:          false,
+			wantPath:        path.Root("speed"),
+			wantMsgContains: []string{"500", "1000", "2000", "5000"},
+		},
+		{
+			name:            "supported speed, unsupported session",
+			matrix:          matrix,
+			speed:           1000,
+			sessionCount:    99999,
+			wantOK:          false,
+			wantPath:        path.Root("session_count"),
+			wantMsgContains: []string{"99999", "1000", "16000", "32000"},
+		},
+		{
+			name:         "empty matrix rejects on speed",
+			matrix:       []*megaport.NATGatewaySession{},
+			speed:        1000,
+			sessionCount: 16000,
+			wantOK:       false,
+			wantPath:     path.Root("speed"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotPath, gotMsg, gotOK := natGatewaySpeedSessionSupported(tc.matrix, tc.speed, tc.sessionCount)
+
+			if gotOK != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (msg=%q)", gotOK, tc.wantOK, gotMsg)
+			}
+			if tc.wantOK {
+				if gotMsg != "" {
+					t.Errorf("expected empty message on success, got %q", gotMsg)
+				}
+				if !gotPath.Equal(path.Empty()) {
+					t.Errorf("expected empty path on success, got %s", gotPath)
+				}
+				return
+			}
+			if !gotPath.Equal(tc.wantPath) {
+				t.Errorf("path = %s, want %s", gotPath, tc.wantPath)
+			}
+			if gotMsg == "" {
+				t.Error("expected a non-empty diagnostic message on failure")
+			}
+			for _, sub := range tc.wantMsgContains {
+				if !strings.Contains(gotMsg, sub) {
+					t.Errorf("message %q does not contain %q", gotMsg, sub)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Validate `speed` / `session_count` at `terraform plan` instead of at `terraform apply`, so invalid configs fail before any resource is created.

- Adds `ModifyPlan` to `megaport_nat_gateway`: fetches the live availability matrix via the SDK's `ListNATGatewaySessions` and checks the planned speed / session count against it.
- The check lives in the provider (`natGatewaySpeedSessionSupported`), not the SDK. `megaportgo` stays a fetch-only shim.
- Fails open: a transient matrix lookup error is a plan warning, not a hard error. Apply still rejects invalid combinations server-side.
- Acceptance test plan-rejects a known-invalid combination.

Pins `megaportgo` v1.14.1. Draft until the `megaportgo` NAT Gateway changes are merged / released.
