### PR TITLE
ESD-1671: Expose as_override on VXC BGP connections

### DIFF
--- a/docs/resources/vxc.md
+++ b/docs/resources/vxc.md
@@ -505,6 +505,7 @@ Optional:
 
 Optional:
 
+- `as_override` (Boolean) Enables AS Override for this eBGP connection, replacing the peer ASN with the local ASN in the advertised AS path (eBGP connections only).
 - `as_path_prepend_count` (Number) The AS path prepend count of the BGP connection. Minimum value of 0 and maximum value of 10.
 - `bfd_enabled` (Boolean) Whether BFD is enabled for the BGP connection.
 - `deny_export_to` (List of String) The denied export to of the BGP connection.
@@ -577,6 +578,7 @@ Optional:
 
 Optional:
 
+- `as_override` (Boolean) Enables AS Override for this eBGP connection, replacing the peer ASN with the local ASN in the advertised AS path (eBGP connections only).
 - `as_path_prepend_count` (Number) The AS path prepend count of the BGP connection. Minimum value of 0 and maximum value of 10.
 - `bfd_enabled` (Boolean) Whether BFD is enabled for the BGP connection.
 - `deny_export_to` (List of String) The denied export to of the BGP connection.
@@ -760,6 +762,7 @@ Optional:
 
 Optional:
 
+- `as_override` (Boolean) Enables AS Override for this eBGP connection, replacing the peer ASN with the local ASN in the advertised AS path (eBGP connections only).
 - `as_path_prepend_count` (Number) The AS path prepend count of the BGP connection. Minimum value of 0 and maximum value of 10.
 - `bfd_enabled` (Boolean) Whether BFD is enabled for the BGP connection.
 - `deny_export_to` (List of String) The denied export to of the BGP connection.
@@ -832,6 +835,7 @@ Optional:
 
 Optional:
 
+- `as_override` (Boolean) Enables AS Override for this eBGP connection, replacing the peer ASN with the local ASN in the advertised AS path (eBGP connections only).
 - `as_path_prepend_count` (Number) The AS path prepend count of the BGP connection. Minimum value of 0 and maximum value of 10.
 - `bfd_enabled` (Boolean) Whether BFD is enabled for the BGP connection.
 - `deny_export_to` (List of String) The denied export to of the BGP connection.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
-	github.com/megaport/megaportgo v1.16.1-0.20260720135248-2087e13f1cf2
+	github.com/megaport/megaportgo v1.17.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
-	github.com/megaport/megaportgo v1.14.1
+	github.com/megaport/megaportgo v1.16.1-0.20260720135248-2087e13f1cf2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -156,10 +156,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/megaport/megaportgo v1.14.1 h1:yhR4MFLyWyF29HTUCKZaujaCUgZBcrqUYlFkNEz/SuU=
-github.com/megaport/megaportgo v1.14.1/go.mod h1:dF1MxT8/kD6FWb4/ojrklWinIUp5exn8v8xYJVUB3Zc=
-github.com/megaport/megaportgo v1.16.1-0.20260720135248-2087e13f1cf2 h1:BTx/UWuLAd6CHQWQpq4eimU3nuSxNEW0cICk1Gq6FDM=
-github.com/megaport/megaportgo v1.16.1-0.20260720135248-2087e13f1cf2/go.mod h1:LoNE7I/7Btg6A63ZezVaMqO5WiGYhDxLsPdPRmt1k78=
+github.com/megaport/megaportgo v1.17.0 h1:H1aGlUCREFf2F0LH0SIzwYUosQyuZEtynekSzai1mZE=
+github.com/megaport/megaportgo v1.17.0/go.mod h1:LoNE7I/7Btg6A63ZezVaMqO5WiGYhDxLsPdPRmt1k78=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,8 @@ github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/Qd
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/megaport/megaportgo v1.14.1 h1:yhR4MFLyWyF29HTUCKZaujaCUgZBcrqUYlFkNEz/SuU=
 github.com/megaport/megaportgo v1.14.1/go.mod h1:dF1MxT8/kD6FWb4/ojrklWinIUp5exn8v8xYJVUB3Zc=
+github.com/megaport/megaportgo v1.16.1-0.20260720135248-2087e13f1cf2 h1:BTx/UWuLAd6CHQWQpq4eimU3nuSxNEW0cICk1Gq6FDM=
+github.com/megaport/megaportgo v1.16.1-0.20260720135248-2087e13f1cf2/go.mod h1:LoNE7I/7Btg6A63ZezVaMqO5WiGYhDxLsPdPRmt1k78=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=

--- a/internal/provider/vxc_resource.go
+++ b/internal/provider/vxc_resource.go
@@ -176,6 +176,7 @@ var (
 		"med_in":                types.Int64Type,
 		"med_out":               types.Int64Type,
 		"bfd_enabled":           types.BoolType,
+		"as_override":           types.BoolType,
 		"export_policy":         types.StringType,
 		"permit_export_to":      types.ListType{}.WithElementType(types.StringType),
 		"deny_export_to":        types.ListType{}.WithElementType(types.StringType),
@@ -240,6 +241,7 @@ var (
 		"med_in":                types.Int64Type,
 		"med_out":               types.Int64Type,
 		"bfd_enabled":           types.BoolType,
+		"as_override":           types.BoolType,
 		"export_policy":         types.StringType,
 		"permit_export_to":      types.ListType{}.WithElementType(types.StringType),
 		"deny_export_to":        types.ListType{}.WithElementType(types.StringType),
@@ -485,6 +487,7 @@ type bgpConnectionConfigModel struct {
 	MedIn              types.Int64  `tfsdk:"med_in"`
 	MedOut             types.Int64  `tfsdk:"med_out"`
 	BfdEnabled         types.Bool   `tfsdk:"bfd_enabled"`
+	AsOverride         types.Bool   `tfsdk:"as_override"`
 	ExportPolicy       types.String `tfsdk:"export_policy"`
 	PermitExportTo     types.List   `tfsdk:"permit_export_to"`
 	DenyExportTo       types.List   `tfsdk:"deny_export_to"`

--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -1290,6 +1290,7 @@ func TestAccMegaportMCRVXCWithBGP_Basic(t *testing.T) {
 							  med_in            = 100
 							  med_out           = 100
 							  bfd_enabled       = true
+							  as_override       = true
 							  export_policy     = "deny"
 							  permit_export_to = ["10.0.1.2"]
 							  import_whitelist = "%s"
@@ -1425,6 +1426,7 @@ func TestAccMegaportMCRVXCWithBGP_Basic(t *testing.T) {
 							  med_in            = 100
 							  med_out           = 100
 							  bfd_enabled       = true
+							  as_override       = true
 							  export_policy     = "deny"
 							  permit_export_to = ["10.0.1.2"]
 							  import_whitelist = "%s"

--- a/internal/provider/vxc_resource_utils.go
+++ b/internal/provider/vxc_resource_utils.go
@@ -627,6 +627,9 @@ func createVrouterPartnerConfig(ctx context.Context, vrouterConfig vxcPartnerCon
 				if !bgpConnection.LocalAsn.IsNull() {
 					bgpToAppend.LocalAsn = megaport.PtrTo(int(bgpConnection.LocalAsn.ValueInt64()))
 				}
+				if !bgpConnection.AsOverride.IsNull() {
+					bgpToAppend.AsOverride = megaport.PtrTo(bgpConnection.AsOverride.ValueBool())
+				}
 				if !bgpConnection.ImportWhitelist.IsNull() {
 					id, d := resolvePrefixListID(prefixFilterList, bgpConnection.ImportWhitelist.ValueString(), "import_whitelist")
 					diags.Append(d...)
@@ -777,6 +780,9 @@ func createAEndPartnerConfig(ctx context.Context, partnerConfigAEndModel vxcPart
 				}
 				if !bgpConnection.LocalAsn.IsNull() {
 					bgpToAppend.LocalAsn = megaport.PtrTo(int(bgpConnection.LocalAsn.ValueInt64()))
+				}
+				if !bgpConnection.AsOverride.IsNull() {
+					bgpToAppend.AsOverride = megaport.PtrTo(bgpConnection.AsOverride.ValueBool())
 				}
 				if !bgpConnection.ImportWhitelist.IsNull() {
 					id, d := resolvePrefixListID(prefixFilterList, bgpConnection.ImportWhitelist.ValueString(), "import_whitelist")

--- a/internal/provider/vxc_resource_utils_test.go
+++ b/internal/provider/vxc_resource_utils_test.go
@@ -110,6 +110,58 @@ func TestCreateVrouterPartnerConfig_IPsecTunnelOptions(t *testing.T) {
 	assert.Nil(t, vrouterConfig.Interfaces[2].IpSecTunnelOptions)
 }
 
+// TestCreateVrouterPartnerConfig_BgpAsOverride verifies the model -> SDK mapping
+// for the optional as_override BGP field: set true/false round-trips the value,
+// and unset (null) leaves the pointer nil so the API default applies.
+func TestCreateVrouterPartnerConfig_BgpAsOverride(t *testing.T) {
+	ctx := context.Background()
+
+	newBgp := func(asOverride types.Bool) bgpConnectionConfigModel {
+		return bgpConnectionConfigModel{
+			PeerAsn:        types.Int64Value(65000),
+			LocalIPAddress: types.StringValue("169.254.1.1"),
+			PeerIPAddress:  types.StringValue("169.254.1.2"),
+			AsOverride:     asOverride,
+			PermitExportTo: types.ListNull(types.StringType),
+			DenyExportTo:   types.ListNull(types.StringType),
+		}
+	}
+
+	bgpList, diags := types.ListValueFrom(ctx, types.ObjectType{}.WithAttributeTypes(bgpVrouterConnectionConfig), []bgpConnectionConfigModel{
+		newBgp(types.BoolValue(true)),
+		newBgp(types.BoolValue(false)),
+		newBgp(types.BoolNull()),
+	})
+	require.False(t, diags.HasError(), "building bgp list: %v", diags)
+
+	iface := vxcPartnerConfigInterfaceModel{
+		IPAddresses:        types.ListNull(types.StringType),
+		IPRoutes:           types.ListNull(types.ObjectType{}.WithAttributeTypes(ipRouteAttrs)),
+		NatIPAddresses:     types.ListNull(types.StringType),
+		Bfd:                types.ObjectNull(bfdConfigAttrs),
+		BgpConnections:     bgpList,
+		IpSecTunnelOptions: types.ObjectNull(ipSecTunnelOptionsAttrs),
+	}
+	ifaceList, diags := types.ListValueFrom(ctx, types.ObjectType{}.WithAttributeTypes(vxcVrouterInterfaceAttrs), []vxcPartnerConfigInterfaceModel{iface})
+	require.False(t, diags.HasError(), "building interface list: %v", diags)
+
+	model := vxcPartnerConfigVrouterModel{Interfaces: ifaceList}
+
+	diags, vrouterConfig, _ := createVrouterPartnerConfig(ctx, model, nil, nil)
+	require.False(t, diags.HasError(), "createVrouterPartnerConfig: %v", diags)
+	require.Len(t, vrouterConfig.Interfaces, 1)
+	conns := vrouterConfig.Interfaces[0].BgpConnections
+	require.Len(t, conns, 3)
+
+	require.NotNil(t, conns[0].AsOverride)
+	assert.True(t, *conns[0].AsOverride)
+
+	require.NotNil(t, conns[1].AsOverride)
+	assert.False(t, *conns[1].AsOverride)
+
+	assert.Nil(t, conns[2].AsOverride, "unset as_override must stay nil so the API default applies")
+}
+
 // TestIPSecPhaseLifetimeValidator covers the cross-field rule that phase2 must
 // be strictly less than phase1, and that the check is skipped when either side
 // is unset.

--- a/internal/provider/vxc_schemas.go
+++ b/internal/provider/vxc_schemas.go
@@ -353,6 +353,10 @@ var (
 										Description: "Whether BFD is enabled for the BGP connection.",
 										Optional:    true,
 									},
+									"as_override": schema.BoolAttribute{
+										Description: "Enables AS Override for this eBGP connection, replacing the peer ASN with the local ASN in the advertised AS path (eBGP connections only).",
+										Optional:    true,
+									},
 									"export_policy": schema.StringAttribute{
 										Description: "The export policy of the BGP connection.",
 										Optional:    true,
@@ -498,6 +502,10 @@ var (
 									},
 									"bfd_enabled": schema.BoolAttribute{
 										Description: "Whether BFD is enabled for the BGP connection.",
+										Optional:    true,
+									},
+									"as_override": schema.BoolAttribute{
+										Description: "Enables AS Override for this eBGP connection, replacing the peer ASN with the local ASN in the advertised AS path (eBGP connections only).",
 										Optional:    true,
 									},
 									"export_policy": schema.StringAttribute{


### PR DESCRIPTION
Exposes the API's `asOverride` BGP field (AS Override for eBGP peering) as an optional `as_override` boolean on vRouter `bgp_connections`, so customers managing MCR BGP peering as code can set it in Terraform instead of the Portal. From support enquiry 00075754 (Strada Global).

- Add `as_override` (Optional, Bool) to both vRouter `bgp_connections` schemas, the model struct, the two attr-type maps, and both plan-to-SDK conversion sites.
- Maps to the SDK's `AsOverride *bool`: unset omits the key so the API keeps its default; an explicit `true`/`false` is sent.
- No read-path change: partner configs are preserved from state on Read (never merged from the API), so there is no drift and no diff on upgrade, exactly like `bfd_enabled` and the export lists.
- New unit test `TestCreateVrouterPartnerConfig_BgpAsOverride` (true/false/unset); docs regenerated.
- megaportgo bumped to the tagged release `v1.17.0` (which carries `AsOverride`), replacing the earlier pseudo-version pin.

**Testing**
- Relevant acceptance tests pass against staging with megaportgo v1.17.0: `TestAccMegaportVXC_Basic`, `TestAccMegaportMCRVXCWithBGP_Basic`, `TestAccMegaportMCRVXC_BEndIpMtu` (all PASS, resources provisioned and torn down cleanly).
- Buy/update mapping also covered by unit tests; end-to-end order + GET echo verified on staging on the SDK ticket (ESD-1670).