### PR TITLE
chore: add senior-backend and staff-backend to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @megaport/esd-go-reviewers
+* @megaport/esd-go-reviewers @megaport/senior-backend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @megaport/esd-go-reviewers @megaport/senior-backend
+* @megaport/esd-go-reviewers @megaport/senior-backend @megaport/staff-backend


### PR DESCRIPTION
Opens code review on this repo to backend senior and staff engineers alongside the existing esd-go-reviewers team.

- Adds @megaport/senior-backend and @megaport/staff-backend to the CODEOWNERS entry

Both teams need write access on this repo for GitHub to recognize them as valid code owners; that access is tracked in a separate platform-eng ticket (PLAT-3098). Until it lands, these entries have no effect, but it's safe to merge now.