### PR TITLE
chore: deprecate legacy computed metadata on port and lag_port

### DIFF
--- a/docs/resources/lag_port.md
+++ b/docs/resources/lag_port.md
@@ -45,26 +45,26 @@ resource "megaport_lag_port" "lag_port" {
 
 ### Read-Only
 
-- `cancelable` (Boolean) Whether the product is cancelable.
+- `cancelable` (Boolean, Deprecated) Whether the product is cancelable.
 - `company_uid` (String) The unique identifier of the company.
-- `contract_end_date` (String) The date the contract ends.
-- `contract_start_date` (String) The date the contract started.
-- `create_date` (String) The date the product was created.
-- `created_by` (String) The user who created the product.
+- `contract_end_date` (String, Deprecated) The date the contract ends.
+- `contract_start_date` (String, Deprecated) The date the contract started.
+- `create_date` (String, Deprecated) The date the product was created.
+- `created_by` (String, Deprecated) The user who created the product.
 - `lag_port_uids` (List of String) The unique identifiers of the LAG ports.
-- `last_updated` (String) The last time the resource was updated.
-- `live_date` (String) The date the product went live.
-- `locked` (Boolean) Whether the product is locked.
-- `market` (String) The market the product is in.
-- `product_id` (Number) The numeric ID of the product.
+- `last_updated` (String, Deprecated) The last time the resource was updated.
+- `live_date` (String, Deprecated) The date the product went live.
+- `locked` (Boolean, Deprecated) Whether the product is locked.
+- `market` (String, Deprecated) The market the product is in.
+- `product_id` (Number, Deprecated) The numeric ID of the product.
 - `product_uid` (String) The unique identifier for the resource.
-- `provisioning_status` (String) The provisioning status of the LAG port. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the port lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.
+- `provisioning_status` (String, Deprecated) The provisioning status of the LAG port. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the port lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.
 - `resources` (Attributes) Resources attached to port. (see [below for nested schema](#nestedatt--resources))
-- `terminate_date` (String) The date the product will be terminated.
-- `usage_algorithm` (String) The usage algorithm for the product.
-- `virtual` (Boolean) Whether the product is virtual. Always false for LAG orders.
-- `vxc_auto_approval` (Boolean) Whether VXC is auto-approved on this product.
-- `vxc_permitted` (Boolean) Whether VXC is permitted on this product.
+- `terminate_date` (String, Deprecated) The date the product will be terminated.
+- `usage_algorithm` (String, Deprecated) The usage algorithm for the product.
+- `virtual` (Boolean, Deprecated) Whether the product is virtual. Always false for LAG orders.
+- `vxc_auto_approval` (Boolean, Deprecated) Whether VXC is auto-approved on this product.
+- `vxc_permitted` (Boolean, Deprecated) Whether VXC is permitted on this product.
 
 <a id="nestedatt--resources"></a>
 ### Nested Schema for `resources`

--- a/docs/resources/port.md
+++ b/docs/resources/port.md
@@ -43,25 +43,25 @@ resource "megaport_port" "port" {
 
 ### Read-Only
 
-- `cancelable` (Boolean) Whether the product is cancelable.
+- `cancelable` (Boolean, Deprecated) Whether the product is cancelable.
 - `company_uid` (String) The unique identifier of the company.
-- `contract_end_date` (String) The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `contract_start_date` (String) The date the contract starts. This value is managed by the Megaport API and may be updated when the port is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `create_date` (String) The date the port was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `created_by` (String) The user who created the product.
-- `last_updated` (String) The last time the resource was updated.
-- `live_date` (String) The date the port went live. This value is set by the Megaport API when the port becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `locked` (Boolean) Whether the product is locked.
-- `market` (String) The market the product is in.
-- `product_id` (Number) The numeric ID of the product.
+- `contract_end_date` (String, Deprecated) The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `contract_start_date` (String, Deprecated) The date the contract starts. This value is managed by the Megaport API and may be updated when the port is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `create_date` (String, Deprecated) The date the port was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `created_by` (String, Deprecated) The user who created the product.
+- `last_updated` (String, Deprecated) The last time the resource was updated.
+- `live_date` (String, Deprecated) The date the port went live. This value is set by the Megaport API when the port becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `locked` (Boolean, Deprecated) Whether the product is locked.
+- `market` (String, Deprecated) The market the product is in.
+- `product_id` (Number, Deprecated) The numeric ID of the product.
 - `product_uid` (String) The unique identifier for the resource.
-- `provisioning_status` (String) The provisioning status of the port. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the port lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.
+- `provisioning_status` (String, Deprecated) The provisioning status of the port. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the port lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.
 - `resources` (Attributes) Resources attached to port. (see [below for nested schema](#nestedatt--resources))
-- `terminate_date` (String) The date the port will be or was terminated. This value is set by the Megaport API when termination is scheduled or completed. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `usage_algorithm` (String) The usage algorithm for the product.
-- `virtual` (Boolean) Whether the product is virtual.
-- `vxc_auto_approval` (Boolean) Whether VXC is auto-approved on this product.
-- `vxc_permitted` (Boolean) Whether VXC is permitted on this product.
+- `terminate_date` (String, Deprecated) The date the port will be or was terminated. This value is set by the Megaport API when termination is scheduled or completed. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `usage_algorithm` (String, Deprecated) The usage algorithm for the product.
+- `virtual` (Boolean, Deprecated) Whether the product is virtual.
+- `vxc_auto_approval` (Boolean, Deprecated) Whether VXC is auto-approved on this product.
+- `vxc_permitted` (Boolean, Deprecated) Whether VXC is permitted on this product.
 
 <a id="nestedatt--resources"></a>
 ### Nested Schema for `resources`

--- a/internal/provider/lag_port_resource.go
+++ b/internal/provider/lag_port_resource.go
@@ -160,8 +160,9 @@ func (r *lagPortResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 		Description: "Link Aggregation Group (LAG) Port Resource for the Megaport Terraform Provider. This can be used to create, modify, and delete Megaport LAG Ports. A LAG bundles physical ports to create a single data path, where the traffic load is distributed among the ports to increase overall connection reliability.",
 		Attributes: map[string]schema.Attribute{
 			"last_updated": schema.StringAttribute{
-				Description: "The last time the resource was updated.",
-				Computed:    true,
+				Description:        "The last time the resource was updated.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"product_uid": schema.StringAttribute{
 				Description: "The unique identifier for the resource.",
@@ -171,8 +172,9 @@ func (r *lagPortResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				},
 			},
 			"product_id": schema.Int64Attribute{
-				Description: "The numeric ID of the product.",
-				Computed:    true,
+				Description:        "The numeric ID of the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
@@ -182,16 +184,19 @@ func (r *lagPortResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Required:    true,
 			},
 			"provisioning_status": schema.StringAttribute{
-				Description: "The provisioning status of the LAG port. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the port lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.",
-				Computed:    true,
+				Description:        "The provisioning status of the LAG port. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the port lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"create_date": schema.StringAttribute{
-				Description: "The date the product was created.",
-				Computed:    true,
+				Description:        "The date the product was created.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"created_by": schema.StringAttribute{
-				Description: "The user who created the product.",
-				Computed:    true,
+				Description:        "The user who created the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -207,16 +212,19 @@ func (r *lagPortResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				},
 			},
 			"terminate_date": schema.StringAttribute{
-				Description: "The date the product will be terminated.",
-				Computed:    true,
+				Description:        "The date the product will be terminated.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"live_date": schema.StringAttribute{
-				Description: "The date the product went live.",
-				Computed:    true,
+				Description:        "The date the product went live.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"market": schema.StringAttribute{
-				Description: "The market the product is in.",
-				Computed:    true,
+				Description:        "The market the product is in.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -243,8 +251,9 @@ func (r *lagPortResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				},
 			},
 			"usage_algorithm": schema.StringAttribute{
-				Description: "The usage algorithm for the product.",
-				Computed:    true,
+				Description:        "The usage algorithm for the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"company_uid": schema.StringAttribute{
 				Description: "The unique identifier of the company.",
@@ -262,48 +271,55 @@ func (r *lagPortResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				},
 			},
 			"contract_start_date": schema.StringAttribute{
-				Description: "The date the contract started.",
-				Computed:    true,
+				Description:        "The date the contract started.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"contract_end_date": schema.StringAttribute{
-				Description: "The date the contract ends.",
-				Computed:    true,
+				Description:        "The date the contract ends.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"marketplace_visibility": schema.BoolAttribute{
 				Description: "Whether the product is visible in the marketplace.",
 				Required:    true,
 			},
 			"vxc_permitted": schema.BoolAttribute{
-				Description: "Whether VXC is permitted on this product.",
-				Computed:    true,
+				Description:        "Whether VXC is permitted on this product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"vxc_auto_approval": schema.BoolAttribute{
-				Description: "Whether VXC is auto-approved on this product.",
-				Computed:    true,
+				Description:        "Whether VXC is auto-approved on this product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"virtual": schema.BoolAttribute{
-				Description: "Whether the product is virtual. Always false for LAG orders.",
-				Computed:    true,
+				Description:        "Whether the product is virtual. Always false for LAG orders.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"locked": schema.BoolAttribute{
-				Description: "Whether the product is locked.",
-				Computed:    true,
+				Description:        "Whether the product is locked.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"cancelable": schema.BoolAttribute{
-				Description: "Whether the product is cancelable.",
-				Computed:    true,
+				Description:        "Whether the product is cancelable.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},

--- a/internal/provider/single_port_resource.go
+++ b/internal/provider/single_port_resource.go
@@ -171,8 +171,9 @@ func (r *portResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 		Description: "Single Port Resource for the Megaport Terraform Provider. This can be used to create, modify, and delete Megaport Ports. Your organization’s Port is the physical point of connection between your organization’s network and the Megaport network. You will need to deploy a Port wherever you want to direct traffic.",
 		Attributes: map[string]schema.Attribute{
 			"last_updated": schema.StringAttribute{
-				Description: "The last time the resource was updated.",
-				Computed:    true,
+				Description:        "The last time the resource was updated.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"product_uid": schema.StringAttribute{
 				Description: "The unique identifier for the resource.",
@@ -182,8 +183,9 @@ func (r *portResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				},
 			},
 			"product_id": schema.Int64Attribute{
-				Description: "The numeric ID of the product.",
-				Computed:    true,
+				Description:        "The numeric ID of the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
@@ -193,16 +195,19 @@ func (r *portResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				Required:    true,
 			},
 			"provisioning_status": schema.StringAttribute{
-				Description: "The provisioning status of the port. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the port lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.",
-				Computed:    true,
+				Description:        "The provisioning status of the port. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the port lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"create_date": schema.StringAttribute{
-				Description: "The date the port was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
+				Description:        "The date the port was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"created_by": schema.StringAttribute{
-				Description: "The user who created the product.",
-				Computed:    true,
+				Description:        "The user who created the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -218,16 +223,19 @@ func (r *portResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				},
 			},
 			"terminate_date": schema.StringAttribute{
-				Description: "The date the port will be or was terminated. This value is set by the Megaport API when termination is scheduled or completed. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
+				Description:        "The date the port will be or was terminated. This value is set by the Megaport API when termination is scheduled or completed. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"live_date": schema.StringAttribute{
-				Description: "The date the port went live. This value is set by the Megaport API when the port becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
+				Description:        "The date the port went live. This value is set by the Megaport API when the port becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"market": schema.StringAttribute{
-				Description: "The market the product is in.",
-				Computed:    true,
+				Description:        "The market the product is in.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -247,8 +255,9 @@ func (r *portResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				},
 			},
 			"usage_algorithm": schema.StringAttribute{
-				Description: "The usage algorithm for the product.",
-				Computed:    true,
+				Description:        "The usage algorithm for the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -276,48 +285,55 @@ func (r *portResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				},
 			},
 			"contract_start_date": schema.StringAttribute{
-				Description: "The date the contract starts. This value is managed by the Megaport API and may be updated when the port is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
+				Description:        "The date the contract starts. This value is managed by the Megaport API and may be updated when the port is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"contract_end_date": schema.StringAttribute{
-				Description: "The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
+				Description:        "The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"marketplace_visibility": schema.BoolAttribute{
 				Description: "Whether the product is visible in the marketplace. By default, the Port is private to your enterprise and consumes services from the Megaport network for your own internal company, team, and resources. When set to Private, the Port is not searchable in the Megaport Marketplace (however, others can still connect to you using a service key). Click Public to make the new Port and profile visible on the Megaport network for inbound connection requests. It is possible to change the Port from Private to Public after the initial setup.",
 				Required:    true,
 			},
 			"vxc_permitted": schema.BoolAttribute{
-				Description: "Whether VXC is permitted on this product.",
-				Computed:    true,
+				Description:        "Whether VXC is permitted on this product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"vxc_auto_approval": schema.BoolAttribute{
-				Description: "Whether VXC is auto-approved on this product.",
-				Computed:    true,
+				Description:        "Whether VXC is auto-approved on this product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"virtual": schema.BoolAttribute{
-				Description: "Whether the product is virtual.",
-				Computed:    true,
+				Description:        "Whether the product is virtual.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"locked": schema.BoolAttribute{
-				Description: "Whether the product is locked.",
-				Computed:    true,
+				Description:        "Whether the product is locked.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"cancelable": schema.BoolAttribute{
-				Description: "Whether the product is cancelable.",
-				Computed:    true,
+				Description:        "Whether the product is cancelable.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},


### PR DESCRIPTION
Marks the read-only bookkeeping attributes on `megaport_port` and `megaport_lag_port` as deprecated. These echo API metadata and clutter state without being useful in config.

Deprecated (16 per resource): `product_id`, `provisioning_status`, `create_date`, `created_by`, `last_updated`, `live_date`, `terminate_date`, `contract_start_date`, `contract_end_date`, `market`, `usage_algorithm`, `virtual`, `locked`, `cancelable`, `vxc_permitted`, `vxc_auto_approval`.

Non-breaking: the attributes still populate as before; anyone referencing them now gets a deprecation warning ahead of removal in a future major release. Docs regenerated. This is the first of a per-resource series (mcr/mve/vxc to follow).