### PR TITLE
fix: mask access_key in provider debug logs

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -191,7 +191,7 @@ func (p *megaportProvider) Configure(ctx context.Context, req provider.Configure
 	ctx = tflog.SetField(ctx, "secret_key", secretKey)
 	ctx = tflog.SetField(ctx, "terms_accepted", acceptTerms)
 	ctx = tflog.SetField(ctx, "wait_time", waitTime)
-	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "secret_key")
+	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "secret_key", "access_key")
 
 	tflog.Debug(ctx, "Creating Megaport client")
 


### PR DESCRIPTION
The provider sets `access_key` as a tflog field but only masks `secret_key`, so the access key is emitted in plaintext in `TF_LOG` output. This adds `access_key` to the `MaskFieldValuesWithFieldKeys` call.

One-line change, no schema/behavior impact.

Salvaged as a standalone fix from the stale `v2/pr-02-port-cleanup` branch (#336) as part of decomposing the v2 stack.