### PR TITLE
chore: deprecate legacy computed metadata on vxc

### DIFF
--- a/docs/resources/vxc.md
+++ b/docs/resources/vxc.md
@@ -307,27 +307,27 @@ resource "megaport_vxc" "service_key_vxc" {
 
 ### Read-Only
 
-- `admin_locked` (Boolean) Whether the product is admin locked.
+- `admin_locked` (Boolean, Deprecated) Whether the product is admin locked.
 - `attribute_tags` (Map of String) The attribute tags associated with the product.
-- `cancelable` (Boolean) Whether the product is cancelable.
-- `company_name` (String) The name of the company the product is associated with.
+- `cancelable` (Boolean, Deprecated) Whether the product is cancelable.
+- `company_name` (String, Deprecated) The name of the company the product is associated with.
 - `company_uid` (String) The UID of the company the product is associated with.
-- `contract_end_date` (String) The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `contract_start_date` (String) The date the contract starts. This value is managed by the Megaport API and may be updated when the VXC is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `create_date` (String) The date the VXC was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `created_by` (String) The user who created the product.
+- `contract_end_date` (String, Deprecated) The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `contract_start_date` (String, Deprecated) The date the contract starts. This value is managed by the Megaport API and may be updated when the VXC is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `create_date` (String, Deprecated) The date the VXC was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
+- `created_by` (String, Deprecated) The user who created the product.
 - `csp_connections` (Attributes List) The Cloud Service Provider (CSP) connections associated with the VXC. (see [below for nested schema](#nestedatt--csp_connections))
 - `distance_band` (String) The distance band of the product.
-- `last_updated` (String) The last time the resource was updated.
-- `live_date` (String) The date the VXC went live. This value is set by the Megaport API when the VXC becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior as the field is being populated from the API.
-- `locked` (Boolean) Whether the product is locked.
-- `product_id` (Number) The numeric ID of the product.
-- `product_type` (String) The type of the product.
+- `last_updated` (String, Deprecated) The last time the resource was updated.
+- `live_date` (String, Deprecated) The date the VXC went live. This value is set by the Megaport API when the VXC becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior as the field is being populated from the API.
+- `locked` (Boolean, Deprecated) Whether the product is locked.
+- `product_id` (Number, Deprecated) The numeric ID of the product.
+- `product_type` (String, Deprecated) The type of the product.
 - `product_uid` (String) The unique identifier for the resource.
-- `provisioning_status` (String) The provisioning status of the VXC. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the VXC lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.
-- `secondary_name` (String) The secondary name of the product.
+- `provisioning_status` (String, Deprecated) The provisioning status of the VXC. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the VXC lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.
+- `secondary_name` (String, Deprecated) The secondary name of the product.
 - `service_id` (Number) The service ID of the VXC.
-- `usage_algorithm` (String) The usage algorithm of the product.
+- `usage_algorithm` (String, Deprecated) The usage algorithm of the product.
 
 <a id="nestedatt--a_end"></a>
 ### Nested Schema for `a_end`

--- a/internal/provider/vxc_resource.go
+++ b/internal/provider/vxc_resource.go
@@ -563,8 +563,9 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 		Description: "Virtual Cross Connect (VXC) Resource for the Megaport Terraform Provider. This resource allows you to create, modify, and update VXCs. VXCs are Layer 2 Ethernet circuits providing private, flexible, and on-demand connections between any of the locations on the Megaport network with 1 Mbps to 100 Gbps of capacity.",
 		Attributes: map[string]schema.Attribute{
 			"last_updated": schema.StringAttribute{
-				Description: "The last time the resource was updated.",
-				Computed:    true,
+				Description:        "The last time the resource was updated.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"product_uid": schema.StringAttribute{
 				Description: "The unique identifier for the resource.",
@@ -574,8 +575,9 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"product_id": schema.Int64Attribute{
-				Description: "The numeric ID of the product.",
-				Computed:    true,
+				Description:        "The numeric ID of the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
@@ -604,8 +606,9 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				Required:    true,
 			},
 			"product_type": schema.StringAttribute{
-				Description: "The type of the product.",
-				Computed:    true,
+				Description:        "The type of the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -618,19 +621,22 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"provisioning_status": schema.StringAttribute{
-				Description: "The provisioning status of the VXC. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the VXC lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.",
-				Computed:    true,
+				Description:        "The provisioning status of the VXC. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the VXC lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"secondary_name": schema.StringAttribute{
-				Description: "The secondary name of the product.",
-				Computed:    true,
+				Description:        "The secondary name of the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"usage_algorithm": schema.StringAttribute{
-				Description: "The usage algorithm of the product.",
-				Computed:    true,
+				Description:        "The usage algorithm of the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -643,19 +649,22 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"created_by": schema.StringAttribute{
-				Description: "The user who created the product.",
-				Computed:    true,
+				Description:        "The user who created the product.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"live_date": schema.StringAttribute{
-				Description: "The date the VXC went live. This value is set by the Megaport API when the VXC becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior as the field is being populated from the API.",
-				Computed:    true,
+				Description:        "The date the VXC went live. This value is set by the Megaport API when the VXC becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior as the field is being populated from the API.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"create_date": schema.StringAttribute{
-				Description: "The date the VXC was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
+				Description:        "The date the VXC was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"contract_term_months": schema.Int64Attribute{
 				Description: "The term of the contract in months: valid values are 1, 12, 24, 36, 48, and 60. To set the product to a month-to-month contract with no minimum term, set the value to 1.",
@@ -958,12 +967,14 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"contract_start_date": schema.StringAttribute{
-				Description: "The date the contract starts. This value is managed by the Megaport API and may be updated when the VXC is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
+				Description:        "The date the contract starts. This value is managed by the Megaport API and may be updated when the VXC is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"contract_end_date": schema.StringAttribute{
-				Description: "The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
+				Description:        "The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 			},
 			"company_uid": schema.StringAttribute{
 				Description: "The UID of the company the product is associated with.",
@@ -973,22 +984,25 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"company_name": schema.StringAttribute{
-				Description: "The name of the company the product is associated with.",
-				Computed:    true,
+				Description:        "The name of the company the product is associated with.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"locked": schema.BoolAttribute{
-				Description: "Whether the product is locked.",
-				Computed:    true,
+				Description:        "Whether the product is locked.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"admin_locked": schema.BoolAttribute{
-				Description: "Whether the product is admin locked.",
-				Computed:    true,
+				Description:        "Whether the product is admin locked.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
@@ -1002,8 +1016,9 @@ func (r *vxcResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"cancelable": schema.BoolAttribute{
-				Description: "Whether the product is cancelable.",
-				Computed:    true,
+				Description:        "Whether the product is cancelable.",
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future release.",
+				Computed:           true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},


### PR DESCRIPTION
Adds a deprecation warning to a set of read-only computed metadata attributes on the `megaport_vxc` resource. This is non-breaking: the attributes still populate exactly as before and only emit a deprecation warning plus a doc marker, ahead of removal in a future major release. This is part of a per-resource series doing the same cleanup across the provider.

Deprecated fields: `last_updated`, `product_id`, `product_type`, `provisioning_status`, `create_date`, `created_by`, `live_date`, `contract_start_date`, `contract_end_date`, `usage_algorithm`, `secondary_name`, `company_name`, `locked`, `admin_locked`, `cancelable`.

Docs regenerated via `tfplugindocs`.