### PR TITLE
ci: run tests on pushes and pull requests targeting feat/v2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,11 +6,13 @@ on:
       - 'README.md'
     branches:
       - 'main'
+      - 'feat/v2'
   pull_request:
     paths-ignore:
       - 'README.md'
     branches:
       - 'main'
+      - 'feat/v2'
   workflow_dispatch:
 
 # Testing only needs permissions to read the repository contents.


### PR DESCRIPTION
PRs based on feat/v2 currently get no CI because test.yaml only triggers on main. Adds feat/v2 to both the push and pull_request branch filters.

Merge this first so the open feat/v2 PRs pick up checks on their next push.