### PR TITLE
chore: deprecate legacy computed metadata on mve

### DIFF
--- a/docs/resources/mve.md
+++ b/docs/resources/mve.md
@@ -184,33 +184,33 @@ resource "megaport_mve" "mve_sixwind_dynamic" {
 
 ### Read-Only
 
-- `admin_locked` (Boolean) Whether the MVE is admin locked.
+- `admin_locked` (Boolean, Deprecated) Whether the MVE is admin locked.
 - `attribute_tags` (Map of String) The attribute tags of the MVE.
-- `buyout_port` (Boolean) Whether the port is buyout.
-- `cancelable` (Boolean) Whether the MVE is cancelable.
-- `company_name` (String) The company name of the MVE.
+- `buyout_port` (Boolean, Deprecated) Whether the port is buyout.
+- `cancelable` (Boolean, Deprecated) Whether the MVE is cancelable.
+- `company_name` (String, Deprecated) The company name of the MVE.
 - `company_uid` (String) The company UID of the MVE.
-- `contract_end_date` (String) The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `contract_start_date` (String) The date the contract starts. This value is managed by the Megaport API and may be updated when the MVE is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `create_date` (String) The date the MVE was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `created_by` (String) The user who created the MVE.
-- `last_updated` (String) The last time the MVE was updated by the Terraform Provider.
-- `live_date` (String) The date the MVE went live. This value is set by the Megaport API when the MVE becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `locked` (Boolean) Whether the MVE is locked.
-- `market` (String) The market the MVE is in.
+- `contract_end_date` (String, Deprecated) The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `contract_start_date` (String, Deprecated) The date the contract starts. This value is managed by the Megaport API and may be updated when the MVE is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `create_date` (String, Deprecated) The date the MVE was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `created_by` (String, Deprecated) The user who created the MVE.
+- `last_updated` (String, Deprecated) The last time the MVE was updated by the Terraform Provider.
+- `live_date` (String, Deprecated) The date the MVE went live. This value is set by the Megaport API when the MVE becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `locked` (Boolean, Deprecated) Whether the MVE is locked.
+- `market` (String, Deprecated) The market the MVE is in.
 - `marketplace_visibility` (Boolean) Whether the MVE is visible in the marketplace.
 - `mve_size` (String) The size of the MVE.
-- `product_id` (Number) The Numeric ID of the MVE.
-- `product_type` (String) The type of product (MVE).
+- `product_id` (Number, Deprecated) The Numeric ID of the MVE.
+- `product_type` (String, Deprecated) The type of product (MVE).
 - `product_uid` (String) The unique identifier of the MVE.
-- `provisioning_status` (String) The provisioning status of the MVE. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the MVE lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.
-- `secondary_name` (String) The secondary name of the MVE.
-- `terminate_date` (String) The date the MVE will be or was terminated. This value is set by the Megaport API when termination is scheduled or completed. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `usage_algorithm` (String) The usage algorithm of the MVE.
+- `provisioning_status` (String, Deprecated) The provisioning status of the MVE. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the MVE lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.
+- `secondary_name` (String, Deprecated) The secondary name of the MVE.
+- `terminate_date` (String, Deprecated) The date the MVE will be or was terminated. This value is set by the Megaport API when termination is scheduled or completed. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `usage_algorithm` (String, Deprecated) The usage algorithm of the MVE.
 - `vendor` (String) The vendor of the MVE.
-- `virtual` (Boolean) Whether the MVE is virtual.
-- `vxc_auto_approval` (Boolean) Whether VXC is auto approved.
-- `vxc_permitted` (Boolean) Whether VXC is permitted.
+- `virtual` (Boolean, Deprecated) Whether the MVE is virtual.
+- `vxc_auto_approval` (Boolean, Deprecated) Whether VXC is auto approved.
+- `vxc_permitted` (Boolean, Deprecated) Whether VXC is permitted.
 
 <a id="nestedatt--vendor_config"></a>
 ### Nested Schema for `vendor_config`

--- a/docs/resources/mve.md
+++ b/docs/resources/mve.md
@@ -258,7 +258,7 @@ Required:
 
 Read-Only:
 
-- `vlan` (Number) The VLAN of the network interface.
+- `vlan` (Number, Deprecated) The VLAN of the network interface.
 
 ## Import
 

--- a/internal/provider/mve_resource.go
+++ b/internal/provider/mve_resource.go
@@ -593,8 +593,9 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 							Required:    true,
 						},
 						"vlan": schema.Int64Attribute{
-							Description: "The VLAN of the network interface.",
-							Computed:    true,
+							Description:        "The VLAN of the network interface.",
+							Computed:           true,
+							DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
 							PlanModifiers: []planmodifier.Int64{
 								int64planmodifier.UseStateForUnknown(),
 							},

--- a/internal/provider/mve_resource.go
+++ b/internal/provider/mve_resource.go
@@ -354,8 +354,9 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 		Description: "Megaport Virtual Edge (MVE) Resource for Megaport Terraform provider. This resource allows you to create, modify, and delete Megaport MVEs. Megaport Virtual Edge (MVE) is an on-demand, vendor-neutral Network Function Virtualization (NFV) platform that provides virtual infrastructure for network services at the edge of Megaport’s global software-defined network (SDN). Network technologies such as SD-WAN and NGFW are hosted directly on Megaport’s global network via Megaport Virtual Edge. Use the `megaport_mve_sizes` data source to query available MVE sizes and the `megaport_mve_images` data source to query available MVE images.",
 		Attributes: map[string]schema.Attribute{
 			"last_updated": schema.StringAttribute{
-				Description: "The last time the MVE was updated by the Terraform Provider.",
-				Computed:    true,
+				Description:        "The last time the MVE was updated by the Terraform Provider.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"product_uid": schema.StringAttribute{
 				Description: "The unique identifier of the MVE.",
@@ -365,8 +366,9 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"product_id": schema.Int64Attribute{
-				Description: "The Numeric ID of the MVE.",
-				Computed:    true,
+				Description:        "The Numeric ID of the MVE.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
@@ -376,30 +378,35 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				Required:    true,
 			},
 			"provisioning_status": schema.StringAttribute{
-				Description: "The provisioning status of the MVE. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the MVE lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.",
-				Computed:    true,
+				Description:        "The provisioning status of the MVE. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the MVE lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"create_date": schema.StringAttribute{
-				Description: "The date the MVE was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
+				Description:        "The date the MVE was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"created_by": schema.StringAttribute{
-				Description: "The user who created the MVE.",
-				Computed:    true,
+				Description:        "The user who created the MVE.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"terminate_date": schema.StringAttribute{
-				Description: "The date the MVE will be or was terminated. This value is set by the Megaport API when termination is scheduled or completed. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
+				Description:        "The date the MVE will be or was terminated. This value is set by the Megaport API when termination is scheduled or completed. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"live_date": schema.StringAttribute{
-				Description: "The date the MVE went live. This value is set by the Megaport API when the MVE becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
+				Description:        "The date the MVE went live. This value is set by the Megaport API when the MVE becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"diversity_zone": schema.StringAttribute{
 				Description: "The diversity zone of the MVE.",
@@ -411,8 +418,9 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"market": schema.StringAttribute{
-				Description: "The market the MVE is in.",
-				Computed:    true,
+				Description:        "The market the MVE is in.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -425,8 +433,9 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"product_type": schema.StringAttribute{
-				Description: "The type of product (MVE).",
-				Computed:    true,
+				Description:        "The type of product (MVE).",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -439,8 +448,9 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"usage_algorithm": schema.StringAttribute{
-				Description: "The usage algorithm of the MVE.",
-				Computed:    true,
+				Description:        "The usage algorithm of the MVE.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -453,12 +463,14 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"contract_start_date": schema.StringAttribute{
-				Description: "The date the contract starts. This value is managed by the Megaport API and may be updated when the MVE is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
+				Description:        "The date the contract starts. This value is managed by the Megaport API and may be updated when the MVE is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"contract_end_date": schema.StringAttribute{
-				Description: "The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
+				Description:        "The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"cost_centre": schema.StringAttribute{
 				Description: "The cost centre of the MVE.",
@@ -473,64 +485,73 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"vxc_permitted": schema.BoolAttribute{
-				Description: "Whether VXC is permitted.",
-				Computed:    true,
+				Description:        "Whether VXC is permitted.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"vxc_auto_approval": schema.BoolAttribute{
-				Description: "Whether VXC is auto approved.",
-				Computed:    true,
+				Description:        "Whether VXC is auto approved.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"secondary_name": schema.StringAttribute{
-				Description: "The secondary name of the MVE.",
-				Computed:    true,
+				Description:        "The secondary name of the MVE.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"company_name": schema.StringAttribute{
-				Description: "The company name of the MVE.",
-				Computed:    true,
+				Description:        "The company name of the MVE.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"virtual": schema.BoolAttribute{
-				Description: "Whether the MVE is virtual.",
-				Computed:    true,
+				Description:        "Whether the MVE is virtual.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"buyout_port": schema.BoolAttribute{
-				Description: "Whether the port is buyout.",
-				Computed:    true,
+				Description:        "Whether the port is buyout.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"locked": schema.BoolAttribute{
-				Description: "Whether the MVE is locked.",
-				Computed:    true,
+				Description:        "Whether the MVE is locked.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"admin_locked": schema.BoolAttribute{
-				Description: "Whether the MVE is admin locked.",
-				Computed:    true,
+				Description:        "Whether the MVE is admin locked.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"cancelable": schema.BoolAttribute{
-				Description: "Whether the MVE is cancelable.",
-				Computed:    true,
+				Description:        "Whether the MVE is cancelable.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},


### PR DESCRIPTION
Adds a `DeprecationMessage` to 21 read-only, computed metadata attributes on the `megaport_mve` resource: `last_updated`, `product_id`, `product_type`, `provisioning_status`, `create_date`, `created_by`, `terminate_date`, `live_date`, `contract_start_date`, `contract_end_date`, `market`, `usage_algorithm`, `secondary_name`, `company_name`, `virtual`, `locked`, `admin_locked`, `cancelable`, `buyout_port`, `vxc_permitted`, and `vxc_auto_approval`.

This is non-breaking: the attributes still populate and behave exactly as before, users just get a deprecation warning ahead of removal in a future major release. Docs regenerated. This is part of a per-resource series applying the same deprecations across resources.