### PR TITLE
ESD-1314: persist VXC UID to state before provisioning wait

### DIFF
--- a/internal/provider/vxc_resource.go
+++ b/internal/provider/vxc_resource.go
@@ -1924,13 +1924,16 @@ func (r *vxcResource) Create(ctx context.Context, req resource.CreateRequest, re
 // terminal state, or the timeout elapses. Transient read errors are retried
 // rather than aborting the wait, since the order has already been placed.
 func (r *vxcResource) waitForVXCProvision(ctx context.Context, uid string, timeoutAfter, pollInterval time.Duration) error {
-	timeout := time.NewTimer(timeoutAfter)
-	defer timeout.Stop()
+	// The polls share this deadline so a stalled HTTP request can't hang
+	// the wait past the overall timeout.
+	pollCtx, cancel := context.WithTimeout(ctx, timeoutAfter)
+	defer cancel()
+
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
 	for {
-		vxc, err := r.client.VXCService.GetVXC(ctx, uid)
+		vxc, err := r.client.VXCService.GetVXC(pollCtx, uid)
 		switch {
 		case err != nil:
 			tflog.Warn(ctx, "error polling VXC provisioning status, will retry", map[string]interface{}{
@@ -1944,10 +1947,11 @@ func (r *vxcResource) waitForVXCProvision(ctx context.Context, uid string, timeo
 		}
 
 		select {
-		case <-timeout.C:
+		case <-pollCtx.Done():
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			return fmt.Errorf("time expired waiting for VXC %s to provision", uid)
-		case <-ctx.Done():
-			return ctx.Err()
 		case <-ticker.C:
 		}
 	}

--- a/internal/provider/vxc_resource.go
+++ b/internal/provider/vxc_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -1208,8 +1209,10 @@ func (r *vxcResource) Create(ctx context.Context, req resource.CreateRequest, re
 		CostCentre: plan.CostCentre.ValueString(),
 		ServiceKey: plan.ServiceKey.ValueString(),
 
-		WaitForProvision: true,
-		WaitForTime:      waitForTime,
+		// Don't wait inside BuyVXC — on wait failure it discards the UID,
+		// orphaning the ordered VXC. We persist the UID to state first,
+		// then wait ourselves (see waitForVXCProvision below).
+		WaitForProvision: false,
 	}
 
 	var serviceKeyBEndUID string
@@ -1866,12 +1869,27 @@ func (r *vxcResource) Create(ctx context.Context, req resource.CreateRequest, re
 
 	createdID := createdVXC.TechnicalServiceUID
 
+	// Persist the UID immediately so any failure below leaves a tracked
+	// (tainted) resource instead of an orphan that later applies try to recreate.
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("product_uid"), createdID)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.waitForVXCProvision(ctx, createdID, waitForTime, 30*time.Second); err != nil {
+		resp.Diagnostics.AddError(
+			"VXC ordered but not ready",
+			"VXC "+plan.Name.ValueString()+" ("+createdID+") was ordered successfully but did not reach a ready state: "+err.Error()+". Its UID has been saved to state and Terraform will replace it on the next apply.",
+		)
+		return
+	}
+
 	// get the created VXC
 	vxc, err := r.client.VXCService.GetVXC(ctx, createdID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading newly created VXC",
-			"Could not read newly created VXC with ID "+createdID+": "+err.Error(),
+			"VXC "+plan.Name.ValueString()+" ("+createdID+") was created but could not be read back: "+err.Error()+". Its UID has been saved to state.",
 		)
 		return
 	}
@@ -1880,7 +1898,7 @@ func (r *vxcResource) Create(ctx context.Context, req resource.CreateRequest, re
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading tags for newly created VXC",
-			"Could not read tags for newly created VXC with ID "+createdID+": "+err.Error(),
+			"VXC "+plan.Name.ValueString()+" ("+createdID+") was created but its tags could not be read: "+err.Error()+". Its UID has been saved to state.",
 		)
 		return
 	}
@@ -1899,6 +1917,37 @@ func (r *vxcResource) Create(ctx context.Context, req resource.CreateRequest, re
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+}
+
+// waitForVXCProvision polls the VXC until it reaches a ready state or
+// the timeout elapses. Transient read errors are retried rather than
+// aborting the wait, since the order has already been placed.
+func (r *vxcResource) waitForVXCProvision(ctx context.Context, uid string, timeoutAfter, pollInterval time.Duration) error {
+	timeout := time.NewTimer(timeoutAfter)
+	defer timeout.Stop()
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout.C:
+			return fmt.Errorf("time expired waiting for VXC %s to provision", uid)
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			vxc, err := r.client.VXCService.GetVXC(ctx, uid)
+			if err != nil {
+				tflog.Warn(ctx, "error polling VXC provisioning status, will retry", map[string]interface{}{
+					"vxc_uid": uid,
+					"error":   err.Error(),
+				})
+				continue
+			}
+			if slices.Contains(megaport.SERVICE_STATE_READY, vxc.ProvisioningStatus) {
+				return nil
+			}
+		}
 	}
 }
 

--- a/internal/provider/vxc_resource.go
+++ b/internal/provider/vxc_resource.go
@@ -1920,9 +1920,9 @@ func (r *vxcResource) Create(ctx context.Context, req resource.CreateRequest, re
 	}
 }
 
-// waitForVXCProvision polls the VXC until it reaches a ready state or
-// the timeout elapses. Transient read errors are retried rather than
-// aborting the wait, since the order has already been placed.
+// waitForVXCProvision polls the VXC until it reaches a ready state, hits a
+// terminal state, or the timeout elapses. Transient read errors are retried
+// rather than aborting the wait, since the order has already been placed.
 func (r *vxcResource) waitForVXCProvision(ctx context.Context, uid string, timeoutAfter, pollInterval time.Duration) error {
 	timeout := time.NewTimer(timeoutAfter)
 	defer timeout.Stop()
@@ -1930,23 +1930,25 @@ func (r *vxcResource) waitForVXCProvision(ctx context.Context, uid string, timeo
 	defer ticker.Stop()
 
 	for {
+		vxc, err := r.client.VXCService.GetVXC(ctx, uid)
+		switch {
+		case err != nil:
+			tflog.Warn(ctx, "error polling VXC provisioning status, will retry", map[string]interface{}{
+				"vxc_uid": uid,
+				"error":   err.Error(),
+			})
+		case slices.Contains(megaport.SERVICE_STATE_READY, vxc.ProvisioningStatus):
+			return nil
+		case vxc.ProvisioningStatus == megaport.STATUS_DECOMMISSIONED || vxc.ProvisioningStatus == megaport.STATUS_CANCELLED:
+			return fmt.Errorf("VXC %s reached terminal state %q before provisioning", uid, vxc.ProvisioningStatus)
+		}
+
 		select {
 		case <-timeout.C:
 			return fmt.Errorf("time expired waiting for VXC %s to provision", uid)
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			vxc, err := r.client.VXCService.GetVXC(ctx, uid)
-			if err != nil {
-				tflog.Warn(ctx, "error polling VXC provisioning status, will retry", map[string]interface{}{
-					"vxc_uid": uid,
-					"error":   err.Error(),
-				})
-				continue
-			}
-			if slices.Contains(megaport.SERVICE_STATE_READY, vxc.ProvisioningStatus) {
-				return nil
-			}
 		}
 	}
 }

--- a/internal/provider/vxc_resource_wait_test.go
+++ b/internal/provider/vxc_resource_wait_test.go
@@ -42,6 +42,16 @@ func TestWaitForVXCProvision_RetriesTransientErrors(t *testing.T) {
 	assert.GreaterOrEqual(t, calls.Load(), int32(3))
 }
 
+func TestWaitForVXCProvision_TerminalState(t *testing.T) {
+	r := waitTestResource(&MockVXCService{
+		GetVXCResult: &megaport.VXC{ProvisioningStatus: megaport.STATUS_CANCELLED},
+	})
+
+	err := r.waitForVXCProvision(context.Background(), "test-uid", time.Second, time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "terminal state")
+}
+
 func TestWaitForVXCProvision_TimesOut(t *testing.T) {
 	r := waitTestResource(&MockVXCService{
 		GetVXCResult: &megaport.VXC{ProvisioningStatus: "DEPLOYABLE"},

--- a/internal/provider/vxc_resource_wait_test.go
+++ b/internal/provider/vxc_resource_wait_test.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	megaport "github.com/megaport/megaportgo"
+)
+
+func waitTestResource(mock *MockVXCService) *vxcResource {
+	return &vxcResource{client: &megaport.Client{VXCService: mock}}
+}
+
+func TestWaitForVXCProvision_ReadyOnFirstPoll(t *testing.T) {
+	r := waitTestResource(&MockVXCService{
+		GetVXCResult: &megaport.VXC{ProvisioningStatus: megaport.SERVICE_LIVE},
+	})
+
+	err := r.waitForVXCProvision(context.Background(), "test-uid", time.Second, time.Millisecond)
+	require.NoError(t, err)
+}
+
+func TestWaitForVXCProvision_RetriesTransientErrors(t *testing.T) {
+	var calls atomic.Int32
+	r := waitTestResource(&MockVXCService{
+		GetVXCFunc: func(ctx context.Context, id string) (*megaport.VXC, error) {
+			if calls.Add(1) <= 2 {
+				return nil, errors.New("invalid character '[' after object key:value pair")
+			}
+			return &megaport.VXC{ProvisioningStatus: megaport.SERVICE_CONFIGURED}, nil
+		},
+	})
+
+	err := r.waitForVXCProvision(context.Background(), "test-uid", time.Second, time.Millisecond)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, calls.Load(), int32(3))
+}
+
+func TestWaitForVXCProvision_TimesOut(t *testing.T) {
+	r := waitTestResource(&MockVXCService{
+		GetVXCResult: &megaport.VXC{ProvisioningStatus: "DEPLOYABLE"},
+	})
+
+	err := r.waitForVXCProvision(context.Background(), "test-uid", 20*time.Millisecond, time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "time expired")
+}
+
+func TestWaitForVXCProvision_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	r := waitTestResource(&MockVXCService{
+		GetVXCResult: &megaport.VXC{ProvisioningStatus: "DEPLOYABLE"},
+	})
+
+	err := r.waitForVXCProvision(ctx, "test-uid", time.Second, time.Millisecond)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/internal/provider/vxcs_data_source_test.go
+++ b/internal/provider/vxcs_data_source_test.go
@@ -21,6 +21,7 @@ type MockVXCService struct {
 	ListVXCsErr               error
 	GetVXCResult              *megaport.VXC
 	GetVXCErr                 error
+	GetVXCFunc                func(ctx context.Context, id string) (*megaport.VXC, error)
 	ListVXCResourceTagsFunc   func(ctx context.Context, vxcID string) (map[string]string, error)
 	ListVXCResourceTagsErr    error
 	ListVXCResourceTagsResult map[string]string
@@ -38,6 +39,9 @@ func (m *MockVXCService) ListVXCs(ctx context.Context, req *megaport.ListVXCsReq
 }
 
 func (m *MockVXCService) GetVXC(ctx context.Context, id string) (*megaport.VXC, error) {
+	if m.GetVXCFunc != nil {
+		return m.GetVXCFunc(ctx, id)
+	}
 	if m.GetVXCErr != nil {
 		return nil, m.GetVXCErr
 	}


### PR DESCRIPTION
Fixes an orphan window in `megaport_vxc` Create: a successful buy followed by any failure (wait timeout, transient read error, interrupted apply) returned without writing state. The VXC kept provisioning and billing, and every later apply retried the create and failed validation (`VLAN N not available ...`) because the orphan still held the slot. Confirmed in production on 2026-06-02 — the user could only recover by manually importing the VXC.

- Order without the SDK-internal wait, write the UID to state immediately after `BuyVXC` succeeds
- Poll for readiness in the provider, retrying transient `GetVXC` errors instead of aborting
- Failures after the buy now leave a tracked, tainted resource and say so in the error message
- Unit tests for the new wait helper

ESD-1314