### PR TITLE
ESD-1734: make the IX provisioning wait honor wait_time

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -693,8 +693,6 @@ To recover, do one of the following before re-applying:
 
 Setting `wait_time` high enough for your slowest-provisioning resources avoids this situation entirely.
 
-> **Note:** Internet Exchange (IX) resources use a fixed 10-minute provisioning wait and are not affected by `wait_time`.
-
 ## Resource Cancellation
 
 When Terraform deletes a Megaport resource, the provider issues an immediate cancellation or deletion request to the Megaport API. Resources are removed from Terraform state as soon as the API call returns successfully. For Ports and LAG Ports specifically, this is always a `CANCEL_NOW` action against the Megaport Products API.

--- a/internal/provider/ix_resource.go
+++ b/internal/provider/ix_resource.go
@@ -572,7 +572,7 @@ func (r *ixResource) Create(ctx context.Context, req resource.CreateRequest, res
 		Shutdown:           plan.Shutdown.ValueBool(),
 		PromoCode:          plan.PromoCode.ValueString(),
 		WaitForProvision:   true,
-		WaitForTime:        10 * time.Minute,
+		WaitForTime:        waitForTime,
 	}
 
 	// Create the IX
@@ -649,7 +649,7 @@ func (r *ixResource) Update(ctx context.Context, req resource.UpdateRequest, res
 	// Create update request with only fields that have changed
 	updateReq := &megaport.UpdateIXRequest{
 		WaitForUpdate: true,
-		WaitForTime:   10 * time.Minute,
+		WaitForTime:   waitForTime,
 	}
 
 	if !plan.ProductName.Equal(state.ProductName) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -91,7 +91,7 @@ func (p *megaportProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 				Description: "Indicates acceptance of the Megaport API terms, this is required to use the provider. Can also be set using the environment variable MEGAPORT_ACCEPT_PURCHASE_TERMS",
 			},
 			"wait_time": schema.Int64Attribute{
-				Description: "Maximum time in minutes to wait for resources to finish provisioning during create and update operations before timing out. Defaults to 10, minimum 1. Increase this if you provision resources that take longer than 10 minutes to become live, such as MVEs or VXCs to cloud providers. Does not apply to Internet Exchange (IX) resources, which use a fixed 10-minute wait.",
+				Description: "Maximum time in minutes to wait for resources to finish provisioning during create and update operations before timing out. Defaults to 10, minimum 1. Increase this if you provision resources that take longer than 10 minutes to become live, such as MVEs or VXCs to cloud providers.",
 				Optional:    true,
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -693,8 +693,6 @@ To recover, do one of the following before re-applying:
 
 Setting `wait_time` high enough for your slowest-provisioning resources avoids this situation entirely.
 
-> **Note:** Internet Exchange (IX) resources use a fixed 10-minute provisioning wait and are not affected by `wait_time`.
-
 ## Resource Cancellation
 
 When Terraform deletes a Megaport resource, the provider issues an immediate cancellation or deletion request to the Megaport API. Resources are removed from Terraform state as soon as the API call returns successfully. For Ports and LAG Ports specifically, this is always a `CANCEL_NOW` action against the Megaport Products API.


### PR DESCRIPTION
The `megaport_ix` resource hard-coded a 10-minute provisioning wait in both Create and Update, ignoring the provider `wait_time` attribute that every other resource respects. This swaps in the shared `waitForTime` variable so IX behaves the same as the rest of the provider.

- `ix_resource.go`: use `waitForTime` instead of the hard-coded `10 * time.Minute` in Create and Update
- `provider.go`: drop the `wait_time` schema description's claim that it does not apply to IX
- `templates/index.md.tmpl` / `docs/index.md`: drop the matching guide note

This overlaps ESD-784 (PR #416, open on `feat/v2`), which makes the same change as part of a larger per-resource timeout refactor. This is the small backport to `main` so IX honors `wait_time` before v2 ships; expect a trivial conflict when v2 merges.