### PR TITLE
ESD-1752: allow overriding the API base and token URLs via environment

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -297,7 +298,13 @@ func (p *megaportProvider) Configure(ctx context.Context, req provider.Configure
 	if managedAccountUID != "" {
 		clientOpts = append(clientOpts, megaport.WithCallContext(managedAccountUID))
 	}
-	clientOpts = append(clientOpts, clientURLOverrides()...)
+	urlOverrides, err := clientURLOverrides()
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Megaport API URL override", err.Error())
+		return
+	}
+	clientOpts = append(clientOpts, urlOverrides...)
+
 	megaportClient, err := megaport.New(nil, clientOpts...)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -333,17 +340,25 @@ func (p *megaportProvider) Configure(ctx context.Context, req provider.Configure
 }
 
 // clientURLOverrides points the client at an API host outside the three named environments, so
-// acceptance tests can run against an ephemeral stack. Set both vars: megaportgo derives the token
-// URL from a fixed host switch, so an unknown base URL cannot authenticate on its own.
-func clientURLOverrides() []megaport.ClientOpt {
-	var opts []megaport.ClientOpt
-	if baseURL := os.Getenv("MEGAPORT_BASE_URL"); baseURL != "" {
-		opts = append(opts, megaport.WithBaseURL(baseURL))
+// acceptance tests can run against an ephemeral stack. Both vars are required together. A token URL
+// on its own authenticates against the override while the API calls stay on the named environment,
+// and a base URL on its own cannot authenticate at all, because megaportgo derives the token URL
+// from a fixed host switch that rejects unknown hosts.
+func clientURLOverrides() ([]megaport.ClientOpt, error) {
+	baseURL := os.Getenv("MEGAPORT_BASE_URL")
+	tokenURL := os.Getenv("MEGAPORT_TOKEN_URL")
+
+	switch {
+	case baseURL == "" && tokenURL == "":
+		return nil, nil
+	case baseURL == "" || tokenURL == "":
+		return nil, errors.New("MEGAPORT_BASE_URL and MEGAPORT_TOKEN_URL must be set together")
 	}
-	if tokenURL := os.Getenv("MEGAPORT_TOKEN_URL"); tokenURL != "" {
-		opts = append(opts, megaport.WithTokenURL(tokenURL))
-	}
-	return opts
+
+	return []megaport.ClientOpt{
+		megaport.WithBaseURL(baseURL),
+		megaport.WithTokenURL(tokenURL),
+	}, nil
 }
 
 // DataSources defines the data sources implemented in the provider.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -303,6 +303,7 @@ func (p *megaportProvider) Configure(ctx context.Context, req provider.Configure
 		resp.Diagnostics.AddError("Invalid Megaport API URL override", err.Error())
 		return
 	}
+	// Appended last on purpose: WithEnvironment above also sets the base URL, and the last write wins.
 	clientOpts = append(clientOpts, urlOverrides...)
 
 	megaportClient, err := megaport.New(nil, clientOpts...)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -297,6 +297,7 @@ func (p *megaportProvider) Configure(ctx context.Context, req provider.Configure
 	if managedAccountUID != "" {
 		clientOpts = append(clientOpts, megaport.WithCallContext(managedAccountUID))
 	}
+	clientOpts = append(clientOpts, clientURLOverrides()...)
 	megaportClient, err := megaport.New(nil, clientOpts...)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -329,6 +330,20 @@ func (p *megaportProvider) Configure(ctx context.Context, req provider.Configure
 	resp.ResourceData = providerData
 
 	tflog.Info(ctx, "Configured Megaport API client", map[string]any{"success": true})
+}
+
+// clientURLOverrides points the client at an API host outside the three named environments, so
+// acceptance tests can run against an ephemeral stack. Set both vars: megaportgo derives the token
+// URL from a fixed host switch, so an unknown base URL cannot authenticate on its own.
+func clientURLOverrides() []megaport.ClientOpt {
+	var opts []megaport.ClientOpt
+	if baseURL := os.Getenv("MEGAPORT_BASE_URL"); baseURL != "" {
+		opts = append(opts, megaport.WithBaseURL(baseURL))
+	}
+	if tokenURL := os.Getenv("MEGAPORT_TOKEN_URL"); tokenURL != "" {
+		opts = append(opts, megaport.WithTokenURL(tokenURL))
+	}
+	return opts
 }
 
 // DataSources defines the data sources implemented in the provider.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -71,7 +71,12 @@ func getTestClient() (*megaport.Client, error) {
 			megaport.WithEnvironment(megaport.EnvironmentStaging),
 			megaport.WithCredentials(accessKey, secretKey),
 		}
-		clientOpts = append(clientOpts, clientURLOverrides()...)
+		urlOverrides, err := clientURLOverrides()
+		if err != nil {
+			testClientErr = err
+			return
+		}
+		clientOpts = append(clientOpts, urlOverrides...)
 
 		testClient, testClientErr = megaport.New(nil, clientOpts...)
 		if testClientErr != nil {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -67,10 +67,13 @@ func getTestClient() (*megaport.Client, error) {
 			return
 		}
 
-		testClient, testClientErr = megaport.New(nil,
+		clientOpts := []megaport.ClientOpt{
 			megaport.WithEnvironment(megaport.EnvironmentStaging),
 			megaport.WithCredentials(accessKey, secretKey),
-		)
+		}
+		clientOpts = append(clientOpts, clientURLOverrides()...)
+
+		testClient, testClientErr = megaport.New(nil, clientOpts...)
 		if testClientErr != nil {
 			return
 		}

--- a/internal/provider/provider_url_overrides_test.go
+++ b/internal/provider/provider_url_overrides_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package provider
 
 import (

--- a/internal/provider/provider_url_overrides_test.go
+++ b/internal/provider/provider_url_overrides_test.go
@@ -16,8 +16,30 @@ func TestClientURLOverridesUnsetLeavesDefaults(t *testing.T) {
 	t.Setenv("MEGAPORT_BASE_URL", "")
 	t.Setenv("MEGAPORT_TOKEN_URL", "")
 
-	if opts := clientURLOverrides(); len(opts) != 0 {
+	opts, err := clientURLOverrides()
+	if err != nil {
+		t.Fatalf("clientURLOverrides: %v", err)
+	}
+	if len(opts) != 0 {
 		t.Fatalf("expected no options when both vars are unset, got %d", len(opts))
+	}
+}
+
+// Setting one var without the other splits authentication from the API calls, so both directions
+// have to be rejected before a client is built.
+func TestClientURLOverridesRejectAnUnpairedVar(t *testing.T) {
+	for name, env := range map[string][2]string{
+		"base URL only":  {"https://api-ci.megaport.com", ""},
+		"token URL only": {"", "https://api-ci.megaport.com/oauth2/token"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("MEGAPORT_BASE_URL", env[0])
+			t.Setenv("MEGAPORT_TOKEN_URL", env[1])
+
+			if _, err := clientURLOverrides(); err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+		})
 	}
 }
 
@@ -35,11 +57,16 @@ func TestClientURLOverridesRetargetTheClient(t *testing.T) {
 	t.Setenv("MEGAPORT_BASE_URL", server.URL)
 	t.Setenv("MEGAPORT_TOKEN_URL", server.URL+"/oauth2/token")
 
+	urlOverrides, err := clientURLOverrides()
+	if err != nil {
+		t.Fatalf("clientURLOverrides: %v", err)
+	}
+
 	// Mirrors the ordering in Configure: the overrides are appended last.
 	clientOpts := append([]megaport.ClientOpt{
 		megaport.WithEnvironment(megaport.EnvironmentStaging),
 		megaport.WithCredentials("test-key", "test-secret"),
-	}, clientURLOverrides()...)
+	}, urlOverrides...)
 
 	client, err := megaport.New(nil, clientOpts...)
 	if err != nil {
@@ -56,37 +83,5 @@ func TestClientURLOverridesRetargetTheClient(t *testing.T) {
 
 	if got := <-paths; got != "/oauth2/token" {
 		t.Errorf("token request path = %q, want %q", got, "/oauth2/token")
-	}
-}
-
-// Without a token URL the host switch rejects a non-standard base URL, so the pair is not optional.
-func TestClientURLOverridesBaseURLAloneCannotAuthorize(t *testing.T) {
-	requests := make(chan string, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests <- r.URL.Path
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(server.Close)
-
-	t.Setenv("MEGAPORT_BASE_URL", server.URL)
-	t.Setenv("MEGAPORT_TOKEN_URL", "")
-
-	clientOpts := append([]megaport.ClientOpt{
-		megaport.WithCredentials("test-key", "test-secret"),
-	}, clientURLOverrides()...)
-
-	client, err := megaport.New(nil, clientOpts...)
-	if err != nil {
-		t.Fatalf("megaport.New: %v", err)
-	}
-
-	if _, err := client.Authorize(context.Background()); err == nil {
-		t.Fatal("expected an error when only the base URL is overridden")
-	}
-
-	select {
-	case path := <-requests:
-		t.Errorf("token request reached %q; the host switch should reject it before any request", path)
-	default:
 	}
 }

--- a/internal/provider/provider_url_overrides_test.go
+++ b/internal/provider/provider_url_overrides_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	megaport "github.com/megaport/megaportgo"
+)
+
+func TestClientURLOverridesUnsetLeavesDefaults(t *testing.T) {
+	t.Setenv("MEGAPORT_BASE_URL", "")
+	t.Setenv("MEGAPORT_TOKEN_URL", "")
+
+	if opts := clientURLOverrides(); len(opts) != 0 {
+		t.Fatalf("expected no options when both vars are unset, got %d", len(opts))
+	}
+}
+
+// The overrides have to beat WithEnvironment on BaseURL and supply a token URL that the host switch
+// would otherwise reject. Authorizing against a local server proves both.
+func TestClientURLOverridesRetargetTheClient(t *testing.T) {
+	paths := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths <- r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"test-token","token_type":"bearer","expires_in":3600}`))
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("MEGAPORT_BASE_URL", server.URL)
+	t.Setenv("MEGAPORT_TOKEN_URL", server.URL+"/oauth2/token")
+
+	// Mirrors the ordering in Configure: the overrides are appended last.
+	clientOpts := append([]megaport.ClientOpt{
+		megaport.WithEnvironment(megaport.EnvironmentStaging),
+		megaport.WithCredentials("test-key", "test-secret"),
+	}, clientURLOverrides()...)
+
+	client, err := megaport.New(nil, clientOpts...)
+	if err != nil {
+		t.Fatalf("megaport.New: %v", err)
+	}
+
+	if got := client.BaseURL.String(); got != server.URL {
+		t.Errorf("BaseURL = %q, want %q", got, server.URL)
+	}
+
+	if _, err := client.Authorize(context.Background()); err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+
+	if got := <-paths; got != "/oauth2/token" {
+		t.Errorf("token request path = %q, want %q", got, "/oauth2/token")
+	}
+}
+
+// Without a token URL the host switch rejects a non-standard base URL, so the pair is not optional.
+func TestClientURLOverridesBaseURLAloneCannotAuthorize(t *testing.T) {
+	requests := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("MEGAPORT_BASE_URL", server.URL)
+	t.Setenv("MEGAPORT_TOKEN_URL", "")
+
+	clientOpts := append([]megaport.ClientOpt{
+		megaport.WithCredentials("test-key", "test-secret"),
+	}, clientURLOverrides()...)
+
+	client, err := megaport.New(nil, clientOpts...)
+	if err != nil {
+		t.Fatalf("megaport.New: %v", err)
+	}
+
+	if _, err := client.Authorize(context.Background()); err == nil {
+		t.Fatal("expected an error when only the base URL is overridden")
+	}
+
+	select {
+	case path := <-requests:
+		t.Errorf("token request reached %q; the host switch should reject it before any request", path)
+	default:
+	}
+}


### PR DESCRIPTION
Adds two env-var-only overrides, `MEGAPORT_BASE_URL` and `MEGAPORT_TOKEN_URL`, so the provider can talk to an API host outside the three named environments. This is the provider-side prerequisite for running acceptance tests against an ephemeral API stack instead of staging.

- `clientURLOverrides()` appends `WithBaseURL`/`WithTokenURL` after every other client option, so the base URL beats `WithEnvironment`
- `getTestClient()` reads the same two vars, so the suite's helper client follows the provider
- No schema attribute, so nothing new lands in the registry docs and `go generate` produces no diff

The two vars are all-or-nothing, and the provider errors if only one is set. Either half on its own points the client at two different hosts: a token URL alone authenticates against the override while the API calls stay on the named environment, and a base URL alone cannot authenticate, because megaportgo derives the token URL from a fixed host switch that rejects unknown hosts. Tests cover both unpaired directions, the paired case, and that nothing changes when neither var is set.