### PR TITLE
feat(v2): enrich API error messages with structured context

### DIFF
--- a/internal/provider/diagnostics.go
+++ b/internal/provider/diagnostics.go
@@ -1,0 +1,62 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	megaport "github.com/megaport/megaportgo"
+)
+
+// addAPIError adds a structured error diagnostic for Megaport API errors.
+// It extracts HTTP status, trace ID, and message from *megaport.ErrorResponse
+// when available, falling back to err.Error() for non-API errors.
+func addAPIError(diags *diag.Diagnostics, summary string, err error) {
+	diags.AddError(summary, buildErrorDetail(err))
+}
+
+// buildErrorDetail extracts structured information from an error.
+// For *megaport.ErrorResponse it returns a multi-line detail with message,
+// optional data, HTTP status, trace ID, and a support hint.
+// For other errors it returns err.Error().
+func buildErrorDetail(err error) string {
+	var apiErr *megaport.ErrorResponse
+	if !errors.As(err, &apiErr) {
+		return err.Error()
+	}
+
+	detail := apiErr.Message
+	if detail == "" {
+		detail = "(no message)"
+	}
+	if apiErr.Data != "" {
+		detail += "\n  Detail: " + apiErr.Data
+	}
+	if apiErr.Response != nil {
+		detail += fmt.Sprintf("\n  HTTP Status: %d (%s)",
+			apiErr.Response.StatusCode,
+			http.StatusText(apiErr.Response.StatusCode))
+	}
+	if apiErr.TraceID != "" {
+		detail += "\n  Trace ID: " + apiErr.TraceID
+	}
+	detail += "\n\n  If this issue persists, contact Megaport support with the above details."
+	return detail
+}
+
+func createErrorSummary(resourceType, name string) string {
+	return fmt.Sprintf("Error Creating %s (%s)", resourceType, name)
+}
+
+func readErrorSummary(resourceType, id string) string {
+	return fmt.Sprintf("Error Reading %s (%s)", resourceType, id)
+}
+
+func updateErrorSummary(resourceType, id string) string {
+	return fmt.Sprintf("Error Updating %s (%s)", resourceType, id)
+}
+
+func deleteErrorSummary(resourceType, id string) string {
+	return fmt.Sprintf("Error Deleting %s (%s)", resourceType, id)
+}

--- a/internal/provider/diagnostics_test.go
+++ b/internal/provider/diagnostics_test.go
@@ -1,0 +1,103 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildErrorDetail_FullAPIError(t *testing.T) {
+	apiErr := &megaport.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusBadRequest},
+		Message:  "Could not find a service with UID abc-123",
+		Data:     "Service has been decommissioned",
+		TraceID:  "req-xyz-789",
+	}
+
+	detail := buildErrorDetail(apiErr)
+
+	assert.Contains(t, detail, "Could not find a service with UID abc-123")
+	assert.Contains(t, detail, "Detail: Service has been decommissioned")
+	assert.Contains(t, detail, "HTTP Status: 400 (Bad Request)")
+	assert.Contains(t, detail, "Trace ID: req-xyz-789")
+	assert.Contains(t, detail, "contact Megaport support")
+}
+
+func TestBuildErrorDetail_APIErrorNoTraceID(t *testing.T) {
+	apiErr := &megaport.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusConflict},
+		Message:  "Resource is locked",
+	}
+
+	detail := buildErrorDetail(apiErr)
+
+	assert.Contains(t, detail, "Resource is locked")
+	assert.Contains(t, detail, "HTTP Status: 409 (Conflict)")
+	assert.NotContains(t, detail, "Trace ID")
+	assert.Contains(t, detail, "contact Megaport support")
+}
+
+func TestBuildErrorDetail_APIErrorNoData(t *testing.T) {
+	apiErr := &megaport.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusInternalServerError},
+		Message:  "Internal error",
+		TraceID:  "trace-abc",
+	}
+
+	detail := buildErrorDetail(apiErr)
+
+	assert.Contains(t, detail, "Internal error")
+	assert.NotContains(t, detail, "Detail:")
+	assert.Contains(t, detail, "HTTP Status: 500 (Internal Server Error)")
+	assert.Contains(t, detail, "Trace ID: trace-abc")
+}
+
+func TestBuildErrorDetail_PlainError(t *testing.T) {
+	err := errors.New("something went wrong")
+	detail := buildErrorDetail(err)
+	assert.Equal(t, "something went wrong", detail)
+}
+
+func TestBuildErrorDetail_WrappedAPIError(t *testing.T) {
+	apiErr := &megaport.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusNotFound},
+		Message:  "Not found",
+		TraceID:  "trace-wrapped",
+	}
+	wrapped := fmt.Errorf("outer context: %w", apiErr)
+
+	detail := buildErrorDetail(wrapped)
+
+	assert.Contains(t, detail, "Not found")
+	assert.Contains(t, detail, "HTTP Status: 404 (Not Found)")
+	assert.Contains(t, detail, "Trace ID: trace-wrapped")
+}
+
+func TestAddAPIError(t *testing.T) {
+	var diags diag.Diagnostics
+	apiErr := &megaport.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusBadRequest},
+		Message:  "Bad request",
+		TraceID:  "trace-123",
+	}
+
+	addAPIError(&diags, "Error Creating Port (test-port)", apiErr)
+
+	require.Len(t, diags, 1)
+	assert.Equal(t, "Error Creating Port (test-port)", diags[0].Summary())
+	assert.True(t, strings.Contains(diags[0].Detail(), "HTTP Status: 400"))
+}
+
+func TestSummaryHelpers(t *testing.T) {
+	assert.Equal(t, "Error Creating Port (my-port)", createErrorSummary("Port", "my-port"))
+	assert.Equal(t, "Error Reading MCR (mcr-uid-123)", readErrorSummary("MCR", "mcr-uid-123"))
+	assert.Equal(t, "Error Updating VXC (vxc-uid)", updateErrorSummary("VXC", "vxc-uid"))
+	assert.Equal(t, "Error Deleting IX (ix-uid)", deleteErrorSummary("IX", "ix-uid"))
+}

--- a/internal/provider/ix_resource.go
+++ b/internal/provider/ix_resource.go
@@ -578,20 +578,14 @@ func (r *ixResource) Create(ctx context.Context, req resource.CreateRequest, res
 	// Create the IX
 	ixResp, err := r.client.IXService.BuyIX(ctx, buyReq)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating IX",
-			"Could not create IX, unexpected error: "+err.Error(),
-		)
+		addAPIError(&resp.Diagnostics, createErrorSummary("IX", plan.ProductName.ValueString()), err)
 		return
 	}
 
 	// Get the created IX
 	ix, err := r.client.IXService.GetIX(ctx, ixResp.TechnicalServiceUID)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading IX",
-			"Could not read IX after creation, unexpected error: "+err.Error(),
-		)
+		addAPIError(&resp.Diagnostics, readErrorSummary("IX", ixResp.TechnicalServiceUID), err)
 		return
 	}
 
@@ -686,10 +680,7 @@ func (r *ixResource) Update(ctx context.Context, req resource.UpdateRequest, res
 		updateReq.Shutdown != nil {
 		_, err := r.client.IXService.UpdateIX(ctx, state.ProductUID.ValueString(), updateReq)
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error updating IX",
-				"Could not update IX, unexpected error: "+err.Error(),
-			)
+			addAPIError(&resp.Diagnostics, updateErrorSummary("IX", state.ProductUID.ValueString()), err)
 			return
 		}
 	}
@@ -697,10 +688,7 @@ func (r *ixResource) Update(ctx context.Context, req resource.UpdateRequest, res
 	// Refetch the updated IX
 	updatedIX, err := r.client.IXService.GetIX(ctx, state.ProductUID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading IX",
-			"Could not read IX after update, unexpected error: "+err.Error(),
-		)
+		addAPIError(&resp.Diagnostics, readErrorSummary("IX", state.ProductUID.ValueString()), err)
 		return
 	}
 
@@ -730,10 +718,7 @@ func (r *ixResource) Delete(ctx context.Context, req resource.DeleteRequest, res
 		})
 	})
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting IX",
-			"Could not delete IX, unexpected error: "+err.Error(),
-		)
+		addAPIError(&resp.Diagnostics, deleteErrorSummary("IX", state.ProductUID.ValueString()), err)
 		return
 	}
 

--- a/internal/provider/location_data_source.go
+++ b/internal/provider/location_data_source.go
@@ -357,20 +357,14 @@ func (d *locationDataSource) Read(ctx context.Context, req datasource.ReadReques
 	if !state.ID.IsNull() {
 		l, err := d.client.LocationService.GetLocationByIDV3(ctx, int(state.ID.ValueInt64()))
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to Get location by ID",
-				err.Error(),
-			)
+			addAPIError(&resp.Diagnostics, readErrorSummary("Location", fmt.Sprintf("%d", state.ID.ValueInt64())), err)
 			return
 		}
 		location = l
 	} else if !state.Name.IsNull() {
 		l, err := d.client.LocationService.GetLocationByNameV3(ctx, state.Name.ValueString())
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to Get location by name",
-				err.Error(),
-			)
+			addAPIError(&resp.Diagnostics, readErrorSummary("Location", state.Name.ValueString()), err)
 			return
 		}
 		location = l

--- a/internal/provider/mcr_prefix_filter_list_data_source.go
+++ b/internal/provider/mcr_prefix_filter_list_data_source.go
@@ -146,11 +146,7 @@ func (d *mcrPrefixFilterListDataSource) Read(ctx context.Context, req datasource
 	// Get prefix filter lists from API
 	prefixFilterLists, err := d.client.MCRService.ListMCRPrefixFilterLists(ctx, config.MCRID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading MCR prefix filter lists",
-			fmt.Sprintf("Could not read prefix filter lists for MCR %s: %s",
-				config.MCRID.ValueString(), err.Error()),
-		)
+		addAPIError(&resp.Diagnostics, readErrorSummary("MCR Prefix Filter List", config.MCRID.ValueString()), err)
 		return
 	}
 

--- a/internal/provider/mcrs_data_source.go
+++ b/internal/provider/mcrs_data_source.go
@@ -265,10 +265,7 @@ func (d *mcrsDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		// Look up a specific MCR by UID
 		mcr, err := d.client.MCRService.GetMCR(ctx, data.ProductUID.ValueString())
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error reading MCR",
-				fmt.Sprintf("Unable to read MCR %s: %v", data.ProductUID.ValueString(), err),
-			)
+			addAPIError(&resp.Diagnostics, readErrorSummary("MCR", data.ProductUID.ValueString()), err)
 			return
 		}
 		if mcr == nil {
@@ -286,10 +283,7 @@ func (d *mcrsDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 			IncludeInactive: false,
 		})
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error listing MCRs",
-				fmt.Sprintf("Unable to list MCRs: %v", err),
-			)
+			addAPIError(&resp.Diagnostics, readErrorSummary("MCR", "list"), err)
 			return
 		}
 	}

--- a/internal/provider/mve_image_data_source.go
+++ b/internal/provider/mve_image_data_source.go
@@ -148,10 +148,7 @@ func (d *mveImageDataSource) Read(ctx context.Context, req datasource.ReadReques
 
 	mveImages, listErr := d.client.MVEService.ListMVEImages(ctx)
 	if listErr != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading MVE Images",
-			"Could not list MVE Images: "+listErr.Error(),
-		)
+		addAPIError(&resp.Diagnostics, readErrorSummary("MVE Images", "list"), listErr)
 		return
 	}
 

--- a/internal/provider/mve_resource.go
+++ b/internal/provider/mve_resource.go
@@ -793,20 +793,14 @@ func (r *mveResource) Create(ctx context.Context, req resource.CreateRequest, re
 
 	err := r.client.MVEService.ValidateMVEOrder(ctx, mveReq)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Validation error while attempting to create MVE",
-			"Validation error while attempting to create MVE with name "+plan.Name.ValueString()+": "+err.Error(),
-		)
+		addAPIError(&resp.Diagnostics, createErrorSummary("MVE", plan.Name.ValueString()), err)
 		return
 	}
 
 	createdMVE, err := r.client.MVEService.BuyMVE(ctx, mveReq)
 
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading MVE",
-			"Could not create MVE with name "+plan.Name.ValueString()+": "+err.Error(),
-		)
+		addAPIError(&resp.Diagnostics, createErrorSummary("MVE", plan.Name.ValueString()), err)
 		return
 	}
 
@@ -815,19 +809,13 @@ func (r *mveResource) Create(ctx context.Context, req resource.CreateRequest, re
 	// get the created MVE
 	mve, err := r.client.MVEService.GetMVE(ctx, createdID)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading newly created MVE",
-			"Could not read newly created MVE with ID "+createdID+": "+err.Error(),
-		)
+		addAPIError(&resp.Diagnostics, readErrorSummary("MVE", createdID), err)
 		return
 	}
 
 	tags, err := r.client.MVEService.ListMVEResourceTags(ctx, createdID)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading tags for newly created MVE",
-			"Could not read tags for newly created MVE with ID "+createdID+": "+err.Error(),
-		)
+		addAPIError(&resp.Diagnostics, readErrorSummary("MVE Tags", createdID), err)
 		return
 	}
 
@@ -866,10 +854,7 @@ func (r *mveResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 			}
 		}
 
-		resp.Diagnostics.AddError(
-			"Error Reading MVE",
-			"Could not read MVE with ID "+state.UID.ValueString()+": "+err.Error(),
-		)
+		addAPIError(&resp.Diagnostics, readErrorSummary("MVE", state.UID.ValueString()), err)
 		return
 	}
 
@@ -882,10 +867,7 @@ func (r *mveResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	// Get tags
 	tags, err := r.client.MVEService.ListMVEResourceTags(ctx, state.UID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading tags for MVE",
-			"Could not read tags for MVE with ID "+state.UID.ValueString()+": "+err.Error(),
-		)
+		addAPIError(&resp.Diagnostics, readErrorSummary("MVE Tags", state.UID.ValueString()), err)
 		return
 	}
 
@@ -943,19 +925,13 @@ func (r *mveResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	})
 
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error updating MVE",
-			"Could not update MVE with ID "+state.UID.ValueString()+": "+err.Error(),
-		)
+		addAPIError(&resp.Diagnostics, updateErrorSummary("MVE", state.UID.ValueString()), err)
 		return
 	}
 
 	updatedMVE, err := r.client.MVEService.GetMVE(ctx, state.UID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading updated MVE",
-			"Could not read updated MVE with ID "+state.UID.ValueString()+": "+err.Error(),
-		)
+		addAPIError(&resp.Diagnostics, readErrorSummary("MVE", state.UID.ValueString()), err)
 		return
 	}
 
@@ -967,20 +943,14 @@ func (r *mveResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		}
 		err = r.client.MVEService.UpdateMVEResourceTags(ctx, state.UID.ValueString(), tagMap)
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error updating tags for MVE",
-				"Could not update tags for MVE with ID "+state.UID.ValueString()+": "+err.Error(),
-			)
+			addAPIError(&resp.Diagnostics, updateErrorSummary("MVE Tags", state.UID.ValueString()), err)
 			return
 		}
 	}
 
 	tags, err := r.client.MVEService.ListMVEResourceTags(ctx, state.UID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading tags for updated MVE",
-			"Could not read tags for updated MVE with ID "+state.UID.ValueString()+": "+err.Error(),
-		)
+		addAPIError(&resp.Diagnostics, readErrorSummary("MVE Tags", state.UID.ValueString()), err)
 		return
 	}
 
@@ -1017,10 +987,7 @@ func (r *mveResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		return deleteErr
 	})
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting MVE",
-			fmt.Sprintf("Could not delete MVE with product UID %s: %s", productUID, err),
-		)
+		addAPIError(&resp.Diagnostics, deleteErrorSummary("MVE", state.UID.ValueString()), err)
 		return
 	}
 

--- a/internal/provider/mve_size_data_source.go
+++ b/internal/provider/mve_size_data_source.go
@@ -98,10 +98,7 @@ func (d *mveSizeDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	mveSizes, listErr := d.client.MVEService.ListAvailableMVESizes(ctx)
 	if listErr != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading MVE Images",
-			"Could not list MVE Images: "+listErr.Error(),
-		)
+		addAPIError(&resp.Diagnostics, readErrorSummary("MVE Sizes", "list"), listErr)
 		return
 	}
 

--- a/internal/provider/partner_port_data_source.go
+++ b/internal/provider/partner_port_data_source.go
@@ -125,10 +125,7 @@ func (d *partnerPortDataSource) Read(ctx context.Context, req datasource.ReadReq
 
 	partnerPorts, listErr := d.client.PartnerService.ListPartnerMegaports(ctx)
 	if listErr != nil {
-		resp.Diagnostics.AddError(
-			"Error listing partner ports",
-			"Could not list partner ports: "+listErr.Error(),
-		)
+		addAPIError(&resp.Diagnostics, readErrorSummary("Partner Port", "list"), listErr)
 		return
 	}
 


### PR DESCRIPTION
Replaces the stale #346, which was built on the dead v2 stack. Clean re-cut targeting `feat/v2`.

Adds shared diagnostics helpers (`diagnostics.go`) that build a structured error detail from a megaportgo `ErrorResponse`: message, data, HTTP status, and trace ID, plus a support hint. Non-API errors fall back to `err.Error()`.

Converts ad-hoc `AddError` call sites across the IX and MVE resources and the location, MCR, MCR prefix-filter-list, MVE image, MVE size, and partner-port data sources to use the helpers for consistent output.

The helpers read only structured fields, never the raw `ErrorResponse.Error()` (which embeds URL and method), so no request URLs or credentials leak into diagnostics.
