### PR TITLE
test: fix MVE-to-MVE inner VLAN and parallel-contention failures (ESD-1548)

### DIFF
--- a/internal/provider/ix_resource_test.go
+++ b/internal/provider/ix_resource_test.go
@@ -15,6 +15,7 @@ func TestAccMegaportIX_Basic(t *testing.T) {
 	locationID, _ := findPortTestLocation(t, 1000)
 	ixName := RandomTestName()
 	portName := RandomTestName()
+	ixMAC := RandomMACAddress()
 	ixNameUpdated := ixName + "-updated"
 	ixRateLimit := 500
 	ixRateLimitUpdated := 750
@@ -35,12 +36,12 @@ resource "megaport_ix" "test_ix" {
     requested_product_uid = megaport_port.test_port.product_uid
     network_service_type = "Sydney IX"
     asn                 = 12345
-    mac_address         = "00:CA:FE:BA:BE:01"
+    mac_address         = "%s"
     rate_limit          = %d
     vlan                = %d
     shutdown            = false
 }
-`, portName, locationID, ixName, ixRateLimit, ixVLAN)
+`, portName, locationID, ixName, ixMAC, ixRateLimit, ixVLAN)
 
 	// Updated Terraform config
 	configUpdated := fmt.Sprintf(`
@@ -57,12 +58,12 @@ resource "megaport_ix" "test_ix" {
     requested_product_uid = megaport_port.test_port.product_uid
     network_service_type = "Sydney IX"
     asn                 = 12345
-    mac_address         = "00:CA:FE:BA:BE:01"
+    mac_address         = "%s"
     rate_limit          = %d
     vlan                = %d
     shutdown            = false
 }
-`, portName, locationID, ixNameUpdated, ixRateLimitUpdated, ixVLANUpdated)
+`, portName, locationID, ixNameUpdated, ixMAC, ixRateLimitUpdated, ixVLANUpdated)
 
 	resourceName := "megaport_ix.test_ix"
 
@@ -117,6 +118,7 @@ func TestAccMegaportIX_PromoCode(t *testing.T) {
 	locationID, _ := findPortTestLocation(t, 1000)
 	ixName := RandomTestName()
 	portName := RandomTestName()
+	ixMAC := RandomMACAddress()
 	initialPromo := testPromoCode()
 	const otherPromo = "tf-acc-test-promo-other"
 
@@ -135,13 +137,13 @@ resource "megaport_ix" "test_ix" {
     requested_product_uid = megaport_port.test_port.product_uid
     network_service_type  = "Sydney IX"
     asn                   = 12345
-    mac_address           = "00:CA:FE:BA:BE:01"
+    mac_address           = "%s"
     rate_limit            = 500
     vlan                  = 2001
     shutdown              = false
     %s
 }
-`, portName, locationID, ixName, promoLine)
+`, portName, locationID, ixName, ixMAC, promoLine)
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/mve_resource_test.go
+++ b/internal/provider/mve_resource_test.go
@@ -8,10 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const (
-	MVEArubaImageIDMVE = 152 // Aruba MVE image ID
-)
-
 func TestAccMegaportMVEAruba_Basic(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()
@@ -70,7 +66,7 @@ func TestAccMegaportMVEAruba_Basic(t *testing.T) {
 						description = "Extra Plane"
 					}
 					]
-                  }`, locationID, MVEArubaImageIDMVE, mveName, costCentre, mveName, mveKey),
+                  }`, locationID, MVEArubaImageID, mveName, costCentre, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_name", mveName),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", costCentre),
@@ -159,7 +155,7 @@ func TestAccMegaportMVEAruba_Basic(t *testing.T) {
 						description = "Extra Plane"
 					}
 					]
-                  }`, locationID, MVEArubaImageIDMVE, mveNameNew, costCentreNew, mveName, mveKey),
+                  }`, locationID, MVEArubaImageID, mveNameNew, costCentreNew, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_name", mveNameNew),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", costCentreNew),
@@ -254,7 +250,7 @@ func TestAccMegaportMVEAruba_CostCentreRemoval(t *testing.T) {
 					{
 						description = "Extra Plane"
 					}]
-				}`, locationID, MVEArubaImageIDMVE, mveName, costCentreName, mveName, mveKey),
+				}`, locationID, MVEArubaImageID, mveName, costCentreName, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", costCentreName),
 				),
@@ -298,7 +294,7 @@ func TestAccMegaportMVEAruba_CostCentreRemoval(t *testing.T) {
 					{
 						description = "Extra Plane"
 					}]
-				}`, locationID, MVEArubaImageIDMVE, mveName, mveName, mveKey),
+				}`, locationID, MVEArubaImageID, mveName, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", ""),
 				),
@@ -354,7 +350,7 @@ func TestAccMegaportMVEAruba_PromoCode(t *testing.T) {
 			{
 				description = "Extra Plane"
 			}]
-		}`, locationID, MVEArubaImageIDMVE, mveName, promoLine, mveName, mveKey)
+		}`, locationID, MVEArubaImageID, mveName, promoLine, mveName, mveKey)
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -427,7 +423,7 @@ func TestAccMegaportMVEAruba_ContractTermUpdate(t *testing.T) {
 					{
 						description = "Extra Plane"
 					}]
-				}`, locationID, MVEArubaImageIDMVE, mveName, mveName, mveKey),
+				}`, locationID, MVEArubaImageID, mveName, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "contract_term_months", "12"),
 					waitForProvisioningStatus("megaport_mve.mve"),
@@ -468,7 +464,7 @@ func TestAccMegaportMVEAruba_ContractTermUpdate(t *testing.T) {
 					{
 						description = "Extra Plane"
 					}]
-				}`, locationID, MVEArubaImageIDMVE, mveName, mveName, mveKey),
+				}`, locationID, MVEArubaImageID, mveName, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "contract_term_months", "24"),
 				),
@@ -719,7 +715,7 @@ func TestAccMegaportMVEImport_WithLifecycleIgnoreChanges(t *testing.T) {
                     {
                         description = "Control Plane"
                     }]
-                }`, locationID, MVEArubaImageIDMVE, mveName, costCentre, mveName, mveKey),
+                }`, locationID, MVEArubaImageID, mveName, costCentre, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.import_test", "product_name", mveName),
 				),
@@ -783,7 +779,7 @@ func TestAccMegaportMVEImport_WithLifecycleIgnoreChanges(t *testing.T) {
                     lifecycle {
                         ignore_changes = [vendor_config]
                     }
-                }`, locationID, MVEArubaImageIDMVE, mveName, costCentre, mveName, mveKey),
+                }`, locationID, MVEArubaImageID, mveName, costCentre, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.import_test", "product_name", mveName+"-updated"),
 					resource.TestCheckResourceAttr("megaport_mve.import_test", "cost_centre", costCentre+"-updated"),

--- a/internal/provider/test_helpers_test.go
+++ b/internal/provider/test_helpers_test.go
@@ -625,23 +625,23 @@ func findMCRTestLocation(t *testing.T, speedMbps int) (id int, name string) {
 // ("LongHaul Transit VXC must be in the same region"). Picking the MCR and
 // partner locations independently can straddle regions under parallel load.
 // Claims the location in the MCR pool.
-func findMCRWithPartnerTestLocation(t *testing.T, mcrSpeedMbps int, connectType string) (id int, name string) {
+func findMCRWithPartnerTestLocation(t *testing.T, mcrSpeedMbps int, connectType string) (id int) {
 	t.Helper()
 	ctx := context.Background()
 	client, err := getTestClient()
 	if err != nil {
 		t.Skipf("skipping: could not get test client: %v", err)
-		return 0, ""
+		return 0
 	}
 	locations, err := client.LocationService.ListLocationsV3(ctx)
 	if err != nil {
 		t.Skipf("skipping: could not list locations: %v", err)
-		return 0, ""
+		return 0
 	}
 	partnerPorts, err := client.PartnerService.ListPartnerMegaports(ctx)
 	if err != nil {
 		t.Skipf("skipping: could not list partner ports: %v", err)
-		return 0, ""
+		return 0
 	}
 	partnerLocs := map[int]bool{}
 	for _, pp := range partnerPorts {
@@ -661,11 +661,11 @@ func findMCRWithPartnerTestLocation(t *testing.T, mcrSpeedMbps int, connectType 
 				delete(mcrClaimedLocations, locID)
 			})
 			t.Logf("findMCRWithPartnerTestLocation(%s): using location %d (%s)", connectType, locID, loc.Name)
-			return locID, loc.Name
+			return locID
 		}
 	}
 	t.Skipf("skipping: no unclaimed ACTIVE location with %d Mbps MCR capacity and %s partner ports", mcrSpeedMbps, connectType)
-	return 0, ""
+	return 0
 }
 
 // findNATGatewayTestLocation returns a staging location ID that supports NAT

--- a/internal/provider/test_helpers_test.go
+++ b/internal/provider/test_helpers_test.go
@@ -618,6 +618,56 @@ func findMCRTestLocation(t *testing.T, speedMbps int) (id int, name string) {
 	return 0, ""
 }
 
+// findMCRWithPartnerTestLocation returns a single ACTIVE staging location that
+// supports an MCR at mcrSpeedMbps AND hosts a VXC-permitted partner port of
+// connectType. Provisioning both VXC ends at one location keeps them in the
+// same region, which the API enforces for partner types like TRANSIT
+// ("LongHaul Transit VXC must be in the same region"). Picking the MCR and
+// partner locations independently can straddle regions under parallel load.
+// Claims the location in the MCR pool.
+func findMCRWithPartnerTestLocation(t *testing.T, mcrSpeedMbps int, connectType string) (id int, name string) {
+	t.Helper()
+	ctx := context.Background()
+	client, err := getTestClient()
+	if err != nil {
+		t.Skipf("skipping: could not get test client: %v", err)
+		return 0, ""
+	}
+	locations, err := client.LocationService.ListLocationsV3(ctx)
+	if err != nil {
+		t.Skipf("skipping: could not list locations: %v", err)
+		return 0, ""
+	}
+	partnerPorts, err := client.PartnerService.ListPartnerMegaports(ctx)
+	if err != nil {
+		t.Skipf("skipping: could not list partner ports: %v", err)
+		return 0, ""
+	}
+	partnerLocs := map[int]bool{}
+	for _, pp := range partnerPorts {
+		if strings.EqualFold(pp.ConnectType, connectType) && pp.VXCPermitted {
+			partnerLocs[pp.LocationId] = true
+		}
+	}
+	mcrClaimedMu.Lock()
+	defer mcrClaimedMu.Unlock()
+	for _, loc := range locations {
+		if strings.EqualFold(loc.Status, "active") && mcrLocationHasCapacity(loc, mcrSpeedMbps) && partnerLocs[loc.ID] && !mcrClaimedLocations[loc.ID] {
+			locID := loc.ID
+			mcrClaimedLocations[locID] = true
+			t.Cleanup(func() {
+				mcrClaimedMu.Lock()
+				defer mcrClaimedMu.Unlock()
+				delete(mcrClaimedLocations, locID)
+			})
+			t.Logf("findMCRWithPartnerTestLocation(%s): using location %d (%s)", connectType, locID, loc.Name)
+			return locID, loc.Name
+		}
+	}
+	t.Skipf("skipping: no unclaimed ACTIVE location with %d Mbps MCR capacity and %s partner ports", mcrSpeedMbps, connectType)
+	return 0, ""
+}
+
 // findNATGatewayTestLocation returns a staging location ID that supports NAT
 // Gateway at the given speed (Mbps) in the "red" diversity zone. Calls t.Skip
 // if none found.

--- a/internal/provider/test_helpers_test.go
+++ b/internal/provider/test_helpers_test.go
@@ -125,7 +125,7 @@ func findMVETestLocation(t *testing.T, minCPUCores int) (id int, name string) {
 	return findMVETestLocationWithOpts(t, mveProbeOpts{
 		vendorConfig: &megaport.ArubaConfig{
 			Vendor:      "aruba",
-			ImageID:     MVEArubaImageIDMVE,
+			ImageID:     MVEArubaImageID,
 			ProductSize: "SMALL",
 			MVELabel:    "MVE 2/8",
 			AccountName: "probe",
@@ -169,7 +169,7 @@ func findMVEWithPartnerTestLocation(t *testing.T, connectType string) (id int) {
 	id, _ = findMVETestLocationWithOpts(t, mveProbeOpts{
 		vendorConfig: &megaport.ArubaConfig{
 			Vendor:      "aruba",
-			ImageID:     MVEArubaImageIDMVE,
+			ImageID:     MVEArubaImageID,
 			ProductSize: "SMALL",
 			MVELabel:    "MVE 2/8",
 			AccountName: "probe",
@@ -219,7 +219,7 @@ func findMVETestLocationHighCapacity(t *testing.T, count int) (id int, name stri
 				Term:       1,
 				VendorConfig: &megaport.ArubaConfig{
 					Vendor:      "aruba",
-					ImageID:     MVEArubaImageIDMVE,
+					ImageID:     MVEArubaImageID,
 					ProductSize: "SMALL",
 					MVELabel:    "MVE 2/8",
 					AccountName: fmt.Sprintf("probe-%d", i),
@@ -304,7 +304,7 @@ func findMVETestLocationBlueZone(t *testing.T) (id int, name string) {
 	return findMVETestLocationWithOpts(t, mveProbeOpts{
 		vendorConfig: &megaport.ArubaConfig{
 			Vendor:      "aruba",
-			ImageID:     MVEArubaImageIDMVE,
+			ImageID:     MVEArubaImageID,
 			ProductSize: "SMALL",
 			MVELabel:    "MVE 2/8",
 			AccountName: "probe",

--- a/internal/provider/test_helpers_test.go
+++ b/internal/provider/test_helpers_test.go
@@ -113,6 +113,8 @@ type mveProbeOpts struct {
 	vendorConfig  megaport.VendorConfig
 	diversityZone string
 	vnicCount     int
+	// locationFilter, if set, restricts candidates to locations it returns true for.
+	locationFilter func(*megaport.LocationV3) bool
 }
 
 // findMVETestLocation returns a staging location with confirmed Aruba SMALL MVE
@@ -133,6 +135,54 @@ func findMVETestLocation(t *testing.T, minCPUCores int) (id int, name string) {
 		diversityZone: "red",
 		vnicCount:     2,
 	})
+}
+
+// findMVEWithPartnerTestLocation returns a single ACTIVE staging location that
+// has confirmed Aruba SMALL MVE capacity AND hosts a VXC-permitted partner port
+// of connectType. Provisioning the MVE and the partner-facing VXC end at one
+// location keeps them in the same region, which the API enforces for partner
+// types like TRANSIT. Picking the MVE and partner locations independently can
+// straddle regions under parallel load. Claims the location in the MVE pool.
+func findMVEWithPartnerTestLocation(t *testing.T, connectType string) (id int) {
+	t.Helper()
+	ctx := context.Background()
+	client, err := getTestClient()
+	if err != nil {
+		t.Skipf("skipping: could not get test client: %v", err)
+		return 0
+	}
+	partnerPorts, err := client.PartnerService.ListPartnerMegaports(ctx)
+	if err != nil {
+		t.Skipf("skipping: could not list partner ports: %v", err)
+		return 0
+	}
+	partnerLocs := map[int]bool{}
+	for _, pp := range partnerPorts {
+		if strings.EqualFold(pp.ConnectType, connectType) && pp.VXCPermitted {
+			partnerLocs[pp.LocationId] = true
+		}
+	}
+	if len(partnerLocs) == 0 {
+		t.Skipf("skipping: no VXC-permitted %s partner ports found", connectType)
+		return 0
+	}
+	id, _ = findMVETestLocationWithOpts(t, mveProbeOpts{
+		vendorConfig: &megaport.ArubaConfig{
+			Vendor:      "aruba",
+			ImageID:     MVEArubaImageIDMVE,
+			ProductSize: "SMALL",
+			MVELabel:    "MVE 2/8",
+			AccountName: "probe",
+			AccountKey:  "probe",
+			SystemTag:   "Preconfiguration-aruba-test-1",
+		},
+		diversityZone: "red",
+		vnicCount:     2,
+		locationFilter: func(loc *megaport.LocationV3) bool {
+			return partnerLocs[loc.ID]
+		},
+	})
+	return id
 }
 
 // findMVETestLocationHighCapacity returns a staging location with enough capacity
@@ -477,6 +527,9 @@ func findMVETestLocationWithOpts(t *testing.T, opts mveProbeOpts) (id int, name 
 
 	probe := func(loc *megaport.LocationV3) bool {
 		if !strings.EqualFold(loc.Status, "active") || !loc.HasMVESupport() {
+			return false
+		}
+		if opts.locationFilter != nil && !opts.locationFilter(loc) {
 			return false
 		}
 		vnics := make([]megaport.MVENetworkInterface, opts.vnicCount)

--- a/internal/provider/test_utils.go
+++ b/internal/provider/test_utils.go
@@ -20,3 +20,18 @@ func RandomTestName(additionalNames ...string) string {
 func randomName(prefix string, length int) string {
 	return fmt.Sprintf("%s%s", prefix, acctest.RandString(length))
 }
+
+// RandomMACAddress returns a locally administered, unicast MAC address with
+// random octets. Tests must not share a MAC: the API rejects a port whose MAC
+// is already in use, which collides when tests run in parallel. The first
+// octet 0x02 marks the address locally administered and unicast, so it never
+// clashes with a real vendor OUI.
+func RandomMACAddress() string {
+	return fmt.Sprintf("02:%02X:%02X:%02X:%02X:%02X",
+		acctest.RandIntRange(0, 256),
+		acctest.RandIntRange(0, 256),
+		acctest.RandIntRange(0, 256),
+		acctest.RandIntRange(0, 256),
+		acctest.RandIntRange(0, 256),
+	)
+}

--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -4425,7 +4425,7 @@ func TestAccMegaportVXC_TransitInternetTagsUpdate(t *testing.T) {
 
 	// MCR and the TRANSIT partner port must share a region, so claim one
 	// location that satisfies both and use it for both ends.
-	mcrLocationID, _ := findMCRWithPartnerTestLocation(t, 1000, "TRANSIT")
+	mcrLocationID := findMCRWithPartnerTestLocation(t, 1000, "TRANSIT")
 	mcrName := RandomTestName()
 	vxcName := RandomTestName()
 
@@ -4514,7 +4514,7 @@ func TestAccMegaportVXC_IPsecTunnel(t *testing.T) {
 	defer acquireAccTestSlot(t)()
 	// MCR and the TRANSIT partner port must share a region, so claim one
 	// location that satisfies both and use it for both ends.
-	mcrLocID, _ := findMCRWithPartnerTestLocation(t, 1000, "TRANSIT")
+	mcrLocID := findMCRWithPartnerTestLocation(t, 1000, "TRANSIT")
 	mcrName := RandomTestName()
 	vxcName := RandomTestName()
 

--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -3518,6 +3518,12 @@ func TestAccMegaportMVE_to_MVE_VXC(t *testing.T) {
                     }
                 }
                 `,
+					// This step is expected to log a "VXC Update Propagation Delay" warning and
+					// take the full updateTimeout (120s): verifyUpdateApplied compares the
+					// requested inner_vlan=-1 directly against the API's returned value, which is
+					// 0 for an untagged end, so it never matches. This is not new flakiness; it's
+					// a known provider gap (verifyUpdateApplied doesn't normalize -1/0 the way
+					// fromAPIVXC's Read-path does), tracked in a separate follow-up ticket.
 					MVEArubaImageID,
 					mveName1, mveLocationID, mveName1, mveName1,
 					mveName2, mveLocationID, mveName2, mveName2,

--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -2107,8 +2107,6 @@ func TestMVE_TransitVXC(t *testing.T) {
 	// The MVE and the TRANSIT partner port must share a region, so claim one
 	// location that satisfies both and use it for both VXC ends.
 	mveLocID := findMVEWithPartnerTestLocation(t, "TRANSIT")
-	portName := RandomTestName()
-	costCentreName := RandomTestName()
 	mveName := RandomTestName()
 	transitVXCName := RandomTestName()
 
@@ -2119,15 +2117,6 @@ func TestMVE_TransitVXC(t *testing.T) {
 				Config: providerConfig + fmt.Sprintf(`
 				data "megaport_location" "loc1" {
 					id = %d
-				  }
-
-				  resource "megaport_port" "port" {
-					product_name           = "%s"
-					port_speed             = 1000
-					location_id            = data.megaport_location.loc1.id
-					contract_term_months   = 12
-					marketplace_visibility = true
-					cost_centre            = "%s"
 				  }
 
 				  data "megaport_partner" "internet_port" {
@@ -2181,7 +2170,7 @@ func TestMVE_TransitVXC(t *testing.T) {
 					  partner = "transit"
 					}
 				  }
-                  `, mveLocID, portName, costCentreName, mveName, MVEArubaImageID, mveName, mveName, transitVXCName),
+                  `, mveLocID, mveName, MVEArubaImageID, mveName, mveName, transitVXCName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("megaport_vxc.transit_vxc", "product_uid"),
 				),

--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -2104,10 +2104,9 @@ func TestAccMegaportOracleVXC_Basic(t *testing.T) {
 func TestMVE_TransitVXC(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()
-	// loc1 hosts the MVE (needs MVE capacity); loc2 needs TRANSIT partner ports.
-	mveLocID, _ := findMVETestLocation(t, 0)
-	transitLocs := findVXCPortTestLocationsWithPartner(t, 1, "TRANSIT")
-	locs := []int{mveLocID, transitLocs[0]}
+	// The MVE and the TRANSIT partner port must share a region, so claim one
+	// location that satisfies both and use it for both VXC ends.
+	mveLocID := findMVEWithPartnerTestLocation(t, "TRANSIT")
 	portName := RandomTestName()
 	costCentreName := RandomTestName()
 	mveName := RandomTestName()
@@ -2122,10 +2121,6 @@ func TestMVE_TransitVXC(t *testing.T) {
 					id = %d
 				  }
 
-				  data "megaport_location" "loc2" {
-					id = %d
-				  }
-
 				  resource "megaport_port" "port" {
 					product_name           = "%s"
 					port_speed             = 1000
@@ -2137,7 +2132,7 @@ func TestMVE_TransitVXC(t *testing.T) {
 
 				  data "megaport_partner" "internet_port" {
 					connect_type  = "TRANSIT"
-					location_id   = data.megaport_location.loc2.id
+					location_id   = data.megaport_location.loc1.id
 				  }
 
 				  resource "megaport_mve" "mve" {
@@ -2186,7 +2181,7 @@ func TestMVE_TransitVXC(t *testing.T) {
 					  partner = "transit"
 					}
 				  }
-                  `, locs[0], locs[1], portName, costCentreName, mveName, MVEArubaImageID, mveName, mveName, transitVXCName),
+                  `, mveLocID, portName, costCentreName, mveName, MVEArubaImageID, mveName, mveName, transitVXCName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("megaport_vxc.transit_vxc", "product_uid"),
 				),

--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -4423,8 +4423,9 @@ func TestAccMegaportVXC_TransitInternetTagsUpdate(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()
 
-	mcrLocationID, _ := findMCRTestLocation(t, 1000)
-	transitLocs := findVXCPortTestLocationsWithPartner(t, 1, "TRANSIT")
+	// MCR and the TRANSIT partner port must share a region, so claim one
+	// location that satisfies both and use it for both ends.
+	mcrLocationID, _ := findMCRWithPartnerTestLocation(t, 1000, "TRANSIT")
 	mcrName := RandomTestName()
 	vxcName := RandomTestName()
 
@@ -4468,7 +4469,7 @@ func TestAccMegaportVXC_TransitInternetTagsUpdate(t *testing.T) {
 
 				%s
 			}
-		`, mcrLocationID, transitLocs[0], mcrName, vxcName, extraVXCAttrs)
+		`, mcrLocationID, mcrLocationID, mcrName, vxcName, extraVXCAttrs)
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -4511,8 +4512,9 @@ func TestAccMegaportVXC_TransitInternetTagsUpdate(t *testing.T) {
 func TestAccMegaportVXC_IPsecTunnel(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()
-	mcrLocID, _ := findMCRTestLocation(t, 1000)
-	transitLocs := findVXCPortTestLocationsWithPartner(t, 1, "TRANSIT")
+	// MCR and the TRANSIT partner port must share a region, so claim one
+	// location that satisfies both and use it for both ends.
+	mcrLocID, _ := findMCRWithPartnerTestLocation(t, 1000, "TRANSIT")
 	mcrName := RandomTestName()
 	vxcName := RandomTestName()
 
@@ -4580,7 +4582,7 @@ func TestAccMegaportVXC_IPsecTunnel(t *testing.T) {
 
 			depends_on = [megaport_mcr_ipsec_addon.addon]
 		}
-	`, mcrLocID, transitLocs[0], mcrName, vxcName)
+	`, mcrLocID, mcrLocID, mcrName, vxcName)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -4435,13 +4435,9 @@ func TestAccMegaportVXC_TransitInternetTagsUpdate(t *testing.T) {
 				id = %d
 			}
 
-			data "megaport_location" "transit_loc" {
-				id = %d
-			}
-
 			data "megaport_partner" "internet_port" {
 				connect_type = "TRANSIT"
-				location_id  = data.megaport_location.transit_loc.id
+				location_id  = data.megaport_location.mcr_loc.id
 			}
 
 			resource "megaport_mcr" "mcr" {
@@ -4469,7 +4465,7 @@ func TestAccMegaportVXC_TransitInternetTagsUpdate(t *testing.T) {
 
 				%s
 			}
-		`, mcrLocationID, mcrLocationID, mcrName, vxcName, extraVXCAttrs)
+		`, mcrLocationID, mcrName, vxcName, extraVXCAttrs)
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -4523,10 +4519,6 @@ func TestAccMegaportVXC_IPsecTunnel(t *testing.T) {
 			id = %d
 		}
 
-		data "megaport_location" "transit_loc" {
-			id = %d
-		}
-
 		resource "megaport_mcr" "mcr" {
 			product_name         = "%s"
 			location_id          = data.megaport_location.mcr_loc.id
@@ -4542,7 +4534,7 @@ func TestAccMegaportVXC_IPsecTunnel(t *testing.T) {
 
 		data "megaport_partner" "internet_port" {
 			connect_type = "TRANSIT"
-			location_id  = data.megaport_location.transit_loc.id
+			location_id  = data.megaport_location.mcr_loc.id
 		}
 
 		resource "megaport_vxc" "ipsec_vxc" {
@@ -4582,7 +4574,7 @@ func TestAccMegaportVXC_IPsecTunnel(t *testing.T) {
 
 			depends_on = [megaport_mcr_ipsec_addon.addon]
 		}
-	`, mcrLocID, mcrLocID, mcrName, vxcName)
+	`, mcrLocID, mcrName, vxcName)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -3525,10 +3525,12 @@ func TestAccMegaportMVE_to_MVE_VXC(t *testing.T) {
                     a_end = {
                       requested_product_uid = megaport_mve.mve_3.product_uid
                       vnic_index            = 1
+                      inner_vlan            = -1
                     }
                     b_end = {
                       requested_product_uid = megaport_mve.mve_4.product_uid
                       vnic_index            = 1
+                      inner_vlan            = -1
                     }
                 }
                 `,
@@ -3549,6 +3551,8 @@ func TestAccMegaportMVE_to_MVE_VXC(t *testing.T) {
 					resource.TestCheckResourceAttr("megaport_vxc.mve_vxc", "product_name", vxcName),
 					resource.TestCheckResourceAttr("megaport_vxc.mve_vxc", "a_end.vnic_index", "1"),
 					resource.TestCheckResourceAttr("megaport_vxc.mve_vxc", "b_end.vnic_index", "1"),
+					resource.TestCheckResourceAttr("megaport_vxc.mve_vxc", "a_end.inner_vlan", "-1"),
+					resource.TestCheckResourceAttr("megaport_vxc.mve_vxc", "b_end.inner_vlan", "-1"),
 
 					// Verify VXC is now connected to the new MVEs
 					resource.TestCheckResourceAttrPair(


### PR DESCRIPTION
Fixes acceptance-test failures against staging. Acceptance tests are disabled in CI, so these went unnoticed. Most are the parallel-contention issues tracked under ESD-1548; the inner-VLAN fix is a related test bug found alongside them.

**MVE-to-MVE VXC move needs an explicit inner VLAN.** `TestAccMegaportMVE_to_MVE_VXC` step 2 re-homes the VXC onto a *different* multi-vNIC MVE with no inner VLAN, which staging rejects with `400 aEndInnerVlan is required`. The original connection is untagged, so the provider has nothing to carry forward and the config must supply one. Set `inner_vlan = -1` on both ends and assert it round-trips.

**Region-sensitive transit VXCs straddled regions under parallel load.** Tests that build a TRANSIT VXC picked the two ends' locations independently, so under contention they could land in different regions and hit `400 LongHaul Transit VXC must be in the same region`. Fixed by claiming one location that satisfies both ends:
- `TestAccMegaportVXC_TransitInternetTagsUpdate` and `..._IPsecTunnel` (MCR + TRANSIT) via new `findMCRWithPartnerTestLocation`.
- `TestMVE_TransitVXC` (MVE + TRANSIT) via new `findMVEWithPartnerTestLocation`, which claims a location that has both MVE capacity and a VXC-permitted TRANSIT partner port.

**IX tests collided on a shared MAC.** Parallel IX tests used a hardcoded MAC, so the second port was rejected with "MAC address is already in use". New `RandomMACAddress()` gives each test a unique locally-administered MAC.

All fixes verified passing against staging, including the contention cases run in parallel.
