### PR TITLE
ESD-1682-fix(v2): warn on silent prefix_filter_lists drop and fix stale MCR migration docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -128,33 +128,11 @@ resource "megaport_mcr_prefix_filter_list" "allow_private_ipv6" {
 }
 ```
 
-#### ⚠️ Deprecated Inline Approach
+#### ❌ Removed Inline Approach
 
-```terraform
-# ❌ DEPRECATED: Inline prefix filter lists (will be removed in future version)
-resource "megaport_mcr" "deprecated_example" {
-  product_name         = "my-mcr"
-  port_speed          = 1000
-  location_id         = 5
-  contract_term_months = 12
-  
-  # This approach is deprecated and will show warnings
-  prefix_filter_lists = [
-    {
-      description    = "Allow private networks"
-      address_family = "IPv4"
-      entries = [
-        {
-          action = "permit"
-          prefix = "10.0.0.0/8"
-          ge     = 16
-          le     = 24
-        }
-      ]
-    }
-  ]
-}
-```
+The inline `prefix_filter_lists` attribute on `megaport_mcr` has been removed. Configurations
+still using it will fail to validate. Migrate to standalone `megaport_mcr_prefix_filter_list`
+resources using the [Migration Guide](#migration-guide) below.
 
 ### Benefits of Standalone Resources
 
@@ -205,7 +183,8 @@ terraform import megaport_mcr_prefix_filter_list.migrated_list_1 mcr-uid:prefix-
 
 #### Step 4: Update MCR Resource
 
-Remove the `prefix_filter_lists` attribute from your MCR resource and add a lifecycle rule:
+Remove the `prefix_filter_lists` attribute from your MCR resource; it no longer exists on the
+resource schema, so no `lifecycle` rule is needed:
 
 ```terraform
 resource "megaport_mcr" "example" {
@@ -213,14 +192,9 @@ resource "megaport_mcr" "example" {
   port_speed          = 1000
   location_id         = 5
   contract_term_months = 12
-  
+
   # Remove or comment out the old prefix_filter_lists attribute
   # prefix_filter_lists = [...]
-  
-  # Add lifecycle rule to prevent drift warnings
-  lifecycle {
-    ignore_changes = [prefix_filter_lists]
-  }
 }
 ```
 
@@ -228,41 +202,14 @@ resource "megaport_mcr" "example" {
 
 Run `terraform plan` to ensure no unexpected changes are detected.
 
-### Mixed Usage Prevention
+### Removal Notice
 
-The provider includes validation to prevent managing the same prefix filter lists through both methods simultaneously. If you attempt to use both inline and standalone management for the same MCR, you'll receive warnings about potential conflicts.
-
-### Deprecation Notice
-
-The inline `prefix_filter_lists` attribute in the MCR resource is deprecated and will be removed in a future version. We recommend migrating to standalone `megaport_mcr_prefix_filter_list` resources for better lifecycle management and improved state handling.
+The inline `prefix_filter_lists` attribute has been removed from the MCR resource. Manage
+prefix filter lists exclusively through standalone `megaport_mcr_prefix_filter_list` resources.
 
 ### Troubleshooting and Best Practices
 
 #### Common Issues
-
-**MCR Resource Shows Drift with Standalone Resources**
-
-When using standalone `megaport_mcr_prefix_filter_list` resources, you should add a lifecycle rule to your MCR resource to prevent Terraform from detecting drift on the `prefix_filter_lists` attribute. This is necessary because:
-
-1. The standalone prefix filter list resources manage the lists independently
-2. The MCR resource still reads the lists from the API, which can cause Terraform to detect "changes" even though the lists are being managed by the standalone resources
-3. This applies to both newly created MCRs and existing ones - the lifecycle rule tells Terraform to ignore differences in this attribute since it's being managed elsewhere
-
-```terraform
-resource "megaport_mcr" "example" {
-  # ... configuration ...
-  
-  lifecycle {
-    ignore_changes = [prefix_filter_lists]
-  }
-}
-```
-
-**Why is this needed for new resources?** Even when creating a new MCR alongside standalone prefix filter list resources, Terraform's refresh cycle will detect that the MCR has prefix filter lists attached (via the standalone resources), and without the lifecycle rule, it may show these as unexpected changes on subsequent plan/apply operations.
-
-**Mixed Usage Warning**
-
-If you see warnings about mixed usage, ensure you're not managing the same prefix filter lists through both inline and standalone methods simultaneously.
 
 **Import Format**
 
@@ -295,10 +242,6 @@ resource "megaport_mcr" "production" {
     Environment = "production"
     Owner       = "network-team"
     Purpose     = "multi-cloud-connectivity"
-  }
-  
-  lifecycle {
-    ignore_changes = [prefix_filter_lists]
   }
 }
 

--- a/internal/provider/mcr_resource.go
+++ b/internal/provider/mcr_resource.go
@@ -23,9 +23,10 @@ import (
 
 var (
 	// Ensure the implementation satisfies the expected interfaces.
-	_ resource.Resource                = &mcrResource{}
-	_ resource.ResourceWithConfigure   = &mcrResource{}
-	_ resource.ResourceWithImportState = &mcrResource{}
+	_ resource.Resource                 = &mcrResource{}
+	_ resource.ResourceWithConfigure    = &mcrResource{}
+	_ resource.ResourceWithImportState  = &mcrResource{}
+	_ resource.ResourceWithUpgradeState = &mcrResource{}
 )
 
 // mcrResourceModel maps the resource schema data.
@@ -104,6 +105,7 @@ func (r *mcrResource) Metadata(_ context.Context, req resource.MetadataRequest, 
 // Schema defines the schema for the resource.
 func (r *mcrResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Version:     1,
 		Description: "Megaport Cloud Router (MCR) Resource for the Megaport Terraform Provider. This can be used to create, modify, and delete Megaport MCRs. The MCR is a managed virtual router service that establishes Layer 3 connectivity on the worldwide Megaport software-defined network (SDN). MCR instances are preconfigured in data centers in key global routing zones. An MCR enables data transfer between multi-cloud or hybrid cloud networks, network service providers, and cloud service providers.",
 		Attributes: map[string]schema.Attribute{
 			"product_uid": schema.StringAttribute{
@@ -199,6 +201,73 @@ func (r *mcrResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				PlanModifiers: []planmodifier.Map{
 					mapplanmodifier.UseStateForUnknown(),
 				},
+			},
+		},
+	}
+}
+
+// mcrResourceModelV0 mirrors the V0 schema, which additionally carried the
+// inline prefix_filter_lists attribute removed in V1.
+type mcrResourceModelV0 struct {
+	mcrResourceModel
+	PrefixFilterLists types.List `tfsdk:"prefix_filter_lists"`
+}
+
+// UpgradeState decodes V0 state (which may still have inline
+// prefix_filter_lists) against the V1 schema, warning when lists are being
+// silently dropped from Terraform management so they aren't mistaken for
+// having been deleted from the backend.
+func (r *mcrResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	v0Schema := schemaResp.Schema
+	v0Schema.Attributes["prefix_filter_lists"] = schema.ListNestedAttribute{
+		Description: "Prefix filter lists previously managed inline on the MCR.",
+		Optional:    true,
+		Computed:    true,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"id":             schema.Int64Attribute{Computed: true},
+				"description":    schema.StringAttribute{Required: true},
+				"address_family": schema.StringAttribute{Required: true},
+				"entries": schema.ListNestedAttribute{
+					Optional: true,
+					Computed: true,
+					NestedObject: schema.NestedAttributeObject{
+						Attributes: map[string]schema.Attribute{
+							"action": schema.StringAttribute{Required: true},
+							"prefix": schema.StringAttribute{Required: true},
+							"ge":     schema.Int64Attribute{Optional: true},
+							"le":     schema.Int64Attribute{Optional: true},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &v0Schema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var priorState mcrResourceModelV0
+				resp.Diagnostics.Append(req.State.Get(ctx, &priorState)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				if !priorState.PrefixFilterLists.IsNull() && len(priorState.PrefixFilterLists.Elements()) > 0 {
+					resp.Diagnostics.AddWarning(
+						"Inline prefix_filter_lists no longer managed",
+						"This MCR had inline prefix_filter_lists configured. That attribute has been removed from "+
+							"the megaport_mcr resource, so Terraform will stop tracking these lists, though they remain "+
+							"active in the Megaport backend. Import each list into a standalone "+
+							"megaport_mcr_prefix_filter_list resource to keep managing them with Terraform; see the "+
+							"provider documentation for migration guidance.",
+					)
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, priorState.mcrResourceModel)...)
 			},
 		},
 	}

--- a/internal/provider/mcr_state_upgrade_test.go
+++ b/internal/provider/mcr_state_upgrade_test.go
@@ -13,11 +13,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The V1 to V2 state upgrade needs no upgrader code: the framework's
-// UpgradeResourceState passthrough decodes prior state against the current
-// schema with IgnoreUndefinedAttributes, so removed attributes are dropped.
-// These tests replicate that passthrough to prove real V1 state still
-// decodes against the V2 schema (i.e. no kept attribute changed type).
+// State upgrade coverage for megaport_mcr (provider v1 to v2). The read-only
+// attributes removed in v2 are dropped by the framework's prior-schema decode
+// with IgnoreUndefinedAttributes; the first two tests replicate that decode to
+// prove real V1 state still reads against the V2 schema (no kept attribute
+// changed type). The user-configured prefix_filter_lists attribute instead
+// gets an explicit schema-version-0 StateUpgrader that drops it and warns; the
+// remaining tests exercise that upgrader directly.
 
 // v1MCRState returns a complete V1 MCR state JSON with all fields that
 // existed in V1 (including those removed in V2).
@@ -182,4 +184,77 @@ func TestMCRStateUpgrade_V1ToV2_NilOptionals(t *testing.T) {
 	assert.True(t, model.CompanyUID.IsNull())
 	assert.True(t, model.AttributeTags.IsNull())
 	assert.True(t, model.ResourceTags.IsNull())
+}
+
+// runMCRV0Upgrader runs the resource's registered schema-version-0
+// StateUpgrader against prior state built from rawJSON, mirroring how the
+// framework populates UpgradeStateRequest.State from the prior schema.
+func runMCRV0Upgrader(t *testing.T, rawJSON []byte) *resource.UpgradeStateResponse {
+	t.Helper()
+	ctx := context.Background()
+
+	upgrader, ok := (&mcrResource{}).UpgradeState(ctx)[0]
+	require.True(t, ok, "expected a state upgrader for schema version 0")
+	require.NotNil(t, upgrader.PriorSchema, "upgrader must set PriorSchema")
+
+	priorRaw, err := (&tfprotov6.RawState{JSON: rawJSON}).UnmarshalWithOpts(
+		upgrader.PriorSchema.Type().TerraformType(ctx),
+		tfprotov6.UnmarshalOpts{
+			ValueFromJSONOpts: tftypes.ValueFromJSONOpts{IgnoreUndefinedAttributes: true},
+		},
+	)
+	require.NoError(t, err, "prior state failed to decode against the V0 schema")
+
+	curSchemaResp := &resource.SchemaResponse{}
+	(&mcrResource{}).Schema(ctx, resource.SchemaRequest{}, curSchemaResp)
+	require.False(t, curSchemaResp.Diagnostics.HasError())
+
+	req := resource.UpgradeStateRequest{
+		RawState: &tfprotov6.RawState{JSON: rawJSON},
+		State:    &tfsdk.State{Raw: priorRaw, Schema: *upgrader.PriorSchema},
+	}
+	resp := &resource.UpgradeStateResponse{State: tfsdk.State{Schema: curSchemaResp.Schema}}
+	upgrader.StateUpgrader(ctx, req, resp)
+	return resp
+}
+
+func TestMCRStateUpgrade_V0Upgrader_WarnsOnInlinePrefixFilterLists(t *testing.T) {
+	ctx := context.Background()
+
+	resp := runMCRV0Upgrader(t, v1MCRState())
+	require.False(t, resp.Diagnostics.HasError(), "upgrader errored: %v", resp.Diagnostics)
+
+	warnings := resp.Diagnostics.Warnings()
+	require.Len(t, warnings, 1, "expected one warning about dropped prefix_filter_lists")
+	assert.Equal(t, "Inline prefix_filter_lists no longer managed", warnings[0].Summary())
+
+	var model mcrResourceModel
+	diags := resp.State.Get(ctx, &model)
+	require.False(t, diags.HasError(), "failed to read upgraded state: %v", diags)
+	assert.Equal(t, "mcr-uid-123", model.UID.ValueString())
+	assert.Equal(t, int64(64512), model.ASN.ValueInt64())
+}
+
+func TestMCRStateUpgrade_V0Upgrader_NoWarnWithoutPrefixFilterLists(t *testing.T) {
+	ctx := context.Background()
+
+	state := map[string]interface{}{
+		"product_uid":            "mcr-no-pfl",
+		"product_name":           "No PFL MCR",
+		"port_speed":             5000,
+		"location_id":            3,
+		"marketplace_visibility": false,
+		"contract_term_months":   12,
+	}
+	rawJSON, err := json.Marshal(state)
+	require.NoError(t, err)
+
+	resp := runMCRV0Upgrader(t, rawJSON)
+	require.False(t, resp.Diagnostics.HasError(), "upgrader errored: %v", resp.Diagnostics)
+	assert.Empty(t, resp.Diagnostics.Warnings(), "no warning expected when prefix_filter_lists is absent")
+
+	var model mcrResourceModel
+	diags := resp.State.Get(ctx, &model)
+	require.False(t, diags.HasError(), "failed to read upgraded state: %v", diags)
+	assert.Equal(t, "mcr-no-pfl", model.UID.ValueString())
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -128,33 +128,11 @@ resource "megaport_mcr_prefix_filter_list" "allow_private_ipv6" {
 }
 ```
 
-#### ⚠️ Deprecated Inline Approach
+#### ❌ Removed Inline Approach
 
-```terraform
-# ❌ DEPRECATED: Inline prefix filter lists (will be removed in future version)
-resource "megaport_mcr" "deprecated_example" {
-  product_name         = "my-mcr"
-  port_speed          = 1000
-  location_id         = 5
-  contract_term_months = 12
-  
-  # This approach is deprecated and will show warnings
-  prefix_filter_lists = [
-    {
-      description    = "Allow private networks"
-      address_family = "IPv4"
-      entries = [
-        {
-          action = "permit"
-          prefix = "10.0.0.0/8"
-          ge     = 16
-          le     = 24
-        }
-      ]
-    }
-  ]
-}
-```
+The inline `prefix_filter_lists` attribute on `megaport_mcr` has been removed. Configurations
+still using it will fail to validate. Migrate to standalone `megaport_mcr_prefix_filter_list`
+resources using the [Migration Guide](#migration-guide) below.
 
 ### Benefits of Standalone Resources
 
@@ -205,7 +183,8 @@ terraform import megaport_mcr_prefix_filter_list.migrated_list_1 mcr-uid:prefix-
 
 #### Step 4: Update MCR Resource
 
-Remove the `prefix_filter_lists` attribute from your MCR resource and add a lifecycle rule:
+Remove the `prefix_filter_lists` attribute from your MCR resource; it no longer exists on the
+resource schema, so no `lifecycle` rule is needed:
 
 ```terraform
 resource "megaport_mcr" "example" {
@@ -213,14 +192,9 @@ resource "megaport_mcr" "example" {
   port_speed          = 1000
   location_id         = 5
   contract_term_months = 12
-  
+
   # Remove or comment out the old prefix_filter_lists attribute
   # prefix_filter_lists = [...]
-  
-  # Add lifecycle rule to prevent drift warnings
-  lifecycle {
-    ignore_changes = [prefix_filter_lists]
-  }
 }
 ```
 
@@ -228,41 +202,14 @@ resource "megaport_mcr" "example" {
 
 Run `terraform plan` to ensure no unexpected changes are detected.
 
-### Mixed Usage Prevention
+### Removal Notice
 
-The provider includes validation to prevent managing the same prefix filter lists through both methods simultaneously. If you attempt to use both inline and standalone management for the same MCR, you'll receive warnings about potential conflicts.
-
-### Deprecation Notice
-
-The inline `prefix_filter_lists` attribute in the MCR resource is deprecated and will be removed in a future version. We recommend migrating to standalone `megaport_mcr_prefix_filter_list` resources for better lifecycle management and improved state handling.
+The inline `prefix_filter_lists` attribute has been removed from the MCR resource. Manage
+prefix filter lists exclusively through standalone `megaport_mcr_prefix_filter_list` resources.
 
 ### Troubleshooting and Best Practices
 
 #### Common Issues
-
-**MCR Resource Shows Drift with Standalone Resources**
-
-When using standalone `megaport_mcr_prefix_filter_list` resources, you should add a lifecycle rule to your MCR resource to prevent Terraform from detecting drift on the `prefix_filter_lists` attribute. This is necessary because:
-
-1. The standalone prefix filter list resources manage the lists independently
-2. The MCR resource still reads the lists from the API, which can cause Terraform to detect "changes" even though the lists are being managed by the standalone resources
-3. This applies to both newly created MCRs and existing ones - the lifecycle rule tells Terraform to ignore differences in this attribute since it's being managed elsewhere
-
-```terraform
-resource "megaport_mcr" "example" {
-  # ... configuration ...
-  
-  lifecycle {
-    ignore_changes = [prefix_filter_lists]
-  }
-}
-```
-
-**Why is this needed for new resources?** Even when creating a new MCR alongside standalone prefix filter list resources, Terraform's refresh cycle will detect that the MCR has prefix filter lists attached (via the standalone resources), and without the lifecycle rule, it may show these as unexpected changes on subsequent plan/apply operations.
-
-**Mixed Usage Warning**
-
-If you see warnings about mixed usage, ensure you're not managing the same prefix filter lists through both inline and standalone methods simultaneously.
 
 **Import Format**
 
@@ -295,10 +242,6 @@ resource "megaport_mcr" "production" {
     Environment = "production"
     Owner       = "network-team"
     Purpose     = "multi-cloud-connectivity"
-  }
-  
-  lifecycle {
-    ignore_changes = [prefix_filter_lists]
   }
 }
 


### PR DESCRIPTION
Split out of #420 so the MCR state-upgrade change gets its own review; #420 stays VXC-only.

Removing the inline `prefix_filter_lists` attribute from `megaport_mcr` was landing silently: anyone still using it would have their lists dropped from Terraform management with no signal that the lists are still live in the backend. This adds a schema-version-0 state upgrader that warns when it sees the removed attribute in prior state, pointing users at the standalone `megaport_mcr_prefix_filter_list` import path.

It also fixes the migration guide, which still told users to add `lifecycle { ignore_changes = [prefix_filter_lists] }` to their MCR even though that attribute no longer exists on the schema (v2 rejects `ignore_changes` for unknown attributes).

**Changes**
- `mcr_resource.go`: bump schema `Version` to 1; add `UpgradeState` that drops inline `prefix_filter_lists` and warns when it was populated.
- `mcr_state_upgrade_test.go`: tests for the warning path and the no-warn (attribute absent) path.
- `docs/index.md` + `templates/index.md.tmpl`: mark the inline approach removed (not deprecated) and drop the stale `ignore_changes` step.

**Note for review:** this deliberately uses a versioned `UpgradeState` rather than the same-version passthrough the rest of the v2 cleanup uses, because emitting a warning needs an upgrader hook. The read-only attribute removals still ride the passthrough; only `prefix_filter_lists` gets the explicit upgrader.
