### PR TITLE
chore: deprecate legacy computed metadata on mcr

### DIFF
--- a/docs/resources/mcr.md
+++ b/docs/resources/mcr.md
@@ -42,34 +42,34 @@ resource "megaport_mcr" "mcr" {
 
 ### Read-Only
 
-- `admin_locked` (Boolean) Whether the product is admin locked.
-- `aggregation_id` (Number) Numeric ID of the aggregation.
+- `admin_locked` (Boolean, Deprecated) Whether the product is admin locked.
+- `aggregation_id` (Number, Deprecated) Numeric ID of the aggregation.
 - `attribute_tags` (Map of String) Attribute tags of the product.
-- `buyout_port` (Boolean) Whether the product is bought out.
-- `cancelable` (Boolean) Whether the product is cancelable.
-- `company_name` (String) Name of the company.
+- `buyout_port` (Boolean, Deprecated) Whether the product is bought out.
+- `cancelable` (Boolean, Deprecated) Whether the product is cancelable.
+- `company_name` (String, Deprecated) Name of the company.
 - `company_uid` (String) Megaport Company UID of the product.
-- `contract_end_date` (String) Contract end date of the product.
-- `contract_start_date` (String) Contract start date of the product.
-- `create_date` (String) The date the MCR was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `created_by` (String) User who created the product.
-- `lag_id` (Number) Numeric ID of the LAG.
-- `lag_primary` (Boolean) Whether the product is a LAG primary.
-- `last_updated` (String) Last updated by the Terraform provider.
-- `live_date` (String) The date the MCR went live. This value is set by the Megaport API when the MCR becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `locked` (Boolean) Whether the product is locked.
-- `market` (String) Market the product is in.
+- `contract_end_date` (String, Deprecated) Contract end date of the product.
+- `contract_start_date` (String, Deprecated) Contract start date of the product.
+- `create_date` (String, Deprecated) The date the MCR was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `created_by` (String, Deprecated) User who created the product.
+- `lag_id` (Number, Deprecated) Numeric ID of the LAG.
+- `lag_primary` (Boolean, Deprecated) Whether the product is a LAG primary.
+- `last_updated` (String, Deprecated) Last updated by the Terraform provider.
+- `live_date` (String, Deprecated) The date the MCR went live. This value is set by the Megaport API when the MCR becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `locked` (Boolean, Deprecated) Whether the product is locked.
+- `market` (String, Deprecated) Market the product is in.
 - `marketplace_visibility` (Boolean) Whether the product is visible in the Marketplace.
-- `product_id` (Number) Numeric ID of the product.
-- `product_type` (String) Type of the product.
+- `product_id` (Number, Deprecated) Numeric ID of the product.
+- `product_type` (String, Deprecated) Type of the product.
 - `product_uid` (String) UID identifier of the product.
-- `provisioning_status` (String) Provisioning status of the product.
-- `secondary_name` (String) Secondary name of the product.
-- `terminate_date` (String) Date the product will be terminated.
-- `usage_algorithm` (String) Usage algorithm of the product.
-- `virtual` (Boolean) Whether the product is virtual.
-- `vxc_auto_approval` (Boolean) Whether VXC is auto approved.
-- `vxc_permitted` (Boolean) Whether VXC is permitted.
+- `provisioning_status` (String, Deprecated) Provisioning status of the product.
+- `secondary_name` (String, Deprecated) Secondary name of the product.
+- `terminate_date` (String, Deprecated) Date the product will be terminated.
+- `usage_algorithm` (String, Deprecated) Usage algorithm of the product.
+- `virtual` (Boolean, Deprecated) Whether the product is virtual.
+- `vxc_auto_approval` (Boolean, Deprecated) Whether VXC is auto approved.
+- `vxc_permitted` (Boolean, Deprecated) Whether VXC is permitted.
 
 <a id="nestedatt--prefix_filter_lists"></a>
 ### Nested Schema for `prefix_filter_lists`

--- a/internal/provider/mcr_resource.go
+++ b/internal/provider/mcr_resource.go
@@ -368,8 +368,9 @@ func (r *mcrResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 		Description: "Megaport Cloud Router (MCR) Resource for the Megaport Terraform Provider. This can be used to create, modify, and delete Megaport MCRs. The MCR is a managed virtual router service that establishes Layer 3 connectivity on the worldwide Megaport software-defined network (SDN). MCR instances are preconfigured in data centers in key global routing zones. An MCR enables data transfer between multi-cloud or hybrid cloud networks, network service providers, and cloud service providers.",
 		Attributes: map[string]schema.Attribute{
 			"last_updated": schema.StringAttribute{
-				Description: "Last updated by the Terraform provider.",
-				Computed:    true,
+				Description:        "Last updated by the Terraform provider.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"product_uid": schema.StringAttribute{
 				Description: "UID identifier of the product.",
@@ -379,8 +380,9 @@ func (r *mcrResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"product_id": schema.Int64Attribute{
-				Description: "Numeric ID of the product.",
-				Computed:    true,
+				Description:        "Numeric ID of the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
@@ -390,15 +392,17 @@ func (r *mcrResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				Required:    true,
 			},
 			"product_type": schema.StringAttribute{
-				Description: "Type of the product.",
-				Computed:    true,
+				Description:        "Type of the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"provisioning_status": schema.StringAttribute{
-				Description: "Provisioning status of the product.",
-				Computed:    true,
+				Description:        "Provisioning status of the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"diversity_zone": schema.StringAttribute{
 				Description: "Diversity zone of the product. If the parameter is not provided, a diversity zone will be automatically allocated.",
@@ -417,15 +421,17 @@ func (r *mcrResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"create_date": schema.StringAttribute{
-				Description: "The date the MCR was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
+				Description:        "The date the MCR was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"created_by": schema.StringAttribute{
-				Description: "User who created the product.",
-				Computed:    true,
+				Description:        "User who created the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -441,16 +447,19 @@ func (r *mcrResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"terminate_date": schema.StringAttribute{
-				Description: "Date the product will be terminated.",
-				Computed:    true,
+				Description:        "Date the product will be terminated.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"live_date": schema.StringAttribute{
-				Description: "The date the MCR went live. This value is set by the Megaport API when the MCR becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
+				Description:        "The date the MCR went live. This value is set by the Megaport API when the MCR becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"market": schema.StringAttribute{
-				Description: "Market the product is in.",
-				Computed:    true,
+				Description:        "Market the product is in.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -470,8 +479,9 @@ func (r *mcrResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"usage_algorithm": schema.StringAttribute{
-				Description: "Usage algorithm of the product.",
-				Computed:    true,
+				Description:        "Usage algorithm of the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -492,35 +502,42 @@ func (r *mcrResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"contract_start_date": schema.StringAttribute{
-				Description: "Contract start date of the product.",
-				Computed:    true,
+				Description:        "Contract start date of the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"contract_end_date": schema.StringAttribute{
-				Description: "Contract end date of the product.",
-				Computed:    true,
+				Description:        "Contract end date of the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"secondary_name": schema.StringAttribute{
-				Description: "Secondary name of the product.",
-				Computed:    true,
+				Description:        "Secondary name of the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"lag_primary": schema.BoolAttribute{
-				Description: "Whether the product is a LAG primary.",
-				Computed:    true,
+				Description:        "Whether the product is a LAG primary.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"lag_id": schema.Int64Attribute{
-				Description: "Numeric ID of the LAG.",
-				Computed:    true,
+				Description:        "Numeric ID of the LAG.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"aggregation_id": schema.Int64Attribute{
-				Description: "Numeric ID of the aggregation.",
-				Computed:    true,
+				Description:        "Numeric ID of the aggregation.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"company_name": schema.StringAttribute{
-				Description: "Name of the company.",
-				Computed:    true,
+				Description:        "Name of the company.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"marketplace_visibility": schema.BoolAttribute{
 				Description: "Whether the product is visible in the Marketplace.",
@@ -538,50 +555,57 @@ func (r *mcrResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"vxc_permitted": schema.BoolAttribute{
-				Description: "Whether VXC is permitted.",
-				Computed:    true,
+				Description:        "Whether VXC is permitted.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"vxc_auto_approval": schema.BoolAttribute{
-				Description: "Whether VXC is auto approved.",
-				Computed:    true,
+				Description:        "Whether VXC is auto approved.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"virtual": schema.BoolAttribute{
-				Description: "Whether the product is virtual.",
-				Computed:    true,
+				Description:        "Whether the product is virtual.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"buyout_port": schema.BoolAttribute{
-				Description: "Whether the product is bought out.",
-				Computed:    true,
+				Description:        "Whether the product is bought out.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"locked": schema.BoolAttribute{
-				Description: "Whether the product is locked.",
-				Computed:    true,
+				Description:        "Whether the product is locked.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"admin_locked": schema.BoolAttribute{
-				Description: "Whether the product is admin locked.",
-				Computed:    true,
+				Description:        "Whether the product is admin locked.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"cancelable": schema.BoolAttribute{
-				Description: "Whether the product is cancelable.",
-				Computed:    true,
+				Description:        "Whether the product is cancelable.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"attribute_tags": schema.MapAttribute{
 				ElementType: types.StringType,


### PR DESCRIPTION
Adds a `DeprecationMessage` to the read-only bookkeeping attributes on the `megaport_mcr` resource. This is non-breaking: the fields still populate and keep working, so this only surfaces a deprecation warning ahead of removal in a future major release. This is part of a per-resource series doing the same cleanup across the provider.

Deprecated fields (24): `last_updated`, `product_id`, `product_type`, `provisioning_status`, `create_date`, `created_by`, `terminate_date`, `live_date`, `contract_start_date`, `contract_end_date`, `market`, `usage_algorithm`, `secondary_name`, `company_name`, `virtual`, `locked`, `admin_locked`, `cancelable`, `buyout_port`, `vxc_permitted`, `vxc_auto_approval`, `aggregation_id`, `lag_id`, `lag_primary`.

Docs regenerated (`docs/resources/mcr.md`).