### PR TITLE
test(v2): drop removed inline prefix_filter_lists from MCR test configs

### DIFF
--- a/internal/provider/mcr_ipsec_addon_resource_test.go
+++ b/internal/provider/mcr_ipsec_addon_resource_test.go
@@ -164,12 +164,6 @@ resource "megaport_mcr" "mcr" {
 	location_id          = data.megaport_location.test_location.id
 	contract_term_months = 1
 	cost_centre          = "%s"
-
-	prefix_filter_lists = []
-
-	lifecycle {
-		ignore_changes = [prefix_filter_lists]
-	}
 }
 
 resource "megaport_mcr_ipsec_addon" "test" {

--- a/internal/provider/mcr_prefix_filter_list_data_source_test.go
+++ b/internal/provider/mcr_prefix_filter_list_data_source_test.go
@@ -31,13 +31,6 @@ func TestAccMegaportMCRPrefixFilterListDataSource_Basic(t *testing.T) {
 					location_id         = data.megaport_location.test_location.id
 					contract_term_months = 12
 					cost_centre         = "%s"
-
-					# Explicitly set empty prefix filter lists to avoid conflicts
-					prefix_filter_lists = []
-
-					lifecycle {
-						ignore_changes = [prefix_filter_lists]
-					}
 				}
 
 				resource "megaport_mcr_prefix_filter_list" "prefix_list_1" {

--- a/internal/provider/mcr_prefix_filter_list_resource_test.go
+++ b/internal/provider/mcr_prefix_filter_list_resource_test.go
@@ -96,7 +96,6 @@ func TestAccMegaportMCRPrefixFilterList_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "resource_tags.key1", "value1"),
 					resource.TestCheckResourceAttr("megaport_mcr.mcr", "resource_tags.key2", "value2"),
 					resource.TestCheckResourceAttrSet("megaport_mcr.mcr", "product_uid"),
-					resource.TestCheckResourceAttrSet("megaport_mcr.mcr", "product_id"),
 
 					// Prefix filter list 1 checks
 					resource.TestCheckResourceAttr("megaport_mcr_prefix_filter_list.prefix_list_1", "description", prefixFilterName),

--- a/internal/provider/mcr_prefix_filter_list_resource_test.go
+++ b/internal/provider/mcr_prefix_filter_list_resource_test.go
@@ -45,13 +45,6 @@ func TestAccMegaportMCRPrefixFilterList_Basic(t *testing.T) {
 						"key1" = "value1"
 						"key2" = "value2"
 					}
-
-					# Explicitly set empty prefix filter lists since we're using standalone resources
-					prefix_filter_lists = []
-
-					lifecycle {
-						ignore_changes = [prefix_filter_lists]
-					}
 				}
 
 				resource "megaport_mcr_prefix_filter_list" "prefix_list_1" {
@@ -178,13 +171,6 @@ func TestAccMegaportMCRPrefixFilterList_Basic(t *testing.T) {
 						"key1updated" = "value1updated"
 						"key2updated" = "value2updated"
 					}
-
-					# Explicitly set empty prefix filter lists since we're using standalone resources
-					prefix_filter_lists = []
-
-					lifecycle {
-						ignore_changes = [prefix_filter_lists]
-					}
 				}
 
 				resource "megaport_mcr_prefix_filter_list" "prefix_list_1" {
@@ -293,13 +279,6 @@ func TestAccMegaportMCRPrefixFilterList_Basic(t *testing.T) {
 						"key1updated" = "value1updated"
 						"key2updated" = "value2updated"
 					}
-
-					# Explicitly set empty prefix filter lists since we're using standalone resources
-					prefix_filter_lists = []
-
-					lifecycle {
-						ignore_changes = [prefix_filter_lists]
-					}
 				}
 
 				resource "megaport_mcr_prefix_filter_list" "prefix_list_single" {
@@ -354,13 +333,6 @@ func TestAccMegaportMCRPrefixFilterList_IPv6(t *testing.T) {
 					location_id         = data.megaport_location.test_location.id
 					contract_term_months = 12
 					cost_centre         = "%s"
-
-					# Explicitly set empty prefix filter lists since we're using standalone resources
-					prefix_filter_lists = []
-
-					lifecycle {
-						ignore_changes = [prefix_filter_lists]
-					}
 				}
 
 				resource "megaport_mcr_prefix_filter_list" "ipv6_list" {
@@ -431,13 +403,6 @@ func TestAccMegaportMCRPrefixFilterList_ExactMatch(t *testing.T) {
 					location_id         = data.megaport_location.test_location.id
 					contract_term_months = 12
 					cost_centre         = "%s"
-
-					# Explicitly set empty prefix filter lists since we're using standalone resources
-					prefix_filter_lists = []
-
-					lifecycle {
-						ignore_changes = [prefix_filter_lists]
-					}
 				}
 
 				# IPv4 Exact Match Test - ge=le should not cause drift
@@ -544,13 +509,6 @@ func TestAccMegaportMCRPrefixFilterList_ExactMatch(t *testing.T) {
 					location_id         = data.megaport_location.test_location.id
 					contract_term_months = 12
 					cost_centre         = "%s"
-
-					# Explicitly set empty prefix filter lists since we're using standalone resources
-					prefix_filter_lists = []
-
-					lifecycle {
-						ignore_changes = [prefix_filter_lists]
-					}
 				}
 
 				# IPv4 Exact Match Test - ge=le should not cause drift
@@ -675,12 +633,6 @@ func TestAccMegaportMCRPrefixFilterList_CIDRValidation(t *testing.T) {
 					location_id         = data.megaport_location.test_location.id
 					contract_term_months = 12
 					cost_centre         = "%s"
-
-					prefix_filter_lists = []
-
-					lifecycle {
-						ignore_changes = [prefix_filter_lists]
-					}
 				}
 
 				resource "megaport_mcr_prefix_filter_list" "cidr_test" {
@@ -728,13 +680,6 @@ func TestAccMegaportMCRPrefixFilterList_MixedExactAndRange(t *testing.T) {
 					location_id         = data.megaport_location.test_location.id
 					contract_term_months = 12
 					cost_centre         = "%s"
-
-					# Explicitly set empty prefix filter lists since we're using standalone resources
-					prefix_filter_lists = []
-
-					lifecycle {
-						ignore_changes = [prefix_filter_lists]
-					}
 				}
 
 				resource "megaport_mcr_prefix_filter_list" "mixed" {
@@ -831,13 +776,6 @@ func TestAccMegaportMCRPrefixFilterList_ImportNoVXCDrift(t *testing.T) {
 				port_speed           = 1000
 				asn                  = 64555
 				cost_centre          = "%s"
-
-				# Using standalone prefix filter list resources
-				prefix_filter_lists = []
-
-				lifecycle {
-					ignore_changes = [prefix_filter_lists]
-				}
 			}
 
 			resource "megaport_mcr_prefix_filter_list" "pfl" {
@@ -993,13 +931,6 @@ func TestAccMegaportMCRPrefixFilterList_ImportMultipleNoVXCDrift(t *testing.T) {
 				port_speed           = 1000
 				asn                  = 64555
 				cost_centre          = "%s"
-
-				# Using standalone prefix filter list resources
-				prefix_filter_lists = []
-
-				lifecycle {
-					ignore_changes = [prefix_filter_lists]
-				}
 			}
 
 			resource "megaport_mcr_prefix_filter_list" "pfl_whitelist" {

--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -1237,25 +1237,26 @@ func TestAccMegaportMCRVXCWithBGP_Basic(t *testing.T) {
 					contract_term_months    = 1
 					port_speed              = 5000
 					asn                     = 64555
+				  }
 
-					prefix_filter_lists = [{
-					  description     = "%s"
-					  address_family  = "IPv4"
-					  entries = [
-						{
-						  action  = "permit"
-						  prefix  = "10.0.1.0/24"
-						  ge      = 24
-						  le      = 24
-						},
-						{
-						  action  = "deny"
-						  prefix  = "10.0.2.0/24"
-						  ge      = 24
-						  le      = 24
-						}
-					  ]
-					}]
+				  resource "megaport_mcr_prefix_filter_list" "prefix_list" {
+					mcr_id          = megaport_mcr.mcr.product_uid
+					description     = "%s"
+					address_family  = "IPv4"
+					entries = [
+					  {
+						action  = "permit"
+						prefix  = "10.0.1.0/24"
+						ge      = 24
+						le      = 24
+					  },
+					  {
+						action  = "deny"
+						prefix  = "10.0.2.0/24"
+						ge      = 24
+						le      = 24
+					  }
+					]
 				  }
 
 				  resource "megaport_vxc" "aws_vxc" {
@@ -1293,7 +1294,7 @@ func TestAccMegaportMCRVXCWithBGP_Basic(t *testing.T) {
 							  as_override       = true
 							  export_policy     = "deny"
 							  permit_export_to = ["10.0.1.2"]
-							  import_whitelist = "%s"
+							  import_whitelist = megaport_mcr_prefix_filter_list.prefix_list.description
 							  as_path_prepend_count = 4
 							}
 						  ]
@@ -1322,7 +1323,7 @@ func TestAccMegaportMCRVXCWithBGP_Basic(t *testing.T) {
 						"key2" = "value2"
 					}
 				  }
-                  `, locs[0], locs[1], mcrName, prefixFilterListName, vxcName1, prefixFilterListName, vxcName1),
+                  `, locs[0], locs[1], mcrName, prefixFilterListName, vxcName1, vxcName1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("megaport_vxc.aws_vxc", "product_uid"),
 					resource.TestCheckResourceAttr("megaport_vxc.aws_vxc", "b_end_partner_config.aws_config.name", vxcName1),
@@ -1373,25 +1374,26 @@ func TestAccMegaportMCRVXCWithBGP_Basic(t *testing.T) {
 					contract_term_months    = 1
 					port_speed              = 5000
 					asn                     = 64555
+				  }
 
-					prefix_filter_lists = [{
-					  description     = "%s"
-					  address_family  = "IPv4"
-					  entries = [
-						{
-						  action  = "permit"
-						  prefix  = "10.0.1.0/24"
-						  ge      = 24
-						  le      = 24
-						},
-						{
-						  action  = "deny"
-						  prefix  = "10.0.2.0/24"
-						  ge      = 24
-						  le      = 24
-						}
-					  ]
-					}]
+				  resource "megaport_mcr_prefix_filter_list" "prefix_list" {
+					mcr_id          = megaport_mcr.mcr.product_uid
+					description     = "%s"
+					address_family  = "IPv4"
+					entries = [
+					  {
+						action  = "permit"
+						prefix  = "10.0.1.0/24"
+						ge      = 24
+						le      = 24
+					  },
+					  {
+						action  = "deny"
+						prefix  = "10.0.2.0/24"
+						ge      = 24
+						le      = 24
+					  }
+					]
 				  }
 
 				  resource "megaport_vxc" "aws_vxc" {
@@ -1429,7 +1431,7 @@ func TestAccMegaportMCRVXCWithBGP_Basic(t *testing.T) {
 							  as_override       = true
 							  export_policy     = "deny"
 							  permit_export_to = ["10.0.1.2"]
-							  import_whitelist = "%s"
+							  import_whitelist = megaport_mcr_prefix_filter_list.prefix_list.description
 							  as_path_prepend_count = 4
 							}
 						  ]
@@ -1458,7 +1460,7 @@ func TestAccMegaportMCRVXCWithBGP_Basic(t *testing.T) {
 						"key2updated" = "value2updated"
 					}
 				  }
-                  `, locs[0], locs[1], mcrName, prefixFilterListName, vxcName1, prefixFilterListName, vxcName1),
+                  `, locs[0], locs[1], mcrName, prefixFilterListName, vxcName1, vxcName1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("megaport_vxc.aws_vxc", "product_uid"),
 					resource.TestCheckResourceAttr("megaport_vxc.aws_vxc", "b_end_partner_config.aws_config.name", vxcName1),


### PR DESCRIPTION
The inline `prefix_filter_lists` attribute is gone from `megaport_mcr` on `feat/v2`, but the acceptance test HCL still set it. Every affected test died at the pre-apply plan with `An argument named "prefix_filter_lists" is not expected here`.

- Drop the empty `prefix_filter_lists` attribute and the `lifecycle` block that ignored it from the MCR prefix filter list, prefix filter list data source, and MCR IPsec add-on tests. Those set it to `[]`, so nothing is lost.
- In `TestAccMegaportMCRVXCWithBGP_Basic` the inline list was populated and referenced by `import_whitelist`. Move it to a standalone `megaport_mcr_prefix_filter_list` resource and point `import_whitelist` at its `description`, the same wiring as `examples/vxc_mcr_bgp`.
- Drop a `product_id` assertion on `megaport_mcr`. That field was removed from the schema too, and the assertion only surfaced once the configs got far enough to run their checks.

Full acceptance suite against staging: 157 pass, 10 skip, 1 fail. The one failure was the `product_id` assertion, fixed in the second commit and verified passing on re-run. The 10 skips are all missing CSP credentials or capacity probes. Unit tests, `go vet`, and `gofmt` are clean.