### PR TITLE
chore(v2): add GNUmakefile with standard provider targets

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,35 @@
+default: build
+
+build:
+	go build -v ./...
+
+install:
+	go install -v ./...
+
+test:
+	go test -v -timeout=30m -cover ./internal/provider/
+
+testacc:
+ifndef MEGAPORT_ACCESS_KEY
+	$(error MEGAPORT_ACCESS_KEY is not set)
+endif
+ifndef MEGAPORT_SECRET_KEY
+	$(error MEGAPORT_SECRET_KEY is not set)
+endif
+	TF_ACC=1 go test -v -timeout=30m -cover ./internal/provider/
+
+lint:
+	golangci-lint run --timeout=10m
+
+generate:
+	go generate ./...
+
+fmt:
+	gofmt -w .
+	@command -v terraform >/dev/null 2>&1 && terraform fmt -recursive examples/ || echo "Skipping terraform fmt: terraform CLI not found"
+
+clean:
+	go clean
+	rm -rf docs/
+
+.PHONY: default build install test testacc lint generate fmt clean

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -26,7 +26,11 @@ generate:
 
 fmt:
 	gofmt -w .
-	@command -v terraform >/dev/null 2>&1 && terraform fmt -recursive examples/ || echo "Skipping terraform fmt: terraform CLI not found"
+	@if command -v terraform >/dev/null 2>&1; then \
+		terraform fmt -recursive examples/; \
+	else \
+		echo "Skipping terraform fmt: terraform CLI not found"; \
+	fi
 
 clean:
 	go clean


### PR DESCRIPTION
Adds a `GNUmakefile` with the standard provider targets: `build`, `install`, `test`, `testacc`, `lint`, `generate`, `fmt`, `clean`. Gives common workflows a single entry point.

Re-cut of the stalled `v2/pr-21-makefile` PR (#350) against `main`, dropping the v2 module-path and dependency churn it carried.