### PR TITLE
ESD-1620: normalize inner_vlan -1/0 in verifyUpdateApplied

### DIFF
--- a/internal/provider/vxc_resource.go
+++ b/internal/provider/vxc_resource.go
@@ -2510,7 +2510,7 @@ func (r *vxcResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	// Only show VLAN mismatch warnings if waitForVXCUpdate failed (timed out or errored)
 	if isChanged && waitErr != nil {
-		if updateReq.AEndInnerVLAN != nil && vxc.AEndConfiguration.InnerVLAN != *updateReq.AEndInnerVLAN {
+		if updateReq.AEndInnerVLAN != nil && !innerVLANMatches(*updateReq.AEndInnerVLAN, vxc.AEndConfiguration.InnerVLAN) {
 			resp.Diagnostics.AddWarning(
 				"A-End Inner VLAN Mismatch",
 				fmt.Sprintf("Expected A-End inner_vlan=%d but API returned %d. This may indicate API propagation delay.",
@@ -2518,7 +2518,7 @@ func (r *vxcResource) Update(ctx context.Context, req resource.UpdateRequest, re
 			)
 		}
 
-		if updateReq.BEndInnerVLAN != nil && vxc.BEndConfiguration.InnerVLAN != *updateReq.BEndInnerVLAN {
+		if updateReq.BEndInnerVLAN != nil && !innerVLANMatches(*updateReq.BEndInnerVLAN, vxc.BEndConfiguration.InnerVLAN) {
 			resp.Diagnostics.AddWarning(
 				"B-End Inner VLAN Mismatch",
 				fmt.Sprintf("Expected B-End inner_vlan=%d but API returned %d. This may indicate API propagation delay.",

--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -3526,12 +3526,6 @@ func TestAccMegaportMVE_to_MVE_VXC(t *testing.T) {
                     }
                 }
                 `,
-					// This step is expected to log a "VXC Update Propagation Delay" warning and
-					// take the full updateTimeout (120s): verifyUpdateApplied compares the
-					// requested inner_vlan=-1 directly against the API's returned value, which is
-					// 0 for an untagged end, so it never matches. This is not new flakiness; it's
-					// a known provider gap (verifyUpdateApplied doesn't normalize -1/0 the way
-					// fromAPIVXC's Read-path does), tracked in a separate follow-up ticket.
 					MVEArubaImageID,
 					mveName1, mveLocationID, mveName1, mveName1,
 					mveName2, mveLocationID, mveName2, mveName2,

--- a/internal/provider/vxc_resource_utils.go
+++ b/internal/provider/vxc_resource_utils.go
@@ -927,6 +927,16 @@ func (r *vxcResource) waitForVXCUpdate(ctx context.Context, uid string, updateRe
 	return fmt.Errorf("update verification timed out after %v", timeout)
 }
 
+// innerVLANMatches compares a requested inner VLAN to the value returned by the API,
+// treating requested -1 (untagged) as satisfied by a returned 0, mirroring the
+// normalization fromAPIVXC applies on Read.
+func innerVLANMatches(requested, actual int) bool {
+	if requested == -1 && actual == 0 {
+		return true
+	}
+	return requested == actual
+}
+
 // verifyUpdateApplied checks if the VXC returned from the API matches the expected values
 // from the update request. It verifies all fields that can be updated.
 //
@@ -937,10 +947,10 @@ func (r *vxcResource) waitForVXCUpdate(ctx context.Context, uid string, updateRe
 // Returns true if all updated fields match their expected values, false otherwise.
 func (r *vxcResource) verifyUpdateApplied(vxc *megaport.VXC, updateReq *megaport.UpdateVXCRequest) bool {
 	// Verify VLAN-related fields
-	if updateReq.AEndInnerVLAN != nil && vxc.AEndConfiguration.InnerVLAN != *updateReq.AEndInnerVLAN {
+	if updateReq.AEndInnerVLAN != nil && !innerVLANMatches(*updateReq.AEndInnerVLAN, vxc.AEndConfiguration.InnerVLAN) {
 		return false
 	}
-	if updateReq.BEndInnerVLAN != nil && vxc.BEndConfiguration.InnerVLAN != *updateReq.BEndInnerVLAN {
+	if updateReq.BEndInnerVLAN != nil && !innerVLANMatches(*updateReq.BEndInnerVLAN, vxc.BEndConfiguration.InnerVLAN) {
 		return false
 	}
 	if updateReq.AEndVLAN != nil && vxc.AEndConfiguration.VLAN != *updateReq.AEndVLAN {

--- a/internal/provider/vxc_resource_utils_test.go
+++ b/internal/provider/vxc_resource_utils_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	megaport "github.com/megaport/megaportgo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -158,3 +159,101 @@ func TestIPSecPhaseLifetimeValidator(t *testing.T) {
 		})
 	}
 }
+
+// TestVerifyUpdateApplied covers the -1 (requested untagged) / 0 (API
+// returned untagged) inner VLAN normalization, a genuine mismatch that must
+// still fail, and unrelated fields being unaffected by the normalization.
+func TestVerifyUpdateApplied(t *testing.T) {
+	intPtr := func(v int) *int { return &v }
+
+	cases := []struct {
+		name      string
+		vxc       *megaport.VXC
+		updateReq *megaport.UpdateVXCRequest
+		want      bool
+	}{
+		{
+			name: "untagged inner VLAN match: requested -1, API returns 0",
+			vxc: &megaport.VXC{
+				AEndConfiguration: megaport.VXCEndConfiguration{InnerVLAN: 0},
+				BEndConfiguration: megaport.VXCEndConfiguration{InnerVLAN: 0},
+			},
+			updateReq: &megaport.UpdateVXCRequest{
+				AEndInnerVLAN: intPtr(-1),
+				BEndInnerVLAN: intPtr(-1),
+			},
+			want: true,
+		},
+		{
+			name: "genuine inner VLAN mismatch is not masked",
+			vxc: &megaport.VXC{
+				AEndConfiguration: megaport.VXCEndConfiguration{InnerVLAN: 200},
+			},
+			updateReq: &megaport.UpdateVXCRequest{
+				AEndInnerVLAN: intPtr(100),
+			},
+			want: false,
+		},
+		{
+			name: "requested -1 but API returns a tagged value is a mismatch",
+			vxc: &megaport.VXC{
+				AEndConfiguration: megaport.VXCEndConfiguration{InnerVLAN: 100},
+			},
+			updateReq: &megaport.UpdateVXCRequest{
+				AEndInnerVLAN: intPtr(-1),
+			},
+			want: false,
+		},
+		{
+			name: "matching non-zero inner VLAN values still verify",
+			vxc: &megaport.VXC{
+				AEndConfiguration: megaport.VXCEndConfiguration{InnerVLAN: 100},
+				BEndConfiguration: megaport.VXCEndConfiguration{InnerVLAN: 200},
+			},
+			updateReq: &megaport.UpdateVXCRequest{
+				AEndInnerVLAN: intPtr(100),
+				BEndInnerVLAN: intPtr(200),
+			},
+			want: true,
+		},
+		{
+			name: "unrelated fields (name, rate limit) unaffected by normalization",
+			vxc: &megaport.VXC{
+				Name:      "updated-name",
+				RateLimit: 500,
+				AEndConfiguration: megaport.VXCEndConfiguration{
+					InnerVLAN: 0,
+				},
+			},
+			updateReq: &megaport.UpdateVXCRequest{
+				AEndInnerVLAN: intPtr(-1),
+				Name:          strPtr("updated-name"),
+				RateLimit:     intPtr(500),
+			},
+			want: true,
+		},
+		{
+			name: "unrelated field mismatch still fails despite VLAN match",
+			vxc: &megaport.VXC{
+				Name: "current-name",
+				AEndConfiguration: megaport.VXCEndConfiguration{
+					InnerVLAN: 0,
+				},
+			},
+			updateReq: &megaport.UpdateVXCRequest{
+				AEndInnerVLAN: intPtr(-1),
+				Name:          strPtr("different-name"),
+			},
+			want: false,
+		},
+	}
+
+	r := &vxcResource{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, r.verifyUpdateApplied(tc.vxc, tc.updateReq))
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/provider/vxc_resource_utils_test.go
+++ b/internal/provider/vxc_resource_utils_test.go
@@ -164,8 +164,6 @@ func TestIPSecPhaseLifetimeValidator(t *testing.T) {
 // returned untagged) inner VLAN normalization, a genuine mismatch that must
 // still fail, and unrelated fields being unaffected by the normalization.
 func TestVerifyUpdateApplied(t *testing.T) {
-	intPtr := func(v int) *int { return &v }
-
 	cases := []struct {
 		name      string
 		vxc       *megaport.VXC
@@ -179,8 +177,8 @@ func TestVerifyUpdateApplied(t *testing.T) {
 				BEndConfiguration: megaport.VXCEndConfiguration{InnerVLAN: 0},
 			},
 			updateReq: &megaport.UpdateVXCRequest{
-				AEndInnerVLAN: intPtr(-1),
-				BEndInnerVLAN: intPtr(-1),
+				AEndInnerVLAN: megaport.PtrTo(-1),
+				BEndInnerVLAN: megaport.PtrTo(-1),
 			},
 			want: true,
 		},
@@ -190,7 +188,7 @@ func TestVerifyUpdateApplied(t *testing.T) {
 				AEndConfiguration: megaport.VXCEndConfiguration{InnerVLAN: 200},
 			},
 			updateReq: &megaport.UpdateVXCRequest{
-				AEndInnerVLAN: intPtr(100),
+				AEndInnerVLAN: megaport.PtrTo(100),
 			},
 			want: false,
 		},
@@ -200,7 +198,7 @@ func TestVerifyUpdateApplied(t *testing.T) {
 				AEndConfiguration: megaport.VXCEndConfiguration{InnerVLAN: 100},
 			},
 			updateReq: &megaport.UpdateVXCRequest{
-				AEndInnerVLAN: intPtr(-1),
+				AEndInnerVLAN: megaport.PtrTo(-1),
 			},
 			want: false,
 		},
@@ -211,8 +209,8 @@ func TestVerifyUpdateApplied(t *testing.T) {
 				BEndConfiguration: megaport.VXCEndConfiguration{InnerVLAN: 200},
 			},
 			updateReq: &megaport.UpdateVXCRequest{
-				AEndInnerVLAN: intPtr(100),
-				BEndInnerVLAN: intPtr(200),
+				AEndInnerVLAN: megaport.PtrTo(100),
+				BEndInnerVLAN: megaport.PtrTo(200),
 			},
 			want: true,
 		},
@@ -226,9 +224,9 @@ func TestVerifyUpdateApplied(t *testing.T) {
 				},
 			},
 			updateReq: &megaport.UpdateVXCRequest{
-				AEndInnerVLAN: intPtr(-1),
-				Name:          strPtr("updated-name"),
-				RateLimit:     intPtr(500),
+				AEndInnerVLAN: megaport.PtrTo(-1),
+				Name:          megaport.PtrTo("updated-name"),
+				RateLimit:     megaport.PtrTo(500),
 			},
 			want: true,
 		},
@@ -241,8 +239,8 @@ func TestVerifyUpdateApplied(t *testing.T) {
 				},
 			},
 			updateReq: &megaport.UpdateVXCRequest{
-				AEndInnerVLAN: intPtr(-1),
-				Name:          strPtr("different-name"),
+				AEndInnerVLAN: megaport.PtrTo(-1),
+				Name:          megaport.PtrTo("different-name"),
 			},
 			want: false,
 		},
@@ -255,5 +253,3 @@ func TestVerifyUpdateApplied(t *testing.T) {
 		})
 	}
 }
-
-func strPtr(s string) *string { return &s }


### PR DESCRIPTION
## Summary
Update requests that set `inner_vlan = -1` (untagged) return `0` from the API for that end. `verifyUpdateApplied` compared these raw values, so it never matched, and `Update()` would spin for the full 120s timeout logging a spurious "VXC Update Propagation Delay" warning even though the update applied correctly. Mirrors the normalization `fromAPIVXC` already does on Read.

- Add `innerVLANMatches` helper: requested `-1` matches API-returned `0`, otherwise plain equality.
- Use it in `verifyUpdateApplied` for `AEndInnerVLAN`/`BEndInnerVLAN` (outer VLAN untouched, since `0` there means auto-assign, not untagged).
- Fix the same raw comparison in `Update()`'s A-End/B-End Inner VLAN Mismatch warnings, which had the identical bug and could fire a false mismatch whenever the update wait timed out for an unrelated reason.
- Add table-driven unit tests for `verifyUpdateApplied` (none existed before).
- Remove the "known gap" comment on `TestAccMegaportMVE_to_MVE_VXC` documenting this exact bug.

## Test plan
- [x] `go build -v ./...`
- [x] `go test -v -timeout=30m -run TestVerifyUpdateApplied ./internal/provider/`
- [x] `go test -timeout=30m ./internal/provider/`
- [x] `golangci-lint run --timeout=10m`
- [x] `TestAccMegaportMVE_to_MVE_VXC` against staging: passes in ~4.2 min, no propagation-delay or VLAN-mismatch warning