### PR TITLE
refactor(v2): extract configureMegaportResource helper

### DIFF
--- a/internal/provider/ix_resource.go
+++ b/internal/provider/ix_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -748,21 +747,9 @@ func (r *ixResource) ImportState(ctx context.Context, req resource.ImportStateRe
 
 // Configure adds the provider configured client to the resource.
 func (r *ixResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	data, ok := req.ProviderData.(*megaportProviderData)
+	data, ok := configureMegaportResource(req, resp)
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Provider Data Type",
-			fmt.Sprintf("Expected *megaportProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
 		return
 	}
-
-	client := data.client
-
-	r.client = client
+	r.client = data.client
 }

--- a/internal/provider/lag_port_resource.go
+++ b/internal/provider/lag_port_resource.go
@@ -669,20 +669,10 @@ func (r *lagPortResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 // Configure adds the provider configured client to the resource.
 func (r *lagPortResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	data, ok := req.ProviderData.(*megaportProviderData)
+	data, ok := configureMegaportResource(req, resp)
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Provider Data Type",
-			fmt.Sprintf("Expected *megaportProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
 		return
 	}
-
 	r.client = data.client
 }
 

--- a/internal/provider/mcr_resource.go
+++ b/internal/provider/mcr_resource.go
@@ -1283,23 +1283,11 @@ func (r *mcrResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 
 // Configure adds the provider configured client to the resource.
 func (r *mcrResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	data, ok := req.ProviderData.(*megaportProviderData)
+	data, ok := configureMegaportResource(req, resp)
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Provider Data Type",
-			fmt.Sprintf("Expected *megaportProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
 		return
 	}
-
-	client := data.client
-
-	r.client = client
+	r.client = data.client
 }
 
 func (r *mcrResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/mve_resource.go
+++ b/internal/provider/mve_resource.go
@@ -1030,23 +1030,11 @@ func (r *mveResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 
 // Configure adds the provider configured client to the resource.
 func (r *mveResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	data, ok := req.ProviderData.(*megaportProviderData)
+	data, ok := configureMegaportResource(req, resp)
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Provider Data Type",
-			fmt.Sprintf("Expected *megaportProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
 		return
 	}
-
-	client := data.client
-
-	r.client = client
+	r.client = data.client
 }
 
 func (r *mveResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -328,6 +328,21 @@ func (p *megaportProvider) Resources(_ context.Context) []func() resource.Resour
 	}
 }
 
+func configureMegaportResource(req resource.ConfigureRequest, resp *resource.ConfigureResponse) (*megaportProviderData, bool) {
+	if req.ProviderData == nil {
+		return nil, false
+	}
+	providerData, ok := req.ProviderData.(*megaportProviderData)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider Data Type",
+			fmt.Sprintf("Expected *megaportProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return nil, false
+	}
+	return providerData, true
+}
+
 func toResourceTagMap(ctx context.Context, in types.Map) (map[string]string, diag.Diagnostics) {
 	tags := map[string]string{}
 	diags := in.ElementsAs(ctx, &tags, false)

--- a/internal/provider/single_port_resource.go
+++ b/internal/provider/single_port_resource.go
@@ -640,20 +640,10 @@ func (r *portResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 // Configure adds the provider configured client to the resource.
 func (r *portResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	data, ok := req.ProviderData.(*megaportProviderData)
+	data, ok := configureMegaportResource(req, resp)
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Provider Data Type",
-			fmt.Sprintf("Expected *megaportProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
 		return
 	}
-
 	r.client = data.client
 }
 


### PR DESCRIPTION
Collapse the identical `ProviderData` type-assertion boilerplate in five resource `Configure` methods into one shared helper in `provider.go`.

- New `configureMegaportResource(req, resp)` helper returns `(*megaportProviderData, bool)`.
- Rewired `port`, `lag_port`, `mcr`, `mve`, and `ix` to use it.
- Behavior-preserving: same error title/message and same nil / type-mismatch handling.

`vxc` is intentionally left out (its Configure carries a different, "Data Source"-worded message, and the file has other work in flight). Net -42 lines. Build, lint, and unit tests pass.