### PR TITLE
feat(v2): MVE per-vendor config blocks and legacy field removal

### DIFF
--- a/docs/resources/mve.md
+++ b/docs/resources/mve.md
@@ -172,81 +172,193 @@ resource "megaport_mve" "mve_sixwind_dynamic" {
 - `contract_term_months` (Number) The term of the contract in months: valid values are 1, 12, 24, 36, 48, and 60. To set the product to a month-to-month contract with no minimum term, set the value to 1.
 - `location_id` (Number) The numeric location ID of the product. This value can be retrieved from the data source megaport_location.
 - `product_name` (String) The name of the MVE.
-- `vendor_config` (Attributes) The vendor configuration of the MVE. Vendor-specific information required to bootstrap the MVE. These values will be different for each vendor, and can include vendor name, size of VM, license/activation code, software version, and SSH keys. This field cannot be changed after the MVE is created and if it is modified, the MVE will be deleted and re-created. Imported MVEs do not have this field populated by the API, so the initially provided configuration will be ignored as it can't be verified to be correct. If the user wants to change the configuration after importing the resource, they can then do so by changing the field after importing the resource and running terraform apply. (see [below for nested schema](#nestedatt--vendor_config))
 
 ### Optional
 
+- `aruba_config` (Attributes) Aruba MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes. (see [below for nested schema](#nestedatt--aruba_config))
+- `aviatrix_config` (Attributes) Aviatrix MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes. (see [below for nested schema](#nestedatt--aviatrix_config))
+- `cisco_config` (Attributes) Cisco MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes. (see [below for nested schema](#nestedatt--cisco_config))
 - `cost_centre` (String) The cost centre of the MVE.
 - `diversity_zone` (String) The diversity zone of the MVE.
+- `fortinet_config` (Attributes) Fortinet MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes. (see [below for nested schema](#nestedatt--fortinet_config))
+- `meraki_config` (Attributes) Meraki MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes. (see [below for nested schema](#nestedatt--meraki_config))
+- `palo_alto_config` (Attributes) Palo Alto MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes. (see [below for nested schema](#nestedatt--palo_alto_config))
+- `prisma_config` (Attributes) Prisma MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes. (see [below for nested schema](#nestedatt--prisma_config))
 - `promo_code` (String) Promo code is an optional string that can be used to enter a promotional code for the service order. The code is not validated, so if the code doesn't exist or doesn't work for the service, the request will still be successful.
 - `resource_tags` (Map of String) The resource tags associated with the product.
+- `sixwind_config` (Attributes) 6WIND MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes. (see [below for nested schema](#nestedatt--sixwind_config))
+- `versa_config` (Attributes) Versa MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes. (see [below for nested schema](#nestedatt--versa_config))
+- `vmware_config` (Attributes) VMware MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes. (see [below for nested schema](#nestedatt--vmware_config))
 - `vnics` (Attributes List) The network interfaces of the MVE. The number of elements in the array is the number of vNICs the user wants to provision. Description can be null. The maximum number of vNICs allowed is 5. If the array is not supplied (i.e. null), it will default to the minimum number of vNICs for the supplier - 2 for Palo Alto and 1 for the others. (see [below for nested schema](#nestedatt--vnics))
 
 ### Read-Only
 
-- `admin_locked` (Boolean) Whether the MVE is admin locked.
 - `attribute_tags` (Map of String) The attribute tags of the MVE.
-- `buyout_port` (Boolean) Whether the port is buyout.
-- `cancelable` (Boolean) Whether the MVE is cancelable.
-- `company_name` (String) The company name of the MVE.
 - `company_uid` (String) The company UID of the MVE.
-- `contract_end_date` (String) The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `contract_start_date` (String) The date the contract starts. This value is managed by the Megaport API and may be updated when the MVE is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `create_date` (String) The date the MVE was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `created_by` (String) The user who created the MVE.
-- `last_updated` (String) The last time the MVE was updated by the Terraform Provider.
-- `live_date` (String) The date the MVE went live. This value is set by the Megaport API when the MVE becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `locked` (Boolean) Whether the MVE is locked.
-- `market` (String) The market the MVE is in.
 - `marketplace_visibility` (Boolean) Whether the MVE is visible in the marketplace.
 - `mve_size` (String) The size of the MVE.
-- `product_id` (Number) The Numeric ID of the MVE.
-- `product_type` (String) The type of product (MVE).
 - `product_uid` (String) The unique identifier of the MVE.
-- `provisioning_status` (String) The provisioning status of the MVE. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the MVE lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.
-- `secondary_name` (String) The secondary name of the MVE.
-- `terminate_date` (String) The date the MVE will be or was terminated. This value is set by the Megaport API when termination is scheduled or completed. During import, this field may show as changing from unknown to its actual value - this is expected behavior.
-- `usage_algorithm` (String) The usage algorithm of the MVE.
 - `vendor` (String) The vendor of the MVE.
-- `virtual` (Boolean) Whether the MVE is virtual.
-- `vxc_auto_approval` (Boolean) Whether VXC is auto approved.
-- `vxc_permitted` (Boolean) Whether VXC is permitted.
 
-<a id="nestedatt--vendor_config"></a>
-### Nested Schema for `vendor_config`
+<a id="nestedatt--aruba_config"></a>
+### Nested Schema for `aruba_config`
 
 Required:
 
 - `image_id` (Number) The image ID of the MVE. Indicates the software version.
-- `product_size` (String) The product size for the vendor config. The size defines the MVE specifications including number of cores, bandwidth, and number of connections. Use the `megaport_mve_sizes` data source to query available sizes dynamically. Common values include SMALL (2 cores), MEDIUM (4 cores), LARGE (8 cores), X_LARGE_16 (16 cores), and X_LARGE_32 (32 cores).
-- `vendor` (String) The name of vendor of the MVE. Currently supported values: "6wind", "aruba", "aviatrix", "cisco", "fortinet", "palo_alto", "prisma", "versa", "vmware", "meraki".
+- `product_size` (String) The product size for the vendor config.
 
 Optional:
 
-- `account_key` (String, Sensitive) The account key for the vendor config. Enter the Account Key from Aruba Orchestrator. The key is linked to the Account Name. Required for Aruba MVE.
-- `account_name` (String) The account name for the vendor config. Enter the Account Name from Aruba Orchestrator. To view your Account Name, log in to Orchestrator and choose Orchestrator > Licensing | Cloud Portal. Required for Aruba MVE.
-- `admin_password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Plain-text admin password for the vendor config. Required for Cisco FTDv (Firewall) MVE only; Palo Alto MVE uses `admin_password_hash` instead. Must be 9–100 characters and may not contain `"`, carriage return, or line feed. This value is only consumed when the MVE is provisioned to seed the initial admin account; after deployment, manage the password via the vendor's management interface. Declared as a [write-only argument](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral/write-only) (Terraform 1.11+) so the password is not persisted in the Terraform plan or state.
-- `admin_password_hash` (String, Sensitive) The sha256crypt-formatted admin password hash for the vendor config. Required for Palo Alto VM-Series MVE; not used by any other vendor. Must match the format `$5$<salt>$<hash>` (e.g. `$5$2833ea35$Pdyc6dKE8N/UBRge3QWDJJyotG3I59pxLJWVmcSQDdC`). On Linux/macOS you can generate this with `mkpasswd -m sha-256 'your_password'`. This value is only consumed when the MVE is provisioned to seed the initial admin account; after deployment, manage the password via the Palo Alto management interface (the provider does not read this value back from the API).
-- `admin_ssh_public_key` (String) The admin SSH public key for the vendor config. Required for Cisco, Fortinet, and Vmware MVEs.
-- `cloud_init` (String) The Base64 encoded cloud init file for the vendor config. The bootstrap configuration file. Required for Aviatrix and Cisco C8000v.
-- `controller_address` (String) The controldler address for the vendor config. A FQDN (Fully Qualified Domain Name) or IPv4 address of your Versa Controller. Required for Versa MVE.
-- `director_address` (String) The director address for the vendor config. A FQDN (Fully Qualified Domain Name) or IPv4 address of your Versa Director. Required for Versa MVE.
+- `account_key` (String, Sensitive) The account key for the vendor config. Enter the Account Key from Aruba Orchestrator.
+- `account_name` (String) The account name for the vendor config. Enter the Account Name from Aruba Orchestrator.
+- `mve_label` (String) The MVE label for the vendor config.
+- `system_tag` (String) The system tag for the vendor config. Aruba Orchestrator System Tags register the EC-V with the Cloud Portal and Orchestrator.
+
+
+<a id="nestedatt--aviatrix_config"></a>
+### Nested Schema for `aviatrix_config`
+
+Required:
+
+- `image_id` (Number) The image ID of the MVE. Indicates the software version.
+- `product_size` (String) The product size for the vendor config.
+
+Optional:
+
+- `cloud_init` (String) The Base64 encoded cloud init file for the vendor config. The bootstrap configuration file. Required for Aviatrix.
+- `mve_label` (String) The MVE label for the vendor config.
+
+
+<a id="nestedatt--cisco_config"></a>
+### Nested Schema for `cisco_config`
+
+Required:
+
+- `image_id` (Number) The image ID of the MVE. Indicates the software version.
+- `product_size` (String) The product size for the vendor config.
+
+Optional:
+
+- `admin_password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Plain-text admin password for the vendor config. Required for Cisco FTDv (Firewall) MVE only. Must be 9–100 characters and may not contain `"`, carriage return, or line feed. This value is only consumed when the MVE is provisioned to seed the initial admin account; after deployment, manage the password via the vendor's management interface. Declared as a [write-only argument](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral/write-only) (Terraform 1.11+) so the password is not persisted in the Terraform plan or state.
+- `admin_ssh_public_key` (String) The admin SSH public key for the vendor config.
+- `cloud_init` (String) The Base64 encoded cloud init file for the vendor config. Required for Cisco C8000v.
 - `fmc_ip_address` (String) The FMC IP address for the vendor config. Required for Cisco FTDv (Firewall) MVE.
 - `fmc_nat_id` (String) The FMC NAT ID for the vendor config. Required for Cisco FTDv (Firewall) MVE.
 - `fmc_registration_key` (String, Sensitive) The FMC registration key for the vendor config. Required for Cisco FTDv (Firewall) MVE.
-- `ion_key` (String, Sensitive) The vION key for the vendor config. Required for Prisma MVE.
-- `license_data` (String, Sensitive) The license data for the vendor config. Required for Fortinet and Palo Alto MVEs.
-- `local_auth` (String, Sensitive) The local auth for the vendor config. Enter the Local Auth string as configured in your Versa Director. Required for Versa MVE.
 - `manage_locally` (Boolean) Whether to manage the MVE locally. Required for Cisco MVE.
 - `mve_label` (String) The MVE label for the vendor config.
-- `remote_auth` (String, Sensitive) The remote auth for the vendor config. Enter the Remote Auth string as configured in your Versa Director. Required for Versa MVE.
-- `secret_key` (String, Sensitive) The secret key for the vendor config. Required for Prisma MVE.
-- `serial_number` (String) The serial number for the vendor config. Enter the serial number that you specified when creating the device in Versa Director. Required for Versa MVE.
-- `ssh_public_key` (String) The SSH public key for the vendor config. Required for 6WIND, VMWare, Palo Alto, and Fortinet MVEs. Must be a 2048-bit RSA key (ed25519 and other key types are not supported). You can generate a compatible key using: ssh-keygen -t rsa -b 2048 -C 'your_email@example.com'
-- `system_tag` (String) The system tag for the vendor config. Aruba Orchestrator System Tags and preconfiguration templates register the EC-V with the Cloud Portal and Orchestrator, and enable Orchestrator to automatically accept and configure newly discovered EC-V appliances. If you created a preconfiguration template in Orchestrator, enter the System Tag you specified here. Required for Aruba MVE.
-- `token` (String, Sensitive) The token for the vendor config. Required for Meraki MVE.
-- `vco_activation_code` (String, Sensitive) The VCO activation code for the vendor config. This is provided by Orchestrator after creating the edge device. Required for VMware MVE.
-- `vco_address` (String) The VCO address for the vendor config. A FQDN (Fully Qualified Domain Name) or IPv4 or IPv6 address for the Orchestrator where you created the edge device. Required for VMware MVE.
+- `ssh_public_key` (String) The SSH public key for the vendor config.
+
+
+<a id="nestedatt--fortinet_config"></a>
+### Nested Schema for `fortinet_config`
+
+Required:
+
+- `image_id` (Number) The image ID of the MVE. Indicates the software version.
+- `product_size` (String) The product size for the vendor config.
+
+Optional:
+
+- `admin_ssh_public_key` (String) The admin SSH public key for the vendor config.
+- `license_data` (String, Sensitive) The license data for the vendor config. Required for Fortinet.
+- `mve_label` (String) The MVE label for the vendor config.
+- `ssh_public_key` (String) The SSH public key for the vendor config. Must be a 2048-bit RSA key.
+
+
+<a id="nestedatt--meraki_config"></a>
+### Nested Schema for `meraki_config`
+
+Required:
+
+- `image_id` (Number) The image ID of the MVE. Indicates the software version.
+- `product_size` (String) The product size for the vendor config.
+
+Optional:
+
+- `mve_label` (String) The MVE label for the vendor config.
+- `token` (String, Sensitive) The token for the vendor config. Required for Meraki.
+
+
+<a id="nestedatt--palo_alto_config"></a>
+### Nested Schema for `palo_alto_config`
+
+Required:
+
+- `image_id` (Number) The image ID of the MVE. Indicates the software version.
+- `product_size` (String) The product size for the vendor config.
+
+Optional:
+
+- `admin_password_hash` (String, Sensitive) The sha256crypt-formatted admin password hash for the vendor config. Required for Palo Alto VM-Series MVE. Must match the format `$5$<salt>$<hash>`.
+- `license_data` (String, Sensitive) The license data for the vendor config. Required for Palo Alto.
+- `mve_label` (String) The MVE label for the vendor config.
+- `ssh_public_key` (String) The SSH public key for the vendor config. Must be a 2048-bit RSA key.
+
+
+<a id="nestedatt--prisma_config"></a>
+### Nested Schema for `prisma_config`
+
+Required:
+
+- `image_id` (Number) The image ID of the MVE. Indicates the software version.
+- `product_size` (String) The product size for the vendor config.
+
+Optional:
+
+- `ion_key` (String, Sensitive) The vION key for the vendor config. Required for Prisma.
+- `mve_label` (String) The MVE label for the vendor config.
+- `secret_key` (String, Sensitive) The secret key for the vendor config. Required for Prisma.
+
+
+<a id="nestedatt--sixwind_config"></a>
+### Nested Schema for `sixwind_config`
+
+Required:
+
+- `image_id` (Number) The image ID of the MVE. Indicates the software version.
+- `product_size` (String) The product size for the vendor config.
+
+Optional:
+
+- `mve_label` (String) The MVE label for the vendor config.
+- `ssh_public_key` (String) The SSH public key for the vendor config. Must be a 2048-bit RSA key.
+
+
+<a id="nestedatt--versa_config"></a>
+### Nested Schema for `versa_config`
+
+Required:
+
+- `image_id` (Number) The image ID of the MVE. Indicates the software version.
+- `product_size` (String) The product size for the vendor config.
+
+Optional:
+
+- `controller_address` (String) A FQDN or IPv4 address of your Versa Controller. Required for Versa.
+- `director_address` (String) A FQDN or IPv4 address of your Versa Director. Required for Versa.
+- `local_auth` (String, Sensitive) The local auth string as configured in your Versa Director. Required for Versa.
+- `mve_label` (String) The MVE label for the vendor config.
+- `remote_auth` (String, Sensitive) The remote auth string as configured in your Versa Director. Required for Versa.
+- `serial_number` (String) The serial number specified when creating the device in Versa Director. Required for Versa.
+
+
+<a id="nestedatt--vmware_config"></a>
+### Nested Schema for `vmware_config`
+
+Required:
+
+- `image_id` (Number) The image ID of the MVE. Indicates the software version.
+- `product_size` (String) The product size for the vendor config.
+
+Optional:
+
+- `admin_ssh_public_key` (String) The admin SSH public key for the vendor config.
+- `mve_label` (String) The MVE label for the vendor config.
+- `ssh_public_key` (String) The SSH public key for the vendor config. Must be a 2048-bit RSA key.
+- `vco_activation_code` (String, Sensitive) The VCO activation code provided by Orchestrator after creating the edge device. Required for VMware.
+- `vco_address` (String) A FQDN or IPv4/IPv6 address for the Orchestrator where you created the edge device. Required for VMware.
 
 
 <a id="nestedatt--vnics"></a>
@@ -255,10 +367,6 @@ Optional:
 Required:
 
 - `description` (String) The description of the network interface.
-
-Read-Only:
-
-- `vlan` (Number) The VLAN of the network interface.
 
 ## Import
 

--- a/internal/provider/mve_move_state.go
+++ b/internal/provider/mve_move_state.go
@@ -1,0 +1,50 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// MoveState implements resource.ResourceWithMoveState to support automatic
+// V1-to-V2 state migration when users move from megaport/megaport (v1) to v2.
+func (r *mveResource) MoveState(ctx context.Context) []resource.StateMover {
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+
+	// The V2 schema is the source schema. The framework decodes the V1 raw
+	// state against it with IgnoreUndefinedAttributes, silently dropping the
+	// removed legacy fields, the old union vendor_config block, and the removed
+	// vnics.vlan attribute. The per-vendor config blocks are absent from V1
+	// state, so they decode to null and are reconciled from config on the first
+	// apply after the move.
+	return []resource.StateMover{
+		{
+			SourceSchema: &schemaResp.Schema,
+			StateMover:   moveStateMVE,
+		},
+	}
+}
+
+// moveStateMVE migrates a V1 megaport_mve state to V2.
+func moveStateMVE(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+	if req.SourceProviderAddress != "registry.terraform.io/megaport/megaport" || req.SourceTypeName != "megaport_mve" {
+		return
+	}
+
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to migrate V1 state",
+			"The source megaport_mve state could not be decoded against the V2 schema.",
+		)
+		return
+	}
+
+	var model mveResourceModel
+	resp.Diagnostics.Append(req.SourceState.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.TargetState.Set(ctx, &model)...)
+}

--- a/internal/provider/mve_move_state_test.go
+++ b/internal/provider/mve_move_state_test.go
@@ -1,0 +1,235 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// v1MVEState returns a complete V1 MVE state JSON with all fields that existed
+// in V1, including the removed legacy fields, the old union vendor_config block,
+// and the removed vnics.vlan attribute.
+func v1MVEState() []byte {
+	state := map[string]interface{}{
+		// Fields kept in V2
+		"product_uid":            "mve-uid-123",
+		"product_name":           "My MVE",
+		"location_id":            7,
+		"marketplace_visibility": false,
+		"company_uid":            "company-xyz",
+		"contract_term_months":   12,
+		"promo_code":             "PROMO1",
+		"cost_centre":            "CC-001",
+		"diversity_zone":         "red",
+		"vendor":                 "CISCO",
+		"mve_size":               "SMALL",
+		"attribute_tags":         map[string]string{"env": "staging"},
+		"resource_tags":          map[string]string{"team": "infra"},
+		"vnics": []map[string]interface{}{
+			{"description": "Data Plane", "vlan": 100},
+			{"description": "Management", "vlan": 200},
+		},
+		// Old union vendor_config block (removed in V2, replaced by per-vendor blocks)
+		"vendor_config": map[string]interface{}{
+			"vendor":               "cisco",
+			"image_id":             42,
+			"product_size":         "SMALL",
+			"mve_label":            "cisco-label",
+			"admin_ssh_public_key": "ssh-rsa AAAA",
+			"ssh_public_key":       "ssh-rsa BBBB",
+			"admin_password":       "sup3rs3cret!",
+			"manage_locally":       true,
+			"cloud_init":           "base64data",
+			"fmc_ip_address":       "10.0.0.1",
+			"fmc_registration_key": "regkey",
+			"fmc_nat_id":           "natid",
+		},
+		// Fields removed in V2
+		"last_updated":        "2024-01-01T00:00:00Z",
+		"product_id":          99,
+		"provisioning_status": "LIVE",
+		"create_date":         "2024-01-01T00:00:00Z",
+		"created_by":          "user@example.com",
+		"terminate_date":      "2025-01-01T00:00:00Z",
+		"live_date":           "2024-01-02T00:00:00Z",
+		"market":              "AU",
+		"product_type":        "MVE",
+		"usage_algorithm":     "some-algo",
+		"contract_start_date": "2024-01-01",
+		"contract_end_date":   "2025-01-01",
+		"vxc_permitted":       true,
+		"vxc_auto_approval":   false,
+		"secondary_name":      "mve-secondary",
+		"company_name":        "My Company",
+		"virtual":             true,
+		"buyout_port":         false,
+		"locked":              false,
+		"admin_locked":        false,
+		"cancelable":          true,
+	}
+	b, _ := json.Marshal(state)
+	return b
+}
+
+// invokeMVEStateMover decodes the raw V1 state against the mover's SourceSchema
+// exactly as the framework server does, then runs the mover.
+func invokeMVEStateMover(t *testing.T, providerAddr, typeName string, rawJSON []byte) *resource.MoveStateResponse {
+	t.Helper()
+	ctx := context.Background()
+	r := &mveResource{}
+
+	movers := r.MoveState(ctx)
+	require.Len(t, movers, 1)
+	require.NotNil(t, movers[0].SourceSchema)
+
+	req := resource.MoveStateRequest{
+		SourceProviderAddress: providerAddr,
+		SourceTypeName:        typeName,
+		SourceRawState:        &tfprotov6.RawState{JSON: rawJSON},
+	}
+
+	if rawJSON != nil {
+		rawValue, err := req.SourceRawState.UnmarshalWithOpts(
+			movers[0].SourceSchema.Type().TerraformType(ctx),
+			tfprotov6.UnmarshalOpts{
+				ValueFromJSONOpts: tftypes.ValueFromJSONOpts{
+					IgnoreUndefinedAttributes: true,
+				},
+			},
+		)
+		require.NoError(t, err, "failed to decode V1 state against the V2 schema")
+		req.SourceState = &tfsdk.State{
+			Raw:    rawValue,
+			Schema: *movers[0].SourceSchema,
+		}
+	}
+
+	resp := &resource.MoveStateResponse{
+		TargetState: tfsdk.State{
+			Schema: *movers[0].SourceSchema,
+			Raw:    tftypes.NewValue(movers[0].SourceSchema.Type().TerraformType(ctx), nil),
+		},
+	}
+
+	movers[0].StateMover(ctx, req, resp)
+	return resp
+}
+
+func TestMoveState_MVE_V1ToV2(t *testing.T) {
+	ctx := context.Background()
+
+	resp := invokeMVEStateMover(t, "registry.terraform.io/megaport/megaport", "megaport_mve", v1MVEState())
+	require.False(t, resp.Diagnostics.HasError(), "unexpected diagnostics: %v", resp.Diagnostics)
+
+	var model mveResourceModel
+	diags := resp.TargetState.Get(ctx, &model)
+	require.False(t, diags.HasError(), "failed to read target state: %v", diags)
+
+	// Kept fields migrate unchanged.
+	assert.Equal(t, "mve-uid-123", model.UID.ValueString())
+	assert.Equal(t, "My MVE", model.Name.ValueString())
+	assert.Equal(t, int64(7), model.LocationID.ValueInt64())
+	assert.False(t, model.MarketplaceVisibility.ValueBool())
+	assert.Equal(t, "company-xyz", model.CompanyUID.ValueString())
+	assert.Equal(t, int64(12), model.ContractTermMonths.ValueInt64())
+	assert.Equal(t, "PROMO1", model.PromoCode.ValueString())
+	assert.Equal(t, "CC-001", model.CostCentre.ValueString())
+	assert.Equal(t, "red", model.DiversityZone.ValueString())
+	assert.Equal(t, "CISCO", model.Vendor.ValueString())
+	assert.Equal(t, "SMALL", model.Size.ValueString())
+
+	// The old union vendor_config is dropped; per-vendor blocks decode to null.
+	assert.True(t, allVendorConfigsNull(model), "expected all per-vendor config blocks to be null after migration")
+
+	// vnics carry over, but the removed vlan attribute is dropped.
+	require.False(t, model.NetworkInterfaces.IsNull())
+	vnicElements := model.NetworkInterfaces.Elements()
+	require.Len(t, vnicElements, 2)
+	vnicObj, ok := vnicElements[0].(types.Object)
+	require.True(t, ok)
+	var vnic mveNetworkInterfaceModel
+	diags = vnicObj.As(ctx, &vnic, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError(), "failed to read vnic: %v", diags)
+	assert.Equal(t, "Data Plane", vnic.Description.ValueString())
+	vnicAttrKeys := vnicObj.Attributes()
+	_, hasVLAN := vnicAttrKeys["vlan"]
+	assert.False(t, hasVLAN, "expected vnics.vlan to be dropped after migration")
+
+	// Resource tags carry over.
+	require.False(t, model.ResourceTags.IsNull())
+	require.Len(t, model.ResourceTags.Elements(), 1)
+}
+
+func TestMoveState_MVE_V1ToV2_NilOptionals(t *testing.T) {
+	ctx := context.Background()
+
+	state := map[string]interface{}{
+		"product_uid":          "mve-nil-test",
+		"product_name":         "Nil MVE",
+		"location_id":          8,
+		"contract_term_months": 1,
+		"vendor":               "ARUBA",
+		"mve_size":             "MEDIUM",
+		"promo_code":           nil,
+		"cost_centre":          nil,
+		"diversity_zone":       nil,
+		"vnics":                nil,
+		"resource_tags":        nil,
+		"vendor_config":        nil,
+		// V1-only fields
+		"last_updated":        nil,
+		"product_id":          nil,
+		"provisioning_status": nil,
+		"created_by":          nil,
+	}
+	rawJSON, err := json.Marshal(state)
+	require.NoError(t, err)
+
+	resp := invokeMVEStateMover(t, "registry.terraform.io/megaport/megaport", "megaport_mve", rawJSON)
+	require.False(t, resp.Diagnostics.HasError(), "unexpected diagnostics: %v", resp.Diagnostics)
+
+	var model mveResourceModel
+	diags := resp.TargetState.Get(ctx, &model)
+	require.False(t, diags.HasError(), "failed to read target state: %v", diags)
+
+	assert.Equal(t, "mve-nil-test", model.UID.ValueString())
+	assert.Equal(t, "Nil MVE", model.Name.ValueString())
+	assert.Equal(t, int64(8), model.LocationID.ValueInt64())
+	assert.Equal(t, "ARUBA", model.Vendor.ValueString())
+	assert.True(t, model.PromoCode.IsNull())
+	assert.True(t, model.CostCentre.IsNull())
+	assert.True(t, model.DiversityZone.IsNull())
+	assert.True(t, model.NetworkInterfaces.IsNull())
+	assert.True(t, model.ResourceTags.IsNull())
+	assert.True(t, allVendorConfigsNull(model))
+}
+
+func TestMoveState_MVE_WrongProvider(t *testing.T) {
+	resp := invokeMVEStateMover(t, "registry.terraform.io/other/other", "megaport_mve", v1MVEState())
+
+	assert.False(t, resp.Diagnostics.HasError())
+	assert.True(t, resp.TargetState.Raw.IsNull(), "expected target state to remain null for wrong provider")
+}
+
+func TestMoveState_MVE_WrongType(t *testing.T) {
+	resp := invokeMVEStateMover(t, "registry.terraform.io/megaport/megaport", "megaport_vxc", v1MVEState())
+
+	assert.False(t, resp.Diagnostics.HasError())
+	assert.True(t, resp.TargetState.Raw.IsNull(), "expected target state to remain null for wrong type")
+}
+
+func TestMoveState_MVE_NilSourceState(t *testing.T) {
+	resp := invokeMVEStateMover(t, "registry.terraform.io/megaport/megaport", "megaport_mve", nil)
+
+	require.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Summary(), "Unable to migrate V1 state")
+}

--- a/internal/provider/mve_resource.go
+++ b/internal/provider/mve_resource.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -31,52 +31,39 @@ var (
 	_ resource.Resource                = &mveResource{}
 	_ resource.ResourceWithConfigure   = &mveResource{}
 	_ resource.ResourceWithImportState = &mveResource{}
+	_ resource.ResourceWithMoveState   = &mveResource{}
 
 	vnicAttrs = map[string]attr.Type{
 		"description": types.StringType,
-		"vlan":        types.Int64Type,
 	}
 )
 
 // mveResourceModel maps the resource schema data.
 type mveResourceModel struct {
-	LastUpdated types.String `tfsdk:"last_updated"`
-
-	ID                    types.Int64  `tfsdk:"product_id"`
 	UID                   types.String `tfsdk:"product_uid"`
 	Name                  types.String `tfsdk:"product_name"`
-	Type                  types.String `tfsdk:"product_type"`
-	ProvisioningStatus    types.String `tfsdk:"provisioning_status"`
-	CreateDate            types.String `tfsdk:"create_date"`
-	CreatedBy             types.String `tfsdk:"created_by"`
-	TerminateDate         types.String `tfsdk:"terminate_date"`
-	LiveDate              types.String `tfsdk:"live_date"`
-	Market                types.String `tfsdk:"market"`
 	LocationID            types.Int64  `tfsdk:"location_id"`
-	UsageAlgorithm        types.String `tfsdk:"usage_algorithm"`
 	MarketplaceVisibility types.Bool   `tfsdk:"marketplace_visibility"`
-	VXCPermitted          types.Bool   `tfsdk:"vxc_permitted"`
-	VXCAutoApproval       types.Bool   `tfsdk:"vxc_auto_approval"`
-	SecondaryName         types.String `tfsdk:"secondary_name"`
 	CompanyUID            types.String `tfsdk:"company_uid"`
-	CompanyName           types.String `tfsdk:"company_name"`
-	ContractStartDate     types.String `tfsdk:"contract_start_date"`
-	ContractEndDate       types.String `tfsdk:"contract_end_date"`
 	ContractTermMonths    types.Int64  `tfsdk:"contract_term_months"`
 	PromoCode             types.String `tfsdk:"promo_code"`
 	CostCentre            types.String `tfsdk:"cost_centre"`
 	DiversityZone         types.String `tfsdk:"diversity_zone"`
 
-	Virtual     types.Bool `tfsdk:"virtual"`
-	BuyoutPort  types.Bool `tfsdk:"buyout_port"`
-	Locked      types.Bool `tfsdk:"locked"`
-	AdminLocked types.Bool `tfsdk:"admin_locked"`
-	Cancelable  types.Bool `tfsdk:"cancelable"`
-
 	Vendor types.String `tfsdk:"vendor"`
 	Size   types.String `tfsdk:"mve_size"`
 
-	VendorConfig types.Object `tfsdk:"vendor_config"`
+	// Per-vendor config blocks. Exactly one must be set.
+	ArubaConfig    types.Object `tfsdk:"aruba_config"`
+	AviatrixConfig types.Object `tfsdk:"aviatrix_config"`
+	CiscoConfig    types.Object `tfsdk:"cisco_config"`
+	FortinetConfig types.Object `tfsdk:"fortinet_config"`
+	MerakiConfig   types.Object `tfsdk:"meraki_config"`
+	PaloAltoConfig types.Object `tfsdk:"palo_alto_config"`
+	PrismaConfig   types.Object `tfsdk:"prisma_config"`
+	SixwindConfig  types.Object `tfsdk:"sixwind_config"`
+	VersaConfig    types.Object `tfsdk:"versa_config"`
+	VmwareConfig   types.Object `tfsdk:"vmware_config"`
 
 	NetworkInterfaces types.List `tfsdk:"vnics"`
 	AttributeTags     types.Map  `tfsdk:"attribute_tags"`
@@ -87,7 +74,114 @@ type mveResourceModel struct {
 // mveNetworkInterfaceModel represents a vNIC.
 type mveNetworkInterfaceModel struct {
 	Description types.String `tfsdk:"description"`
-	VLAN        types.Int64  `tfsdk:"vlan"`
+}
+
+// Per-vendor config model structs.
+
+type arubaConfigModel struct {
+	ImageID     types.Int64  `tfsdk:"image_id"`
+	ProductSize types.String `tfsdk:"product_size"`
+	MVELabel    types.String `tfsdk:"mve_label"`
+	AccountName types.String `tfsdk:"account_name"`
+	AccountKey  types.String `tfsdk:"account_key"`
+	SystemTag   types.String `tfsdk:"system_tag"`
+}
+
+type aviatrixConfigModel struct {
+	ImageID     types.Int64  `tfsdk:"image_id"`
+	ProductSize types.String `tfsdk:"product_size"`
+	MVELabel    types.String `tfsdk:"mve_label"`
+	CloudInit   types.String `tfsdk:"cloud_init"`
+}
+
+type ciscoConfigModel struct {
+	ImageID            types.Int64  `tfsdk:"image_id"`
+	ProductSize        types.String `tfsdk:"product_size"`
+	MVELabel           types.String `tfsdk:"mve_label"`
+	AdminSSHPublicKey  types.String `tfsdk:"admin_ssh_public_key"`
+	SSHPublicKey       types.String `tfsdk:"ssh_public_key"`
+	AdminPassword      types.String `tfsdk:"admin_password"`
+	ManageLocally      types.Bool   `tfsdk:"manage_locally"`
+	CloudInit          types.String `tfsdk:"cloud_init"`
+	FMCIPAddress       types.String `tfsdk:"fmc_ip_address"`
+	FMCRegistrationKey types.String `tfsdk:"fmc_registration_key"`
+	FMCNatID           types.String `tfsdk:"fmc_nat_id"`
+}
+
+type fortinetConfigModel struct {
+	ImageID           types.Int64  `tfsdk:"image_id"`
+	ProductSize       types.String `tfsdk:"product_size"`
+	MVELabel          types.String `tfsdk:"mve_label"`
+	AdminSSHPublicKey types.String `tfsdk:"admin_ssh_public_key"`
+	SSHPublicKey      types.String `tfsdk:"ssh_public_key"`
+	LicenseData       types.String `tfsdk:"license_data"`
+}
+
+type merakiConfigModel struct {
+	ImageID     types.Int64  `tfsdk:"image_id"`
+	ProductSize types.String `tfsdk:"product_size"`
+	MVELabel    types.String `tfsdk:"mve_label"`
+	Token       types.String `tfsdk:"token"`
+}
+
+type paloAltoConfigModel struct {
+	ImageID           types.Int64  `tfsdk:"image_id"`
+	ProductSize       types.String `tfsdk:"product_size"`
+	MVELabel          types.String `tfsdk:"mve_label"`
+	SSHPublicKey      types.String `tfsdk:"ssh_public_key"`
+	AdminPasswordHash types.String `tfsdk:"admin_password_hash"`
+	LicenseData       types.String `tfsdk:"license_data"`
+}
+
+type prismaConfigModel struct {
+	ImageID     types.Int64  `tfsdk:"image_id"`
+	ProductSize types.String `tfsdk:"product_size"`
+	MVELabel    types.String `tfsdk:"mve_label"`
+	IONKey      types.String `tfsdk:"ion_key"`
+	SecretKey   types.String `tfsdk:"secret_key"`
+}
+
+type sixwindConfigModel struct {
+	ImageID      types.Int64  `tfsdk:"image_id"`
+	ProductSize  types.String `tfsdk:"product_size"`
+	MVELabel     types.String `tfsdk:"mve_label"`
+	SSHPublicKey types.String `tfsdk:"ssh_public_key"`
+}
+
+type versaConfigModel struct {
+	ImageID           types.Int64  `tfsdk:"image_id"`
+	ProductSize       types.String `tfsdk:"product_size"`
+	MVELabel          types.String `tfsdk:"mve_label"`
+	DirectorAddress   types.String `tfsdk:"director_address"`
+	ControllerAddress types.String `tfsdk:"controller_address"`
+	LocalAuth         types.String `tfsdk:"local_auth"`
+	RemoteAuth        types.String `tfsdk:"remote_auth"`
+	SerialNumber      types.String `tfsdk:"serial_number"`
+}
+
+type vmwareConfigModel struct {
+	ImageID           types.Int64  `tfsdk:"image_id"`
+	ProductSize       types.String `tfsdk:"product_size"`
+	MVELabel          types.String `tfsdk:"mve_label"`
+	AdminSSHPublicKey types.String `tfsdk:"admin_ssh_public_key"`
+	SSHPublicKey      types.String `tfsdk:"ssh_public_key"`
+	VcoAddress        types.String `tfsdk:"vco_address"`
+	VcoActivationCode types.String `tfsdk:"vco_activation_code"`
+}
+
+// mveVendorConfigPaths lists path expressions for all per-vendor config blocks,
+// used with ExactlyOneOf validators.
+var mveVendorConfigPaths = []path.Expression{
+	path.MatchRoot("aruba_config"),
+	path.MatchRoot("aviatrix_config"),
+	path.MatchRoot("cisco_config"),
+	path.MatchRoot("fortinet_config"),
+	path.MatchRoot("meraki_config"),
+	path.MatchRoot("palo_alto_config"),
+	path.MatchRoot("prisma_config"),
+	path.MatchRoot("sixwind_config"),
+	path.MatchRoot("versa_config"),
+	path.MatchRoot("vmware_config"),
 }
 
 func toAPINetworkInterface(orm *mveNetworkInterfaceModel) *megaport.MVENetworkInterface {
@@ -96,88 +190,360 @@ func toAPINetworkInterface(orm *mveNetworkInterfaceModel) *megaport.MVENetworkIn
 	}
 }
 
-// vendorConfigModel represents the vendor configuration for an MVE.
-type vendorConfigModel struct {
-	Vendor             types.String `tfsdk:"vendor"`
-	ImageID            types.Int64  `tfsdk:"image_id"`
-	ProductSize        types.String `tfsdk:"product_size"`
-	MVELabel           types.String `tfsdk:"mve_label"`
-	AccountName        types.String `tfsdk:"account_name"`
-	AccountKey         types.String `tfsdk:"account_key"`
-	AdminSSHPublicKey  types.String `tfsdk:"admin_ssh_public_key"`
-	CloudInit          types.String `tfsdk:"cloud_init"`
-	LicenseData        types.String `tfsdk:"license_data"`
-	AdminPasswordHash  types.String `tfsdk:"admin_password_hash"`
-	AdminPassword      types.String `tfsdk:"admin_password"`
-	DirectorAddress    types.String `tfsdk:"director_address"`
-	ControllerAddress  types.String `tfsdk:"controller_address"`
-	LocalAuth          types.String `tfsdk:"local_auth"`
-	RemoteAuth         types.String `tfsdk:"remote_auth"`
-	ManageLocally      types.Bool   `tfsdk:"manage_locally"`
-	SerialNumber       types.String `tfsdk:"serial_number"`
-	SSHPublicKey       types.String `tfsdk:"ssh_public_key"`
-	SystemTag          types.String `tfsdk:"system_tag"`
-	VcoAddress         types.String `tfsdk:"vco_address"`
-	VcoActivationCode  types.String `tfsdk:"vco_activation_code"`
-	Token              types.String `tfsdk:"token"`
-	FMCIPAddress       types.String `tfsdk:"fmc_ip_address"`
-	FMCRegistrationKey types.String `tfsdk:"fmc_registration_key"`
-	FMCNatID           types.String `tfsdk:"fmc_nat_id"`
-	IONKey             types.String `tfsdk:"ion_key"`
-	SecretKey          types.String `tfsdk:"secret_key"`
+// vendorObjects returns all 10 vendor config blocks from the model.
+func (m *mveResourceModel) vendorObjects() []types.Object {
+	return []types.Object{
+		m.ArubaConfig, m.AviatrixConfig, m.CiscoConfig, m.FortinetConfig, m.MerakiConfig,
+		m.PaloAltoConfig, m.PrismaConfig, m.SixwindConfig, m.VersaConfig, m.VmwareConfig,
+	}
+}
+
+func objectSet(o types.Object) bool { return !o.IsNull() && !o.IsUnknown() }
+
+// allVendorConfigsNull reports whether all 10 vendor config blocks are null or unknown.
+func allVendorConfigsNull(m mveResourceModel) bool {
+	for _, o := range m.vendorObjects() {
+		if objectSet(o) {
+			return false
+		}
+	}
+	return true
+}
+
+// copyVendorConfigs copies all 10 vendor config blocks from src to dst.
+func copyVendorConfigs(dst, src *mveResourceModel) {
+	dst.ArubaConfig = src.ArubaConfig
+	dst.AviatrixConfig = src.AviatrixConfig
+	dst.CiscoConfig = src.CiscoConfig
+	dst.FortinetConfig = src.FortinetConfig
+	dst.MerakiConfig = src.MerakiConfig
+	dst.PaloAltoConfig = src.PaloAltoConfig
+	dst.PrismaConfig = src.PrismaConfig
+	dst.SixwindConfig = src.SixwindConfig
+	dst.VersaConfig = src.VersaConfig
+	dst.VmwareConfig = src.VmwareConfig
+}
+
+// vendorNameFromModel returns the canonical vendor name based on which config
+// block is set in the model, or "" if none is set.
+func vendorNameFromModel(m mveResourceModel) string {
+	switch {
+	case objectSet(m.ArubaConfig):
+		return "aruba"
+	case objectSet(m.AviatrixConfig):
+		return "aviatrix"
+	case objectSet(m.CiscoConfig):
+		return "cisco"
+	case objectSet(m.FortinetConfig):
+		return "fortinet"
+	case objectSet(m.MerakiConfig):
+		return "meraki"
+	case objectSet(m.PaloAltoConfig):
+		return "palo_alto"
+	case objectSet(m.PrismaConfig):
+		return "prisma"
+	case objectSet(m.SixwindConfig):
+		return "6wind"
+	case objectSet(m.VersaConfig):
+		return "versa"
+	case objectSet(m.VmwareConfig):
+		return "vmware"
+	}
+	return ""
+}
+
+// vendorConfigPath returns the root path for the config block matching the given
+// vendor name. Used for RequiresReplace in ModifyPlan.
+func vendorConfigPath(vendorName string) path.Path {
+	switch strings.ToLower(vendorName) {
+	case "aruba":
+		return path.Root("aruba_config")
+	case "aviatrix":
+		return path.Root("aviatrix_config")
+	case "cisco":
+		return path.Root("cisco_config")
+	case "fortinet":
+		return path.Root("fortinet_config")
+	case "meraki":
+		return path.Root("meraki_config")
+	case "palo_alto":
+		return path.Root("palo_alto_config")
+	case "prisma":
+		return path.Root("prisma_config")
+	case "6wind":
+		return path.Root("sixwind_config")
+	case "versa":
+		return path.Root("versa_config")
+	case "vmware":
+		return path.Root("vmware_config")
+	}
+	return path.Empty()
+}
+
+// blockForVendor returns the config block object for the given vendor name.
+func blockForVendor(m mveResourceModel, vendorName string) types.Object {
+	switch strings.ToLower(vendorName) {
+	case "aruba":
+		return m.ArubaConfig
+	case "aviatrix":
+		return m.AviatrixConfig
+	case "cisco":
+		return m.CiscoConfig
+	case "fortinet":
+		return m.FortinetConfig
+	case "meraki":
+		return m.MerakiConfig
+	case "palo_alto":
+		return m.PaloAltoConfig
+	case "prisma":
+		return m.PrismaConfig
+	case "6wind":
+		return m.SixwindConfig
+	case "versa":
+		return m.VersaConfig
+	case "vmware":
+		return m.VmwareConfig
+	}
+	return types.ObjectNull(nil)
+}
+
+// vendorBlockEqualIgnoringSizeCase compares two vendor config objects, treating
+// product_size case-insensitively. The API normalizes product_size to uppercase,
+// so a case-only difference must not trigger a spurious replace.
+func vendorBlockEqualIgnoringSizeCase(a, b types.Object) bool {
+	if a.IsNull() != b.IsNull() {
+		return false
+	}
+	am := a.Attributes()
+	bm := b.Attributes()
+	if len(am) != len(bm) {
+		return false
+	}
+	for k, av := range am {
+		bv, ok := bm[k]
+		if !ok {
+			return false
+		}
+		if k == "product_size" {
+			as, aok := av.(types.String)
+			bs, bok := bv.(types.String)
+			if aok && bok {
+				if !strings.EqualFold(as.ValueString(), bs.ValueString()) {
+					return false
+				}
+				continue
+			}
+		}
+		if !av.Equal(bv) {
+			return false
+		}
+	}
+	return true
+}
+
+// toAPIVendorConfigFromModel converts the set per-vendor config block into a
+// megaport.VendorConfig. adminPassword is the write-only Cisco admin password
+// re-read from config in Create (it is never persisted to plan or state).
+func toAPIVendorConfigFromModel(ctx context.Context, m *mveResourceModel, adminPassword string) (megaport.VendorConfig, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	count := 0
+	for _, o := range m.vendorObjects() {
+		if objectSet(o) {
+			count++
+		}
+	}
+	if count != 1 {
+		diags.AddError(
+			"Invalid vendor configuration",
+			fmt.Sprintf("Exactly one vendor configuration block must be set, got %d.", count),
+		)
+		return nil, diags
+	}
+
+	switch {
+	case objectSet(m.ArubaConfig):
+		var cfg arubaConfigModel
+		diags.Append(m.ArubaConfig.As(ctx, &cfg, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &megaport.ArubaConfig{
+			Vendor:      "aruba",
+			ImageID:     int(cfg.ImageID.ValueInt64()),
+			ProductSize: cfg.ProductSize.ValueString(),
+			MVELabel:    cfg.MVELabel.ValueString(),
+			AccountName: cfg.AccountName.ValueString(),
+			AccountKey:  cfg.AccountKey.ValueString(),
+			SystemTag:   cfg.SystemTag.ValueString(),
+		}, diags
+	case objectSet(m.AviatrixConfig):
+		var cfg aviatrixConfigModel
+		diags.Append(m.AviatrixConfig.As(ctx, &cfg, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &megaport.AviatrixConfig{
+			Vendor:      "aviatrix",
+			ImageID:     int(cfg.ImageID.ValueInt64()),
+			ProductSize: cfg.ProductSize.ValueString(),
+			MVELabel:    cfg.MVELabel.ValueString(),
+			CloudInit:   cfg.CloudInit.ValueString(),
+		}, diags
+	case objectSet(m.CiscoConfig):
+		var cfg ciscoConfigModel
+		diags.Append(m.CiscoConfig.As(ctx, &cfg, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &megaport.CiscoConfig{
+			Vendor:             "cisco",
+			ImageID:            int(cfg.ImageID.ValueInt64()),
+			ProductSize:        cfg.ProductSize.ValueString(),
+			MVELabel:           cfg.MVELabel.ValueString(),
+			AdminSSHPublicKey:  cfg.AdminSSHPublicKey.ValueString(),
+			SSHPublicKey:       cfg.SSHPublicKey.ValueString(),
+			AdminPassword:      adminPassword,
+			ManageLocally:      cfg.ManageLocally.ValueBool(),
+			CloudInit:          cfg.CloudInit.ValueString(),
+			FMCIPAddress:       cfg.FMCIPAddress.ValueString(),
+			FMCRegistrationKey: cfg.FMCRegistrationKey.ValueString(),
+			FMCNatID:           cfg.FMCNatID.ValueString(),
+		}, diags
+	case objectSet(m.FortinetConfig):
+		var cfg fortinetConfigModel
+		diags.Append(m.FortinetConfig.As(ctx, &cfg, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &megaport.FortinetConfig{
+			Vendor:            "fortinet",
+			ImageID:           int(cfg.ImageID.ValueInt64()),
+			ProductSize:       cfg.ProductSize.ValueString(),
+			MVELabel:          cfg.MVELabel.ValueString(),
+			AdminSSHPublicKey: cfg.AdminSSHPublicKey.ValueString(),
+			SSHPublicKey:      cfg.SSHPublicKey.ValueString(),
+			LicenseData:       cfg.LicenseData.ValueString(),
+		}, diags
+	case objectSet(m.MerakiConfig):
+		var cfg merakiConfigModel
+		diags.Append(m.MerakiConfig.As(ctx, &cfg, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &megaport.MerakiConfig{
+			Vendor:      "meraki",
+			ImageID:     int(cfg.ImageID.ValueInt64()),
+			ProductSize: cfg.ProductSize.ValueString(),
+			MVELabel:    cfg.MVELabel.ValueString(),
+			Token:       cfg.Token.ValueString(),
+		}, diags
+	case objectSet(m.PaloAltoConfig):
+		var cfg paloAltoConfigModel
+		diags.Append(m.PaloAltoConfig.As(ctx, &cfg, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &megaport.PaloAltoConfig{
+			Vendor:            "palo_alto",
+			ImageID:           int(cfg.ImageID.ValueInt64()),
+			ProductSize:       cfg.ProductSize.ValueString(),
+			MVELabel:          cfg.MVELabel.ValueString(),
+			SSHPublicKey:      cfg.SSHPublicKey.ValueString(),
+			AdminPasswordHash: cfg.AdminPasswordHash.ValueString(),
+			LicenseData:       cfg.LicenseData.ValueString(),
+		}, diags
+	case objectSet(m.PrismaConfig):
+		var cfg prismaConfigModel
+		diags.Append(m.PrismaConfig.As(ctx, &cfg, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &megaport.PrismaConfig{
+			Vendor:      "prisma",
+			ImageID:     int(cfg.ImageID.ValueInt64()),
+			ProductSize: cfg.ProductSize.ValueString(),
+			MVELabel:    cfg.MVELabel.ValueString(),
+			IONKey:      cfg.IONKey.ValueString(),
+			SecretKey:   cfg.SecretKey.ValueString(),
+		}, diags
+	case objectSet(m.SixwindConfig):
+		var cfg sixwindConfigModel
+		diags.Append(m.SixwindConfig.As(ctx, &cfg, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &megaport.SixwindVSRConfig{
+			Vendor:       "6wind",
+			ImageID:      int(cfg.ImageID.ValueInt64()),
+			ProductSize:  cfg.ProductSize.ValueString(),
+			MVELabel:     cfg.MVELabel.ValueString(),
+			SSHPublicKey: cfg.SSHPublicKey.ValueString(),
+		}, diags
+	case objectSet(m.VersaConfig):
+		var cfg versaConfigModel
+		diags.Append(m.VersaConfig.As(ctx, &cfg, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &megaport.VersaConfig{
+			Vendor:            "versa",
+			ImageID:           int(cfg.ImageID.ValueInt64()),
+			ProductSize:       cfg.ProductSize.ValueString(),
+			MVELabel:          cfg.MVELabel.ValueString(),
+			DirectorAddress:   cfg.DirectorAddress.ValueString(),
+			ControllerAddress: cfg.ControllerAddress.ValueString(),
+			LocalAuth:         cfg.LocalAuth.ValueString(),
+			RemoteAuth:        cfg.RemoteAuth.ValueString(),
+			SerialNumber:      cfg.SerialNumber.ValueString(),
+		}, diags
+	case objectSet(m.VmwareConfig):
+		var cfg vmwareConfigModel
+		diags.Append(m.VmwareConfig.As(ctx, &cfg, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &megaport.VmwareConfig{
+			Vendor:            "vmware",
+			ImageID:           int(cfg.ImageID.ValueInt64()),
+			ProductSize:       cfg.ProductSize.ValueString(),
+			MVELabel:          cfg.MVELabel.ValueString(),
+			AdminSSHPublicKey: cfg.AdminSSHPublicKey.ValueString(),
+			SSHPublicKey:      cfg.SSHPublicKey.ValueString(),
+			VcoAddress:        cfg.VcoAddress.ValueString(),
+			VcoActivationCode: cfg.VcoActivationCode.ValueString(),
+		}, diags
+	}
+	diags.AddError("No vendor config set", "Exactly one vendor config block must be set")
+	return nil, diags
+}
+
+// planProductSizeFromModel extracts product_size from whichever vendor config
+// block is set in the model.
+func planProductSizeFromModel(m mveResourceModel) string {
+	vendor := vendorNameFromModel(m)
+	obj := blockForVendor(m, vendor)
+	if !objectSet(obj) {
+		return ""
+	}
+	if ps, ok := obj.Attributes()["product_size"].(types.String); ok {
+		return ps.ValueString()
+	}
+	return ""
 }
 
 func (orm *mveResourceModel) fromAPIMVE(ctx context.Context, p *megaport.MVE, tags map[string]string) diag.Diagnostics {
 	apiDiags := diag.Diagnostics{}
-	orm.ID = types.Int64Value(int64(p.ID))
 	orm.UID = types.StringValue(p.UID)
 	orm.Name = types.StringValue(p.Name)
-	orm.Type = types.StringValue(p.Type)
-	orm.ProvisioningStatus = types.StringValue(p.ProvisioningStatus)
-	orm.CreatedBy = types.StringValue(p.CreatedBy)
-	orm.Market = types.StringValue(p.Market)
 	orm.LocationID = types.Int64Value(int64(p.LocationID))
-	orm.UsageAlgorithm = types.StringValue(p.UsageAlgorithm)
 	orm.MarketplaceVisibility = types.BoolValue(p.MarketplaceVisibility)
-	orm.VXCPermitted = types.BoolValue(p.VXCPermitted)
-	orm.VXCAutoApproval = types.BoolValue(p.VXCAutoApproval)
-	orm.SecondaryName = types.StringValue(p.SecondaryName)
 	orm.CompanyUID = types.StringValue(p.CompanyUID)
-	orm.CompanyName = types.StringValue(p.CompanyName)
 	orm.ContractTermMonths = types.Int64Value(int64(p.ContractTermMonths))
-	orm.Virtual = types.BoolValue(p.Virtual)
-	orm.BuyoutPort = types.BoolValue(p.BuyoutPort)
-	orm.Locked = types.BoolValue(p.Locked)
-	orm.AdminLocked = types.BoolValue(p.AdminLocked)
-	orm.Cancelable = types.BoolValue(p.Cancelable)
 	orm.Vendor = types.StringValue(p.Vendor)
 	orm.Size = types.StringValue(p.Size)
-	orm.LiveDate = types.StringValue("")
-	orm.TerminateDate = types.StringValue("")
 	orm.CostCentre = types.StringValue(p.CostCentre)
 	orm.DiversityZone = types.StringValue(p.DiversityZone)
-
-	if p.CreateDate != nil {
-		orm.CreateDate = types.StringValue(p.CreateDate.Format(time.RFC850))
-	} else {
-		orm.CreateDate = types.StringValue("")
-	}
-	if p.TerminateDate != nil {
-		orm.TerminateDate = types.StringValue(p.TerminateDate.Format(time.RFC850))
-	}
-	if p.LiveDate != nil {
-		orm.LiveDate = types.StringValue(p.LiveDate.Format(time.RFC850))
-	}
-	if p.ContractStartDate != nil {
-		orm.ContractStartDate = types.StringValue(p.ContractStartDate.Format(time.RFC850))
-	} else {
-		orm.ContractStartDate = types.StringValue("")
-	}
-	if p.ContractEndDate != nil {
-		orm.ContractEndDate = types.StringValue(p.ContractEndDate.Format(time.RFC850))
-	} else {
-		orm.ContractEndDate = types.StringValue("")
-	}
 
 	if p.AttributeTags != nil {
 		tags, tagDiags := types.MapValueFrom(ctx, types.StringType, p.AttributeTags)
@@ -199,7 +565,6 @@ func (orm *mveResourceModel) fromAPIMVE(ctx context.Context, p *megaport.MVE, ta
 	for _, n := range p.NetworkInterfaces {
 		model := &mveNetworkInterfaceModel{
 			Description: types.StringValue(n.Description),
-			VLAN:        types.Int64Value(int64(n.VLAN)),
 		}
 		vnic, vnicDiags := types.ObjectValueFrom(ctx, vnicAttrs, model)
 		apiDiags = append(apiDiags, vnicDiags...)
@@ -212,128 +577,7 @@ func (orm *mveResourceModel) fromAPIMVE(ctx context.Context, p *megaport.MVE, ta
 	return apiDiags
 }
 
-func toAPIVendorConfig(v *vendorConfigModel) (megaport.VendorConfig, diag.Diagnostics) {
-	apiDiags := diag.Diagnostics{}
-	vendor := strings.ToLower(v.Vendor.ValueString()) // Allow for uppercase vendor names for more flexibility.
-	switch vendor {
-	case "6wind":
-		vsrConfig := &megaport.SixwindVSRConfig{
-			Vendor:       v.Vendor.ValueString(),
-			ImageID:      int(v.ImageID.ValueInt64()),
-			ProductSize:  v.ProductSize.ValueString(),
-			MVELabel:     v.MVELabel.ValueString(),
-			SSHPublicKey: v.SSHPublicKey.ValueString(),
-		}
-		return vsrConfig, apiDiags
-	case "aruba":
-		arubaConfig := &megaport.ArubaConfig{
-			Vendor:      v.Vendor.ValueString(),
-			ImageID:     int(v.ImageID.ValueInt64()),
-			ProductSize: v.ProductSize.ValueString(),
-			MVELabel:    v.MVELabel.ValueString(),
-			AccountName: v.AccountName.ValueString(),
-			AccountKey:  v.AccountKey.ValueString(),
-			SystemTag:   v.SystemTag.ValueString(),
-		}
-		return arubaConfig, apiDiags
-	case "aviatrix":
-		aviatrixConfig := &megaport.AviatrixConfig{
-			Vendor:      v.Vendor.ValueString(),
-			ImageID:     int(v.ImageID.ValueInt64()),
-			ProductSize: v.ProductSize.ValueString(),
-			MVELabel:    v.MVELabel.ValueString(),
-			CloudInit:   v.CloudInit.ValueString(),
-		}
-		return aviatrixConfig, apiDiags
-	case "cisco":
-		ciscoConfig := &megaport.CiscoConfig{
-			Vendor:             v.Vendor.ValueString(),
-			ImageID:            int(v.ImageID.ValueInt64()),
-			ProductSize:        v.ProductSize.ValueString(),
-			MVELabel:           v.MVELabel.ValueString(),
-			AdminSSHPublicKey:  v.AdminSSHPublicKey.ValueString(),
-			SSHPublicKey:       v.SSHPublicKey.ValueString(),
-			AdminPassword:      v.AdminPassword.ValueString(),
-			ManageLocally:      v.ManageLocally.ValueBool(),
-			CloudInit:          v.CloudInit.ValueString(),
-			FMCIPAddress:       v.FMCIPAddress.ValueString(),
-			FMCNatID:           v.FMCNatID.ValueString(),
-			FMCRegistrationKey: v.FMCRegistrationKey.ValueString(),
-		}
-		return ciscoConfig, apiDiags
-	case "fortinet":
-		fortinetConfig := &megaport.FortinetConfig{
-			Vendor:            v.Vendor.ValueString(),
-			ImageID:           int(v.ImageID.ValueInt64()),
-			ProductSize:       v.ProductSize.ValueString(),
-			MVELabel:          v.MVELabel.ValueString(),
-			AdminSSHPublicKey: v.AdminSSHPublicKey.ValueString(),
-			SSHPublicKey:      v.SSHPublicKey.ValueString(),
-			LicenseData:       v.LicenseData.ValueString(),
-		}
-		return fortinetConfig, apiDiags
-	case "palo_alto":
-		paloAltoConfig := &megaport.PaloAltoConfig{
-			Vendor:            v.Vendor.ValueString(),
-			ImageID:           int(v.ImageID.ValueInt64()),
-			ProductSize:       v.ProductSize.ValueString(),
-			MVELabel:          v.MVELabel.ValueString(),
-			SSHPublicKey:      v.SSHPublicKey.ValueString(),
-			AdminPasswordHash: v.AdminPasswordHash.ValueString(),
-			LicenseData:       v.LicenseData.ValueString(),
-		}
-		return paloAltoConfig, apiDiags
-	case "prisma":
-		prismaConfig := &megaport.PrismaConfig{
-			Vendor:      v.Vendor.ValueString(),
-			ImageID:     int(v.ImageID.ValueInt64()),
-			ProductSize: v.ProductSize.ValueString(),
-			MVELabel:    v.MVELabel.ValueString(),
-			IONKey:      v.IONKey.ValueString(),
-			SecretKey:   v.SecretKey.ValueString(),
-		}
-		return prismaConfig, apiDiags
-	case "versa":
-		versaConfig := &megaport.VersaConfig{
-			Vendor:            v.Vendor.ValueString(),
-			ImageID:           int(v.ImageID.ValueInt64()),
-			ProductSize:       v.ProductSize.ValueString(),
-			MVELabel:          v.MVELabel.ValueString(),
-			DirectorAddress:   v.DirectorAddress.ValueString(),
-			ControllerAddress: v.ControllerAddress.ValueString(),
-			LocalAuth:         v.LocalAuth.ValueString(),
-			RemoteAuth:        v.RemoteAuth.ValueString(),
-			SerialNumber:      v.SerialNumber.ValueString(),
-		}
-		return versaConfig, apiDiags
-	case "vmware":
-		vmwareConfig := &megaport.VmwareConfig{
-			Vendor:            v.Vendor.ValueString(),
-			ImageID:           int(v.ImageID.ValueInt64()),
-			ProductSize:       v.ProductSize.ValueString(),
-			MVELabel:          v.MVELabel.ValueString(),
-			AdminSSHPublicKey: v.AdminSSHPublicKey.ValueString(),
-			SSHPublicKey:      v.SSHPublicKey.ValueString(),
-			VcoAddress:        v.VcoAddress.ValueString(),
-			VcoActivationCode: v.VcoActivationCode.ValueString(),
-		}
-		return vmwareConfig, apiDiags
-	case "meraki":
-		merakiConfig := &megaport.MerakiConfig{
-			Vendor:      v.Vendor.ValueString(),
-			ImageID:     int(v.ImageID.ValueInt64()),
-			ProductSize: v.ProductSize.ValueString(),
-			MVELabel:    v.MVELabel.ValueString(),
-			Token:       v.Token.ValueString(),
-		}
-		return merakiConfig, apiDiags
-	}
-	apiDiags.AddError("vendor not supported",
-		"vendor not supported")
-	return nil, apiDiags
-}
-
-// NewPortResource is a helper function to simplify the provider implementation.
+// NewMVEResource is a helper function to simplify the provider implementation.
 func NewMVEResource() resource.Resource {
 	return &mveResource{}
 }
@@ -350,13 +594,16 @@ func (r *mveResource) Metadata(_ context.Context, req resource.MetadataRequest, 
 
 // Schema defines the schema for the resource.
 func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	vendorConfigPlanModifiers := []planmodifier.Object{
+		objectplanmodifier.UseStateForUnknown(),
+	}
+	vendorConfigValidators := []validator.Object{
+		objectvalidator.ExactlyOneOf(mveVendorConfigPaths...),
+	}
+
 	resp.Schema = schema.Schema{
 		Description: "Megaport Virtual Edge (MVE) Resource for Megaport Terraform provider. This resource allows you to create, modify, and delete Megaport MVEs. Megaport Virtual Edge (MVE) is an on-demand, vendor-neutral Network Function Virtualization (NFV) platform that provides virtual infrastructure for network services at the edge of Megaport’s global software-defined network (SDN). Network technologies such as SD-WAN and NGFW are hosted directly on Megaport’s global network via Megaport Virtual Edge. Use the `megaport_mve_sizes` data source to query available MVE sizes and the `megaport_mve_images` data source to query available MVE images.",
 		Attributes: map[string]schema.Attribute{
-			"last_updated": schema.StringAttribute{
-				Description: "The last time the MVE was updated by the Terraform Provider.",
-				Computed:    true,
-			},
 			"product_uid": schema.StringAttribute{
 				Description: "The unique identifier of the MVE.",
 				Computed:    true,
@@ -364,42 +611,9 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"product_id": schema.Int64Attribute{
-				Description: "The Numeric ID of the MVE.",
-				Computed:    true,
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.UseStateForUnknown(),
-				},
-			},
 			"product_name": schema.StringAttribute{
 				Description: "The name of the MVE.",
 				Required:    true,
-			},
-			"provisioning_status": schema.StringAttribute{
-				Description: "The provisioning status of the MVE. This field represents the current state (e.g., CONFIGURED, LIVE, DECOMMISSIONED) and may transition through multiple states during the MVE lifecycle. During import, this field will populate from the API and may show as changing from unknown to its actual value on first apply - this is expected behavior.",
-				Computed:    true,
-			},
-			"create_date": schema.StringAttribute{
-				Description: "The date the MVE was created. This timestamp is set by the Megaport API at creation time. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"created_by": schema.StringAttribute{
-				Description: "The user who created the MVE.",
-				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"terminate_date": schema.StringAttribute{
-				Description: "The date the MVE will be or was terminated. This value is set by the Megaport API when termination is scheduled or completed. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
-			},
-			"live_date": schema.StringAttribute{
-				Description: "The date the MVE went live. This value is set by the Megaport API when the MVE becomes active. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
 			},
 			"diversity_zone": schema.StringAttribute{
 				Description: "The diversity zone of the MVE.",
@@ -410,25 +624,11 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"market": schema.StringAttribute{
-				Description: "The market the MVE is in.",
-				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
 			"location_id": schema.Int64Attribute{
 				Description: "The numeric location ID of the product. This value can be retrieved from the data source megaport_location.",
 				Required:    true,
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.RequiresReplace(),
-				},
-			},
-			"product_type": schema.StringAttribute{
-				Description: "The type of product (MVE).",
-				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"contract_term_months": schema.Int64Attribute{
@@ -438,27 +638,12 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 					int64validator.OneOf(1, 12, 24, 36, 48, 60),
 				},
 			},
-			"usage_algorithm": schema.StringAttribute{
-				Description: "The usage algorithm of the MVE.",
-				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
 			"company_uid": schema.StringAttribute{
 				Description: "The company UID of the MVE.",
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
-			},
-			"contract_start_date": schema.StringAttribute{
-				Description: "The date the contract starts. This value is managed by the Megaport API and may be updated when the MVE is provisioned or when contract terms change. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
-			},
-			"contract_end_date": schema.StringAttribute{
-				Description: "The date the contract ends. This value is calculated by the Megaport API based on the contract start date and term. During import, this field may show as changing from unknown to its actual value - this is expected behavior.",
-				Computed:    true,
 			},
 			"cost_centre": schema.StringAttribute{
 				Description: "The cost centre of the MVE.",
@@ -467,69 +652,6 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 			},
 			"marketplace_visibility": schema.BoolAttribute{
 				Description: "Whether the MVE is visible in the marketplace.",
-				Computed:    true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"vxc_permitted": schema.BoolAttribute{
-				Description: "Whether VXC is permitted.",
-				Computed:    true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"vxc_auto_approval": schema.BoolAttribute{
-				Description: "Whether VXC is auto approved.",
-				Computed:    true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"secondary_name": schema.StringAttribute{
-				Description: "The secondary name of the MVE.",
-				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"company_name": schema.StringAttribute{
-				Description: "The company name of the MVE.",
-				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"virtual": schema.BoolAttribute{
-				Description: "Whether the MVE is virtual.",
-				Computed:    true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"buyout_port": schema.BoolAttribute{
-				Description: "Whether the port is buyout.",
-				Computed:    true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"locked": schema.BoolAttribute{
-				Description: "Whether the MVE is locked.",
-				Computed:    true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"admin_locked": schema.BoolAttribute{
-				Description: "Whether the MVE is admin locked.",
-				Computed:    true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"cancelable": schema.BoolAttribute{
-				Description: "Whether the MVE is cancelable.",
 				Computed:    true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
@@ -571,13 +693,6 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 							Description: "The description of the network interface.",
 							Required:    true,
 						},
-						"vlan": schema.Int64Attribute{
-							Description: "The VLAN of the network interface.",
-							Computed:    true,
-							PlanModifiers: []planmodifier.Int64{
-								int64planmodifier.UseStateForUnknown(),
-							},
-						},
 					},
 				},
 				PlanModifiers: []planmodifier.List{
@@ -593,133 +708,149 @@ func (r *mveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 					mapplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"vendor_config": schema.SingleNestedAttribute{
-				Description: "The vendor configuration of the MVE. Vendor-specific information required to bootstrap the MVE. These values will be different for each vendor, and can include vendor name, size of VM, license/activation code, software version, and SSH keys. This field cannot be changed after the MVE is created and if it is modified, the MVE will be deleted and re-created. Imported MVEs do not have this field populated by the API, so the initially provided configuration will be ignored as it can't be verified to be correct. If the user wants to change the configuration after importing the resource, they can then do so by changing the field after importing the resource and running terraform apply.",
-				Required:    true,
-				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.UseStateForUnknown(),
-				},
+			// Per-vendor config blocks. Exactly one must be set. The block that is
+			// populated implies the vendor; only image_id and product_size are
+			// required, all other fields remain optional because the API is the
+			// source of truth for what each vendor image needs.
+			"aruba_config": schema.SingleNestedAttribute{
+				Description:   "Aruba MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes.",
+				Optional:      true,
+				PlanModifiers: vendorConfigPlanModifiers,
+				Validators:    vendorConfigValidators,
 				Attributes: map[string]schema.Attribute{
-					"vendor": schema.StringAttribute{
-						Description: `The name of vendor of the MVE. Currently supported values: "6wind", "aruba", "aviatrix", "cisco", "fortinet", "palo_alto", "prisma", "versa", "vmware", "meraki".`,
-						Required:    true,
-					},
-					"image_id": schema.Int64Attribute{
-						Description: "The image ID of the MVE. Indicates the software version.",
-						Required:    true,
-					},
-					"product_size": schema.StringAttribute{
-						Description: "The product size for the vendor config. The size defines the MVE specifications including number of cores, bandwidth, and number of connections. Use the `megaport_mve_sizes` data source to query available sizes dynamically. Common values include SMALL (2 cores), MEDIUM (4 cores), LARGE (8 cores), X_LARGE_16 (16 cores), and X_LARGE_32 (32 cores).",
-						Required:    true,
-					},
-					"mve_label": schema.StringAttribute{
-						Description: "The MVE label for the vendor config.",
-						Optional:    true,
-					},
-					"account_name": schema.StringAttribute{
-						Description: "The account name for the vendor config. Enter the Account Name from Aruba Orchestrator. To view your Account Name, log in to Orchestrator and choose Orchestrator > Licensing | Cloud Portal. Required for Aruba MVE.",
-						Optional:    true,
-					},
-					"account_key": schema.StringAttribute{
-						Description: "The account key for the vendor config. Enter the Account Key from Aruba Orchestrator. The key is linked to the Account Name. Required for Aruba MVE.",
-						Sensitive:   true,
-						Optional:    true,
-					},
-					"admin_ssh_public_key": schema.StringAttribute{
-						Description: "The admin SSH public key for the vendor config. Required for Cisco, Fortinet, and Vmware MVEs.",
-						Optional:    true,
-					},
-					"ssh_public_key": schema.StringAttribute{
-						Description: "The SSH public key for the vendor config. Required for 6WIND, VMWare, Palo Alto, and Fortinet MVEs. Must be a 2048-bit RSA key (ed25519 and other key types are not supported). You can generate a compatible key using: ssh-keygen -t rsa -b 2048 -C 'your_email@example.com'",
-						Optional:    true,
-					},
-					"cloud_init": schema.StringAttribute{
-						Description: "The Base64 encoded cloud init file for the vendor config. The bootstrap configuration file. Required for Aviatrix and Cisco C8000v.",
-						Optional:    true,
-					},
-					"license_data": schema.StringAttribute{
-						Description: "The license data for the vendor config. Required for Fortinet and Palo Alto MVEs.",
-						Sensitive:   true,
-						Optional:    true,
-					},
-					"admin_password_hash": schema.StringAttribute{
-						Description: "The sha256crypt-formatted admin password hash for the vendor config. Required for Palo Alto VM-Series MVE; not used by any other vendor. Must match the format `$5$<salt>$<hash>` (e.g. `$5$2833ea35$Pdyc6dKE8N/UBRge3QWDJJyotG3I59pxLJWVmcSQDdC`). On Linux/macOS you can generate this with `mkpasswd -m sha-256 'your_password'`. This value is only consumed when the MVE is provisioned to seed the initial admin account; after deployment, manage the password via the Palo Alto management interface (the provider does not read this value back from the API).",
-						Sensitive:   true,
-						Optional:    true,
-					},
-					"admin_password": schema.StringAttribute{
-						Description: "Plain-text admin password for the vendor config. Required for Cisco FTDv (Firewall) MVE only; Palo Alto MVE uses `admin_password_hash` instead. Must be 9–100 characters and may not contain `\"`, carriage return, or line feed. This value is only consumed when the MVE is provisioned to seed the initial admin account; after deployment, manage the password via the vendor's management interface. Declared as a [write-only argument](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral/write-only) (Terraform 1.11+) so the password is not persisted in the Terraform plan or state.",
-						Optional:    true,
-						Sensitive:   true,
-						WriteOnly:   true,
-					},
-					"director_address": schema.StringAttribute{
-						Description: "The director address for the vendor config. A FQDN (Fully Qualified Domain Name) or IPv4 address of your Versa Director. Required for Versa MVE.",
-						Optional:    true,
-					},
-					"controller_address": schema.StringAttribute{
-						Description: "The controldler address for the vendor config. A FQDN (Fully Qualified Domain Name) or IPv4 address of your Versa Controller. Required for Versa MVE.",
-						Optional:    true,
-					},
-					"manage_locally": schema.BoolAttribute{
-						Description: "Whether to manage the MVE locally. Required for Cisco MVE.",
-						Optional:    true,
-					},
-					"local_auth": schema.StringAttribute{
-						Description: "The local auth for the vendor config. Enter the Local Auth string as configured in your Versa Director. Required for Versa MVE.",
-						Sensitive:   true,
-						Optional:    true,
-					},
-					"remote_auth": schema.StringAttribute{
-						Description: "The remote auth for the vendor config. Enter the Remote Auth string as configured in your Versa Director. Required for Versa MVE.",
-						Sensitive:   true,
-						Optional:    true,
-					},
-					"serial_number": schema.StringAttribute{
-						Description: "The serial number for the vendor config. Enter the serial number that you specified when creating the device in Versa Director. Required for Versa MVE.",
-						Optional:    true,
-					},
-					"system_tag": schema.StringAttribute{
-						Description: "The system tag for the vendor config. Aruba Orchestrator System Tags and preconfiguration templates register the EC-V with the Cloud Portal and Orchestrator, and enable Orchestrator to automatically accept and configure newly discovered EC-V appliances. If you created a preconfiguration template in Orchestrator, enter the System Tag you specified here. Required for Aruba MVE.",
-						Optional:    true,
-					},
-					"vco_address": schema.StringAttribute{
-						Description: "The VCO address for the vendor config. A FQDN (Fully Qualified Domain Name) or IPv4 or IPv6 address for the Orchestrator where you created the edge device. Required for VMware MVE.",
-						Optional:    true,
-					},
-					"vco_activation_code": schema.StringAttribute{
-						Description: "The VCO activation code for the vendor config. This is provided by Orchestrator after creating the edge device. Required for VMware MVE.",
-						Sensitive:   true,
-						Optional:    true,
-					},
-					"fmc_ip_address": schema.StringAttribute{
-						Description: "The FMC IP address for the vendor config. Required for Cisco FTDv (Firewall) MVE.",
-						Optional:    true,
-					},
-					"fmc_registration_key": schema.StringAttribute{
-						Description: "The FMC registration key for the vendor config. Required for Cisco FTDv (Firewall) MVE.",
-						Sensitive:   true,
-						Optional:    true,
-					},
-					"fmc_nat_id": schema.StringAttribute{
-						Description: "The FMC NAT ID for the vendor config. Required for Cisco FTDv (Firewall) MVE.",
-						Optional:    true,
-					},
-					"token": schema.StringAttribute{
-						Description: "The token for the vendor config. Required for Meraki MVE.",
-						Sensitive:   true,
-						Optional:    true,
-					},
-					"ion_key": schema.StringAttribute{
-						Description: "The vION key for the vendor config. Required for Prisma MVE.",
-						Sensitive:   true,
-						Optional:    true,
-					},
-					"secret_key": schema.StringAttribute{
-						Description: "The secret key for the vendor config. Required for Prisma MVE.",
-						Sensitive:   true,
-						Optional:    true,
-					},
+					"image_id":     schema.Int64Attribute{Description: "The image ID of the MVE. Indicates the software version.", Required: true},
+					"product_size": schema.StringAttribute{Description: "The product size for the vendor config.", Required: true},
+					"mve_label":    schema.StringAttribute{Description: "The MVE label for the vendor config.", Optional: true},
+					"account_name": schema.StringAttribute{Description: "The account name for the vendor config. Enter the Account Name from Aruba Orchestrator.", Optional: true},
+					"account_key":  schema.StringAttribute{Description: "The account key for the vendor config. Enter the Account Key from Aruba Orchestrator.", Optional: true, Sensitive: true},
+					"system_tag":   schema.StringAttribute{Description: "The system tag for the vendor config. Aruba Orchestrator System Tags register the EC-V with the Cloud Portal and Orchestrator.", Optional: true},
+				},
+			},
+			"aviatrix_config": schema.SingleNestedAttribute{
+				Description:   "Aviatrix MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes.",
+				Optional:      true,
+				PlanModifiers: vendorConfigPlanModifiers,
+				Validators:    vendorConfigValidators,
+				Attributes: map[string]schema.Attribute{
+					"image_id":     schema.Int64Attribute{Description: "The image ID of the MVE. Indicates the software version.", Required: true},
+					"product_size": schema.StringAttribute{Description: "The product size for the vendor config.", Required: true},
+					"mve_label":    schema.StringAttribute{Description: "The MVE label for the vendor config.", Optional: true},
+					"cloud_init":   schema.StringAttribute{Description: "The Base64 encoded cloud init file for the vendor config. The bootstrap configuration file. Required for Aviatrix.", Optional: true},
+				},
+			},
+			"cisco_config": schema.SingleNestedAttribute{
+				Description:   "Cisco MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes.",
+				Optional:      true,
+				PlanModifiers: vendorConfigPlanModifiers,
+				Validators:    vendorConfigValidators,
+				Attributes: map[string]schema.Attribute{
+					"image_id":             schema.Int64Attribute{Description: "The image ID of the MVE. Indicates the software version.", Required: true},
+					"product_size":         schema.StringAttribute{Description: "The product size for the vendor config.", Required: true},
+					"mve_label":            schema.StringAttribute{Description: "The MVE label for the vendor config.", Optional: true},
+					"admin_ssh_public_key": schema.StringAttribute{Description: "The admin SSH public key for the vendor config.", Optional: true},
+					"ssh_public_key":       schema.StringAttribute{Description: "The SSH public key for the vendor config.", Optional: true},
+					"admin_password":       schema.StringAttribute{Description: "Plain-text admin password for the vendor config. Required for Cisco FTDv (Firewall) MVE only. Must be 9–100 characters and may not contain `\"`, carriage return, or line feed. This value is only consumed when the MVE is provisioned to seed the initial admin account; after deployment, manage the password via the vendor's management interface. Declared as a [write-only argument](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral/write-only) (Terraform 1.11+) so the password is not persisted in the Terraform plan or state.", Optional: true, Sensitive: true, WriteOnly: true},
+					"manage_locally":       schema.BoolAttribute{Description: "Whether to manage the MVE locally. Required for Cisco MVE.", Optional: true},
+					"cloud_init":           schema.StringAttribute{Description: "The Base64 encoded cloud init file for the vendor config. Required for Cisco C8000v.", Optional: true},
+					"fmc_ip_address":       schema.StringAttribute{Description: "The FMC IP address for the vendor config. Required for Cisco FTDv (Firewall) MVE.", Optional: true},
+					"fmc_registration_key": schema.StringAttribute{Description: "The FMC registration key for the vendor config. Required for Cisco FTDv (Firewall) MVE.", Optional: true, Sensitive: true},
+					"fmc_nat_id":           schema.StringAttribute{Description: "The FMC NAT ID for the vendor config. Required for Cisco FTDv (Firewall) MVE.", Optional: true},
+				},
+			},
+			"fortinet_config": schema.SingleNestedAttribute{
+				Description:   "Fortinet MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes.",
+				Optional:      true,
+				PlanModifiers: vendorConfigPlanModifiers,
+				Validators:    vendorConfigValidators,
+				Attributes: map[string]schema.Attribute{
+					"image_id":             schema.Int64Attribute{Description: "The image ID of the MVE. Indicates the software version.", Required: true},
+					"product_size":         schema.StringAttribute{Description: "The product size for the vendor config.", Required: true},
+					"mve_label":            schema.StringAttribute{Description: "The MVE label for the vendor config.", Optional: true},
+					"admin_ssh_public_key": schema.StringAttribute{Description: "The admin SSH public key for the vendor config.", Optional: true},
+					"ssh_public_key":       schema.StringAttribute{Description: "The SSH public key for the vendor config. Must be a 2048-bit RSA key.", Optional: true},
+					"license_data":         schema.StringAttribute{Description: "The license data for the vendor config. Required for Fortinet.", Optional: true, Sensitive: true},
+				},
+			},
+			"meraki_config": schema.SingleNestedAttribute{
+				Description:   "Meraki MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes.",
+				Optional:      true,
+				PlanModifiers: vendorConfigPlanModifiers,
+				Validators:    vendorConfigValidators,
+				Attributes: map[string]schema.Attribute{
+					"image_id":     schema.Int64Attribute{Description: "The image ID of the MVE. Indicates the software version.", Required: true},
+					"product_size": schema.StringAttribute{Description: "The product size for the vendor config.", Required: true},
+					"mve_label":    schema.StringAttribute{Description: "The MVE label for the vendor config.", Optional: true},
+					"token":        schema.StringAttribute{Description: "The token for the vendor config. Required for Meraki.", Optional: true, Sensitive: true},
+				},
+			},
+			"palo_alto_config": schema.SingleNestedAttribute{
+				Description:   "Palo Alto MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes.",
+				Optional:      true,
+				PlanModifiers: vendorConfigPlanModifiers,
+				Validators:    vendorConfigValidators,
+				Attributes: map[string]schema.Attribute{
+					"image_id":            schema.Int64Attribute{Description: "The image ID of the MVE. Indicates the software version.", Required: true},
+					"product_size":        schema.StringAttribute{Description: "The product size for the vendor config.", Required: true},
+					"mve_label":           schema.StringAttribute{Description: "The MVE label for the vendor config.", Optional: true},
+					"ssh_public_key":      schema.StringAttribute{Description: "The SSH public key for the vendor config. Must be a 2048-bit RSA key.", Optional: true},
+					"admin_password_hash": schema.StringAttribute{Description: "The sha256crypt-formatted admin password hash for the vendor config. Required for Palo Alto VM-Series MVE. Must match the format `$5$<salt>$<hash>`.", Optional: true, Sensitive: true},
+					"license_data":        schema.StringAttribute{Description: "The license data for the vendor config. Required for Palo Alto.", Optional: true, Sensitive: true},
+				},
+			},
+			"prisma_config": schema.SingleNestedAttribute{
+				Description:   "Prisma MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes.",
+				Optional:      true,
+				PlanModifiers: vendorConfigPlanModifiers,
+				Validators:    vendorConfigValidators,
+				Attributes: map[string]schema.Attribute{
+					"image_id":     schema.Int64Attribute{Description: "The image ID of the MVE. Indicates the software version.", Required: true},
+					"product_size": schema.StringAttribute{Description: "The product size for the vendor config.", Required: true},
+					"mve_label":    schema.StringAttribute{Description: "The MVE label for the vendor config.", Optional: true},
+					"ion_key":      schema.StringAttribute{Description: "The vION key for the vendor config. Required for Prisma.", Optional: true, Sensitive: true},
+					"secret_key":   schema.StringAttribute{Description: "The secret key for the vendor config. Required for Prisma.", Optional: true, Sensitive: true},
+				},
+			},
+			"sixwind_config": schema.SingleNestedAttribute{
+				Description:   "6WIND MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes.",
+				Optional:      true,
+				PlanModifiers: vendorConfigPlanModifiers,
+				Validators:    vendorConfigValidators,
+				Attributes: map[string]schema.Attribute{
+					"image_id":       schema.Int64Attribute{Description: "The image ID of the MVE. Indicates the software version.", Required: true},
+					"product_size":   schema.StringAttribute{Description: "The product size for the vendor config.", Required: true},
+					"mve_label":      schema.StringAttribute{Description: "The MVE label for the vendor config.", Optional: true},
+					"ssh_public_key": schema.StringAttribute{Description: "The SSH public key for the vendor config. Must be a 2048-bit RSA key.", Optional: true},
+				},
+			},
+			"versa_config": schema.SingleNestedAttribute{
+				Description:   "Versa MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes.",
+				Optional:      true,
+				PlanModifiers: vendorConfigPlanModifiers,
+				Validators:    vendorConfigValidators,
+				Attributes: map[string]schema.Attribute{
+					"image_id":           schema.Int64Attribute{Description: "The image ID of the MVE. Indicates the software version.", Required: true},
+					"product_size":       schema.StringAttribute{Description: "The product size for the vendor config.", Required: true},
+					"mve_label":          schema.StringAttribute{Description: "The MVE label for the vendor config.", Optional: true},
+					"director_address":   schema.StringAttribute{Description: "A FQDN or IPv4 address of your Versa Director. Required for Versa.", Optional: true},
+					"controller_address": schema.StringAttribute{Description: "A FQDN or IPv4 address of your Versa Controller. Required for Versa.", Optional: true},
+					"local_auth":         schema.StringAttribute{Description: "The local auth string as configured in your Versa Director. Required for Versa.", Optional: true, Sensitive: true},
+					"remote_auth":        schema.StringAttribute{Description: "The remote auth string as configured in your Versa Director. Required for Versa.", Optional: true, Sensitive: true},
+					"serial_number":      schema.StringAttribute{Description: "The serial number specified when creating the device in Versa Director. Required for Versa.", Optional: true},
+				},
+			},
+			"vmware_config": schema.SingleNestedAttribute{
+				Description:   "VMware MVE vendor configuration. Exactly one vendor config block must be set. The MVE is destroyed and re-created if this block changes.",
+				Optional:      true,
+				PlanModifiers: vendorConfigPlanModifiers,
+				Validators:    vendorConfigValidators,
+				Attributes: map[string]schema.Attribute{
+					"image_id":             schema.Int64Attribute{Description: "The image ID of the MVE. Indicates the software version.", Required: true},
+					"product_size":         schema.StringAttribute{Description: "The product size for the vendor config.", Required: true},
+					"mve_label":            schema.StringAttribute{Description: "The MVE label for the vendor config.", Optional: true},
+					"admin_ssh_public_key": schema.StringAttribute{Description: "The admin SSH public key for the vendor config.", Optional: true},
+					"ssh_public_key":       schema.StringAttribute{Description: "The SSH public key for the vendor config. Must be a 2048-bit RSA key.", Optional: true},
+					"vco_address":          schema.StringAttribute{Description: "A FQDN or IPv4/IPv6 address for the Orchestrator where you created the edge device. Required for VMware.", Optional: true},
+					"vco_activation_code":  schema.StringAttribute{Description: "The VCO activation code provided by Orchestrator after creating the edge device. Required for VMware.", Optional: true, Sensitive: true},
 				},
 			},
 		},
@@ -757,24 +888,17 @@ func (r *mveResource) Create(ctx context.Context, req resource.CreateRequest, re
 		mveReq.ResourceTags = tagMap
 	}
 
-	if plan.VendorConfig.IsNull() {
-		resp.Diagnostics.AddError(
-			"vendor config required", "vendor config required",
-		)
-	}
-	vcModel := &vendorConfigModel{}
-	vcDiags := plan.VendorConfig.As(ctx, vcModel, basetypes.ObjectAsOptions{})
-	resp.Diagnostics = append(resp.Diagnostics, vcDiags...)
-	// admin_password is a write-only attribute, so it is null in req.Plan.
-	// Pull it from req.Config and apply it to the vendor model before mapping
-	// to the API request.
+	// admin_password is a write-only attribute (Cisco FTDv), so it is null in
+	// req.Plan. Re-read it from req.Config and pass it through to the API request.
 	var configAdminPassword types.String
-	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("vendor_config").AtName("admin_password"), &configAdminPassword)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if objectSet(plan.CiscoConfig) {
+		resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("cisco_config").AtName("admin_password"), &configAdminPassword)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
-	vcModel.AdminPassword = configAdminPassword
-	vendorConfig, apiVCDiags := toAPIVendorConfig(vcModel)
+
+	vendorConfig, apiVCDiags := toAPIVendorConfigFromModel(ctx, &plan, configAdminPassword.ValueString())
 	resp.Diagnostics = append(resp.Diagnostics, apiVCDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -834,7 +958,6 @@ func (r *mveResource) Create(ctx context.Context, req resource.CreateRequest, re
 	// update the plan with the MVE info
 	apiDiags := plan.fromAPIMVE(ctx, mve, tags)
 	resp.Diagnostics = append(resp.Diagnostics, apiDiags...)
-	plan.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, plan)
@@ -889,6 +1012,7 @@ func (r *mveResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
+	// fromAPIMVE does not touch the vendor config blocks; they remain from state.
 	apiDiags := state.fromAPIMVE(ctx, mve, tags)
 	resp.Diagnostics = append(resp.Diagnostics, apiDiags...)
 
@@ -906,11 +1030,11 @@ func (r *mveResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
-	// Preserve the plan's VendorConfig in state. This handles two cases:
-	// 1. After Import, VendorConfig in state is null — adopt the plan value.
-	// 2. Case-only changes (e.g., "aruba" → "aRuBa") — adopt the plan's casing
-	//    so Terraform doesn't see an inconsistent result after apply.
-	state.VendorConfig = plan.VendorConfig
+	// Preserve the plan's vendor config blocks in state. This handles two cases:
+	// 1. After Import, the vendor config blocks in state are null — adopt the plan value.
+	// 2. Case-only changes (e.g., "small" → "SMALL") — adopt the plan's casing so
+	//    Terraform doesn't see an inconsistent result after apply.
+	copyVendorConfigs(&state, &plan)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -987,7 +1111,6 @@ func (r *mveResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	apiDiags := state.fromAPIMVE(ctx, updatedMVE, tags)
 	resp.Diagnostics = append(resp.Diagnostics, apiDiags...)
 
-	state.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
 	state.PromoCode = plan.PromoCode
 
 	diags := resp.State.Set(ctx, state)
@@ -1055,14 +1178,16 @@ func (r *mveResource) ImportState(ctx context.Context, req resource.ImportStateR
 }
 
 func (r *mveResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	// Get the plan and state
+	if req.Plan.Raw.IsNull() {
+		// Destroy operation — nothing to do.
+		return
+	}
+
 	var plan, state mveResourceModel
-	if !req.Plan.Raw.IsNull() {
-		planDiags := req.Plan.Get(ctx, &plan)
-		resp.Diagnostics.Append(planDiags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
+	planDiags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(planDiags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 	if !req.State.Raw.IsNull() {
 		stateDiags := req.State.Get(ctx, &state)
@@ -1072,70 +1197,53 @@ func (r *mveResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 		}
 	}
 
-	if !state.UID.IsNull() {
-		// If VendorConfig is null in the state, set it to the value from the plan
-		if state.VendorConfig.IsNull() {
-			// Add this check to avoid trying to convert a null value
-			if plan.VendorConfig.IsNull() {
-				// Both state and plan have null VendorConfig, nothing to do
-				return
-			}
-			var planVendorConfig vendorConfigModel
-			planVendorConfigDiags := plan.VendorConfig.As(ctx, &planVendorConfig, basetypes.ObjectAsOptions{})
-			resp.Diagnostics = append(resp.Diagnostics, planVendorConfigDiags...)
-			if resp.Diagnostics.HasError() {
-				return
-			}
-			// Check the computed vendor/size values from the API. If the vendor or size changes, require a replace - check with case insensitivity.
+	// Only evaluate immutability on an existing resource.
+	if state.UID.IsNull() {
+		return
+	}
 
-			if !strings.EqualFold(state.Size.ValueString(), planVendorConfig.ProductSize.ValueString()) {
-				resp.RequiresReplace = append(resp.RequiresReplace, path.Root("vendor_config"))
-			}
+	planVendor := vendorNameFromModel(plan)
+	cfgPath := vendorConfigPath(planVendor)
 
-			if !strings.EqualFold(state.Vendor.ValueString(), planVendorConfig.Vendor.ValueString()) {
-				resp.RequiresReplace = append(resp.RequiresReplace, path.Root("vendor_config"))
-			}
-			state.VendorConfig = plan.VendorConfig
-		} else if !plan.VendorConfig.Equal(state.VendorConfig) {
-			// During destroy, the plan's VendorConfig is null — nothing to compare.
-			if plan.VendorConfig.IsNull() || plan.VendorConfig.IsUnknown() {
-				// No replacement decision needed during destroy.
-			} else {
-				// vendor_config cannot be changed after creation — require replace on
-				// any change. However, the API normalizes vendor/size to uppercase
-				// (e.g., "aruba" → "ARUBA"), so Equal() can return false on casing
-				// differences alone. Compare vendor and size case-insensitively to
-				// avoid unnecessary destroy+recreate on case-only changes.
-				var planVC vendorConfigModel
-				planVCDiags := plan.VendorConfig.As(ctx, &planVC, basetypes.ObjectAsOptions{})
-				resp.Diagnostics.Append(planVCDiags...)
-				if resp.Diagnostics.HasError() {
-					return
-				}
-				if !strings.EqualFold(state.Vendor.ValueString(), planVC.Vendor.ValueString()) ||
-					!strings.EqualFold(state.Size.ValueString(), planVC.ProductSize.ValueString()) {
-					// Vendor or size changed (case-insensitive) — must replace.
-					resp.RequiresReplace = append(resp.RequiresReplace, path.Root("vendor_config"))
-				} else {
-					// Vendor/size match case-insensitively. Normalize them in the
-					// plan to match state casing, then check remaining fields.
-					planVC.Vendor = types.StringValue(state.Vendor.ValueString())
-					planVC.ProductSize = types.StringValue(state.Size.ValueString())
-					normalized, normDiags := types.ObjectValueFrom(ctx, plan.VendorConfig.AttributeTypes(ctx), &planVC)
-					resp.Diagnostics.Append(normDiags...)
-					if resp.Diagnostics.HasError() {
-						return
-					}
-					if !normalized.Equal(state.VendorConfig) {
-						resp.RequiresReplace = append(resp.RequiresReplace, path.Root("vendor_config"))
-					}
-				}
-			}
-		}
-		diags := req.State.Set(ctx, &state)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
+	if allVendorConfigsNull(state) {
+		// Import scenario: vendor config blocks are null in state. Compare the
+		// plan's vendor/size against the API-derived state values (which are
+		// uppercase), requiring replacement only when they differ. The compare is
+		// case-insensitive because the API normalizes vendor/size to uppercase.
+		if allVendorConfigsNull(plan) {
 			return
 		}
+
+		if !state.Vendor.IsNull() && !state.Vendor.IsUnknown() &&
+			!strings.EqualFold(state.Vendor.ValueString(), planVendor) {
+			resp.RequiresReplace = append(resp.RequiresReplace, cfgPath)
+		}
+
+		if !state.Size.IsNull() && !state.Size.IsUnknown() {
+			planSize := planProductSizeFromModel(plan)
+			if planSize != "" && !strings.EqualFold(state.Size.ValueString(), planSize) {
+				resp.RequiresReplace = append(resp.RequiresReplace, cfgPath)
+			}
+		}
+		return
+	}
+
+	// Existing resource with a vendor config block in state. The vendor config is
+	// immutable, so any change requires replacement. A change of vendor (a
+	// different block being set) always requires replacement; otherwise compare
+	// the block contents, treating product_size case-insensitively.
+	stateVendor := vendorNameFromModel(state)
+	if !strings.EqualFold(stateVendor, planVendor) {
+		resp.RequiresReplace = append(resp.RequiresReplace, cfgPath)
+		return
+	}
+
+	planObj := blockForVendor(plan, planVendor)
+	stateObj := blockForVendor(state, stateVendor)
+	if planObj.IsNull() || planObj.IsUnknown() {
+		return
+	}
+	if !vendorBlockEqualIgnoringSizeCase(planObj, stateObj) {
+		resp.RequiresReplace = append(resp.RequiresReplace, cfgPath)
 	}
 }

--- a/internal/provider/mve_resource_test.go
+++ b/internal/provider/mve_resource_test.go
@@ -42,8 +42,7 @@ func TestAccMegaportMVEAruba_Basic(t *testing.T) {
 					cost_centre = "%s"
 					diversity_zone = "red"
 
-                    vendor_config = {
-                        vendor = "aruba"
+                    aruba_config = {
                         product_size = "SMALL"
 						mve_label = "MVE 2/8"
                         image_id = data.megaport_mve_images.aruba.mve_images.0.id
@@ -74,21 +73,14 @@ func TestAccMegaportMVEAruba_Basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_name", mveName),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", costCentre),
-					resource.TestCheckResourceAttr("megaport_mve.mve", "product_type", "MVE"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "contract_term_months", "1"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "vendor", "ARUBA"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "mve_size", "SMALL"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "resource_tags.key1", "value1"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "resource_tags.key2", "value2"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_uid"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_id"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "provisioning_status"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "create_date"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "created_by"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "market"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "location_id"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "company_uid"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "company_name"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "diversity_zone", "red"),
 				),
 			},
@@ -110,7 +102,7 @@ func TestAccMegaportMVEAruba_Basic(t *testing.T) {
 					}
 					return rawState["product_uid"], nil
 				},
-				ImportStateVerifyIgnore: []string{"last_updated", "contract_start_date", "contract_end_date", "live_date", "vendor_config", "resources", "provisioning_status"},
+				ImportStateVerifyIgnore: []string{"aruba_config", "resources"},
 			},
 			// Update Testing
 			{
@@ -136,8 +128,7 @@ func TestAccMegaportMVEAruba_Basic(t *testing.T) {
 						"key2updated" = "value2updated"
 					}
 
-                    vendor_config = {
-                        vendor = "aRuBa"
+                    aruba_config = {
                         product_size = "SmAlL"
 						mve_label = "MVE 2/8"
                         image_id = data.megaport_mve_images.aruba.mve_images.0.id
@@ -163,7 +154,6 @@ func TestAccMegaportMVEAruba_Basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_name", mveNameNew),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", costCentreNew),
-					resource.TestCheckResourceAttr("megaport_mve.mve", "product_type", "MVE"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "contract_term_months", "1"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "vendor", "ARUBA"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "mve_size", "SMALL"),
@@ -171,14 +161,8 @@ func TestAccMegaportMVEAruba_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("megaport_mve.mve", "resource_tags.key1updated", "value1updated"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "resource_tags.key2updated", "value2updated"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_uid"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_id"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "provisioning_status"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "create_date"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "created_by"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "market"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "location_id"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "company_uid"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "company_name"),
 				),
 			},
 			// Make sure resource has not been destroyed by change of casing in Vendor Config
@@ -199,7 +183,7 @@ func TestAccMegaportMVEAruba_Basic(t *testing.T) {
 					}
 					return rawState["product_uid"], nil
 				},
-				ImportStateVerifyIgnore: []string{"last_updated", "contract_start_date", "contract_end_date", "live_date", "vendor_config", "resources", "provisioning_status"},
+				ImportStateVerifyIgnore: []string{"aruba_config", "resources"},
 			},
 		},
 	})
@@ -230,8 +214,7 @@ func TestAccMegaportMVEAruba_CostCentreRemoval(t *testing.T) {
 					contract_term_months = 1
 					cost_centre = "%s"
 					diversity_zone = "red"
-					vendor_config = {
-						vendor = "aruba"
+					aruba_config = {
 						product_size = "SMALL"
 						mve_label = "MVE 2/8"
 						image_id = data.megaport_mve_images.aruba.mve_images.0.id
@@ -274,8 +257,7 @@ func TestAccMegaportMVEAruba_CostCentreRemoval(t *testing.T) {
 					contract_term_months = 1
 					cost_centre = ""
 					diversity_zone = "red"
-					vendor_config = {
-						vendor = "aruba"
+					aruba_config = {
 						product_size = "SMALL"
 						mve_label = "MVE 2/8"
 						image_id = data.megaport_mve_images.aruba.mve_images.0.id
@@ -333,8 +315,7 @@ func TestAccMegaportMVEAruba_PromoCode(t *testing.T) {
 			location_id          = data.megaport_location.test_location.id
 			contract_term_months = 1
 			%s
-			vendor_config = {
-				vendor       = "aruba"
+			aruba_config = {
 				product_size = "SMALL"
 				mve_label    = "MVE 2/8"
 				image_id     = data.megaport_mve_images.aruba.mve_images.0.id
@@ -406,8 +387,7 @@ func TestAccMegaportMVEAruba_ContractTermUpdate(t *testing.T) {
 					location_id = data.megaport_location.test_location.id
 					contract_term_months = 12
 					diversity_zone = "red"
-					vendor_config = {
-						vendor = "aruba"
+					aruba_config = {
 						product_size = "SMALL"
 						mve_label = "MVE 2/8"
 						image_id = data.megaport_mve_images.aruba.mve_images.0.id
@@ -447,8 +427,7 @@ func TestAccMegaportMVEAruba_ContractTermUpdate(t *testing.T) {
 					location_id = data.megaport_location.test_location.id
 					contract_term_months = 24
 					diversity_zone = "red"
-					vendor_config = {
-						vendor = "aruba"
+					aruba_config = {
 						product_size = "SMALL"
 						mve_label = "MVE 2/8"
 						image_id = data.megaport_mve_images.aruba.mve_images.0.id
@@ -511,8 +490,7 @@ func TestAccMegaportMVEVersa_Basic(t *testing.T) {
 						"key2" = "value2"
 					}
 
-                    vendor_config = {
-                        vendor = "versa"
+                    versa_config = {
                         product_size = "SMALL"
 						mve_label = "MVE 2/8"
                         image_id = data.megaport_mve_images.versa.mve_images.0.id
@@ -540,21 +518,14 @@ func TestAccMegaportMVEVersa_Basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_name", mveName),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", costCentre),
-					resource.TestCheckResourceAttr("megaport_mve.mve", "product_type", "MVE"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "contract_term_months", "1"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "vendor", "VERSA"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "mve_size", "SMALL"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "resource_tags.key1", "value1"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "resource_tags.key2", "value2"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_uid"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_id"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "provisioning_status"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "create_date"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "created_by"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "market"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "location_id"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "company_uid"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "company_name"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "diversity_zone", "red"),
 				),
 			},
@@ -576,7 +547,7 @@ func TestAccMegaportMVEVersa_Basic(t *testing.T) {
 					}
 					return rawState["product_uid"], nil
 				},
-				ImportStateVerifyIgnore: []string{"last_updated", "contract_start_date", "contract_end_date", "live_date", "resources", "vendor_config", "provisioning_status"},
+				ImportStateVerifyIgnore: []string{"versa_config", "resources"},
 			},
 			// Update Testing
 			{
@@ -602,8 +573,7 @@ func TestAccMegaportMVEVersa_Basic(t *testing.T) {
 						"key2updated" = "value2updated"
 					}
 
-                    vendor_config = {
-                        vendor = "versa"
+                    versa_config = {
                         product_size = "SMALL"
 						mve_label = "MVE 2/8"
                         image_id = data.megaport_mve_images.versa.mve_images.0.id
@@ -631,21 +601,14 @@ func TestAccMegaportMVEVersa_Basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_name", mveNameNew),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", costCentreNew),
-					resource.TestCheckResourceAttr("megaport_mve.mve", "product_type", "MVE"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "contract_term_months", "1"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "vendor", "VERSA"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "mve_size", "SMALL"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "resource_tags.key1updated", "value1updated"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "resource_tags.key2updated", "value2updated"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_uid"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_id"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "provisioning_status"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "create_date"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "created_by"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "market"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "location_id"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "company_uid"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "company_name"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "diversity_zone", "red"),
 				),
 			},
@@ -667,7 +630,7 @@ func TestAccMegaportMVEVersa_Basic(t *testing.T) {
 					}
 					return rawState["product_uid"], nil
 				},
-				ImportStateVerifyIgnore: []string{"last_updated", "contract_start_date", "contract_end_date", "live_date", "resources", "vendor_config", "provisioning_status"},
+				ImportStateVerifyIgnore: []string{"versa_config", "resources"},
 			},
 		},
 	})
@@ -703,8 +666,7 @@ func TestAccMegaportMVEImport_WithLifecycleIgnoreChanges(t *testing.T) {
                     cost_centre = "%s"
                     diversity_zone = "red"
 
-                    vendor_config = {
-                        vendor = "aruba"
+                    aruba_config = {
                         product_size = "SMALL"
                         mve_label = "MVE Import Test"
                         image_id = data.megaport_mve_images.aruba.mve_images.0.id
@@ -742,7 +704,7 @@ func TestAccMegaportMVEImport_WithLifecycleIgnoreChanges(t *testing.T) {
 					}
 					return rawState["product_uid"], nil
 				},
-				ImportStateVerifyIgnore: []string{"last_updated", "contract_start_date", "contract_end_date", "live_date", "vendor_config", "resources", "provisioning_status"},
+				ImportStateVerifyIgnore: []string{"aruba_config", "resources"},
 			},
 			// Test a modification with lifecycle.ignore_changes
 			{
@@ -763,8 +725,7 @@ func TestAccMegaportMVEImport_WithLifecycleIgnoreChanges(t *testing.T) {
                     cost_centre = "%s-updated"
                     diversity_zone = "red"
 
-                    vendor_config = {
-                        vendor = "aruba"
+                    aruba_config = {
                         product_size = "SMALL"
                         mve_label = "MVE Import Test"
                         image_id = data.megaport_mve_images.aruba.mve_images.0.id
@@ -781,7 +742,7 @@ func TestAccMegaportMVEImport_WithLifecycleIgnoreChanges(t *testing.T) {
                     }]
 
                     lifecycle {
-                        ignore_changes = [vendor_config]
+                        ignore_changes = [aruba_config]
                     }
                 }`, locationID, MVEArubaImageIDMVE, mveName, costCentre, mveName, mveKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -832,8 +793,7 @@ func TestAccMegaportMVECisco_Basic(t *testing.T) {
 					cost_centre          = "%s"
 					diversity_zone       = "red"
 
-					vendor_config = {
-						vendor         = "cisco"
+					cisco_config = {
 						product_size   = "MEDIUM"
 						mve_label      = "MVE 4/16"
 						image_id       = data.megaport_mve_images.cisco.mve_images.0.id
@@ -851,20 +811,13 @@ func TestAccMegaportMVECisco_Basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_name", mveName),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", costCentre),
-					resource.TestCheckResourceAttr("megaport_mve.mve", "product_type", "MVE"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "contract_term_months", "1"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "vendor", "CISCO"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "diversity_zone", "red"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "mve_size"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_uid"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_id"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "provisioning_status"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "create_date"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "created_by"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "market"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "location_id"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "company_uid"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "company_name"),
 				),
 			},
 			// ImportState testing
@@ -885,7 +838,7 @@ func TestAccMegaportMVECisco_Basic(t *testing.T) {
 					}
 					return rawState["product_uid"], nil
 				},
-				ImportStateVerifyIgnore: []string{"last_updated", "contract_start_date", "contract_end_date", "live_date", "vendor_config", "resources", "provisioning_status"},
+				ImportStateVerifyIgnore: []string{"cisco_config", "resources"},
 			},
 			// Update: rename and change cost centre.
 			{
@@ -906,8 +859,7 @@ func TestAccMegaportMVECisco_Basic(t *testing.T) {
 					cost_centre          = "%s"
 					diversity_zone       = "red"
 
-					vendor_config = {
-						vendor         = "cisco"
+					cisco_config = {
 						product_size   = "MEDIUM"
 						mve_label      = "MVE 4/16"
 						image_id       = data.megaport_mve_images.cisco.mve_images.0.id
@@ -970,8 +922,7 @@ func TestAccMegaportMVEPaloAlto_Basic(t *testing.T) {
 					cost_centre          = "%s"
 					diversity_zone       = "red"
 
-					vendor_config = {
-						vendor              = "palo_alto"
+					palo_alto_config = {
 						product_size        = "MEDIUM"
 						mve_label           = "MVE 4/16"
 						image_id            = data.megaport_mve_images.palo_alto.mve_images.0.id
@@ -987,20 +938,13 @@ func TestAccMegaportMVEPaloAlto_Basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_name", mveName),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", costCentre),
-					resource.TestCheckResourceAttr("megaport_mve.mve", "product_type", "MVE"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "contract_term_months", "1"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "vendor", "PALO_ALTO"),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "diversity_zone", "red"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "mve_size"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_uid"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_id"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "provisioning_status"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "create_date"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "created_by"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "market"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "location_id"),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "company_uid"),
-					resource.TestCheckResourceAttrSet("megaport_mve.mve", "company_name"),
 				),
 			},
 			// ImportState testing
@@ -1021,7 +965,7 @@ func TestAccMegaportMVEPaloAlto_Basic(t *testing.T) {
 					}
 					return rawState["product_uid"], nil
 				},
-				ImportStateVerifyIgnore: []string{"last_updated", "contract_start_date", "contract_end_date", "live_date", "vendor_config", "resources", "provisioning_status"},
+				ImportStateVerifyIgnore: []string{"palo_alto_config", "resources"},
 			},
 			// Update: rename and change cost centre.
 			{
@@ -1042,8 +986,7 @@ func TestAccMegaportMVEPaloAlto_Basic(t *testing.T) {
 					cost_centre          = "%s"
 					diversity_zone       = "red"
 
-					vendor_config = {
-						vendor              = "palo_alto"
+					palo_alto_config = {
 						product_size        = "MEDIUM"
 						mve_label           = "MVE 4/16"
 						image_id            = data.megaport_mve_images.palo_alto.mve_images.0.id


### PR DESCRIPTION
Re-cut of #352 (that PR's stack is dead). Two changes to `megaport_mve`.

**Per-vendor config split.** The single union `vendor_config` block is replaced by one Optional block per vendor: `aruba_config`, `aviatrix_config`, `cisco_config`, `fortinet_config`, `meraki_config`, `palo_alto_config`, `prisma_config`, `sixwind_config`, `versa_config`, `vmware_config`. `ExactlyOneOf` enforces that one and only one is set, and the vendor is inferred from the block, so the old `vendor` selector string is gone. Only `image_id` and `product_size` are required per block; the API stays the source of truth for the rest.

**Legacy field removal.** Drops the 21 deprecated read-only fields (`last_updated`, `product_id`, `provisioning_status`, `create_date`, `created_by`, `terminate_date`, `live_date`, `market`, `product_type`, `usage_algorithm`, `contract_start_date`, `contract_end_date`, `vxc_permitted`, `vxc_auto_approval`, `secondary_name`, `company_name`, `virtual`, `buyout_port`, `locked`, `admin_locked`, `cancelable`) plus `vnics.vlan`.

- `admin_password` (Cisco FTDv, write-only + sensitive) is preserved and re-read from config in Create.
- Adds a `ResourceWithMoveState` migrator for V1 to V2: the V2 schema doubles as the source schema, so the framework decode drops the removed fields, the old union block, and `vnics.vlan`; per-vendor blocks reconcile from config on the next apply.
- Sensitive flags unchanged from the current schema; no fields promoted to Sensitive.

Verified: `go build`, `golangci-lint` (0 issues), unit tests, `gofmt`, and `go generate` (only `docs/resources/mve.md` changes) all clean.