### PR TITLE
docs: README breaking-change notice for cancel_at_end_of_term removal (ESD-1183)

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,27 @@ If you need to find the location ID for a specific site code, you can:
 
 ---
 
+## 🚨 BREAKING CHANGE: `cancel_at_end_of_term` Removed
+
+### ⚠️ Action required if you set `cancel_at_end_of_term`
+
+**If your `provider "megaport"` block sets `cancel_at_end_of_term`, you must remove it or your `terraform plan`/`apply` will fail with an "Unsupported argument" error.**
+
+The Megaport API no longer accepts delayed (end-of-term) cancellation, so the provider now always issues an immediate `CANCEL_NOW` when destroying resources. The `cancel_at_end_of_term` provider option has been removed.
+
+#### ❌ What No Longer Works
+```terraform
+provider "megaport" {
+  # ...
+  cancel_at_end_of_term = true  # ❌ removed - Terraform will reject this argument
+}
+```
+
+#### ✅ What To Do
+Delete the `cancel_at_end_of_term` line from your provider block. Resource deletion is always immediate - see [Resource Cancellation](#resource-cancellation) for details and billing implications.
+
+---
+
 ## Datacenter Location Data Source
 
 Locations for Megaport Data Centers can be retrieved using the Locations Data Source in the Megaport Terraform Provider.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
-	github.com/megaport/megaportgo v1.11.0
+	github.com/megaport/megaportgo v1.12.1
 )
 
 require (
@@ -82,7 +82,7 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/zclconf/go-cty v1.18.1 // indirect
-	golang.org/x/crypto v0.50.0 // indirect
+	golang.org/x/crypto v0.50.0
 	golang.org/x/exp v0.0.0-20230809150735-7b3493d9a819 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.52.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/megaport/megaportgo v1.11.0 h1:cSfopzOQLs3yWlLmSPZYGDNE7IErZD7wWEb92IFccDs=
-github.com/megaport/megaportgo v1.11.0/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
+github.com/megaport/megaportgo v1.12.1 h1:I2pwAFlMspiN0NW2mJB275lZkUOrwsG9Gu7r3YxKDnw=
+github.com/megaport/megaportgo v1.12.1/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=


### PR DESCRIPTION
The Megaport API is dropping the end-of-term CANCEL endpoint (EIP-5296 / ENG-27615). #385 already removed the now-defunct `cancel_at_end_of_term` provider attribute.

Since release notes are auto-generated from PR titles, this adds a top-level README breaking-change banner (matching the `site_code` one) so the removal is visible to anyone upgrading. Docs-only.