### PR TITLE
ENG-35346: Run the acceptance job on provider pull requests

### DIFF
--- a/.github/workflows/acceptance-label.yaml
+++ b/.github/workflows/acceptance-label.yaml
@@ -15,23 +15,15 @@ jobs:
     if: github.event.label.name == 'acceptance'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Two labels in quick succession would otherwise both read the run list
+    # before either dispatch exists, and neither would cancel the other.
+    concurrency:
+      group: acceptance-label-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     env:
       HARNESS: megaport/terraform-provider-acceptance-ci
       PR: ${{ github.event.pull_request.number }}
     steps:
-      # Anyone with triage access can add a label. Only write access may
-      # spend a run on the shared stack.
-      - name: Require write access for whoever added the label
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SENDER: ${{ github.event.sender.login }}
-        run: |
-          permission=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$SENDER/permission" --jq .permission || echo none)
-          case "$permission" in
-            admin|write) ;;
-            *) echo "::error::$SENDER has '$permission' access to this repository; write access is required to run the acceptance tests"; exit 1 ;;
-          esac
-
       - name: Mint a token for the acceptance harness
         id: harness-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
@@ -41,18 +33,38 @@ jobs:
           owner: megaport
           repositories: terraform-provider-acceptance-ci
           permission-actions: write
+          permission-metadata: read
 
-      # The harness names each run "PR #<n> at <sha>"; a newer push supersedes
-      # any run still queued or in progress for the same pull request.
+      # The harness checks the pull request out and runs its code beside live
+      # credentials, so the label must not grant more than the labeler already
+      # has. Triage access is enough to label; only write access on the harness
+      # may spend a run.
+      - name: Require write access to the harness
+        env:
+          GH_TOKEN: ${{ steps.harness-token.outputs.token }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          permission=$(gh api "repos/$HARNESS/collaborators/$SENDER/permission" --jq .permission) || {
+            echo "::error::could not read $SENDER's access to $HARNESS"
+            exit 1
+          }
+          case "$permission" in
+            admin|write) ;;
+            *) echo "::error::$SENDER has '$permission' access to $HARNESS; write access is required to run the acceptance tests"; exit 1 ;;
+          esac
+
+      # Labeling again cancels any run still queued or in progress for this
+      # pull request. The harness names its runs "PR #<n> at <sha>".
       - name: Cancel earlier runs for this pull request
         env:
           GH_TOKEN: ${{ steps.harness-token.outputs.token }}
         run: |
-          gh api "repos/$HARNESS/actions/workflows/acceptance.yml/runs?event=workflow_dispatch&per_page=100" \
-            --jq ".workflow_runs[] | select(.status != \"completed\" and (.display_title | startswith(\"PR #$PR \"))) | .id" |
-          while read -r id; do
+          # shellcheck disable=SC2016  # $ENV.PR is jq's, not the shell's
+          ids=$(gh api "repos/$HARNESS/actions/workflows/acceptance.yml/runs?event=workflow_dispatch&per_page=100" \
+            --jq '.workflow_runs[] | select(.status != "completed" and (.display_title | startswith("PR #" + $ENV.PR + " "))) | .id')
+          for id in $ids; do
             echo "cancelling run $id"
-            gh api -X POST "repos/$HARNESS/actions/runs/$id/cancel" || true
+            gh api -X POST "repos/$HARNESS/actions/runs/$id/cancel" || echo "::warning::could not cancel run $id"
           done
 
       - name: Dispatch the acceptance run
@@ -61,9 +73,10 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: gh workflow run acceptance.yml -R "$HARNESS" -f provider_ref="$HEAD_SHA" -f pr_number="$PR"
 
-      # Removing the label turns it back into a button for the next push.
+      # Removing the label turns it back into a button for the next push. The
+      # label may already be gone by hand, and that answers 404.
       - name: Remove the label
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh api -X DELETE "repos/$GITHUB_REPOSITORY/issues/$PR/labels/acceptance"
+        run: gh api -X DELETE "repos/$GITHUB_REPOSITORY/issues/$PR/labels/acceptance" || true

--- a/.github/workflows/acceptance-label.yaml
+++ b/.github/workflows/acceptance-label.yaml
@@ -1,0 +1,69 @@
+name: Acceptance on label
+
+# Runs in the base repository with its secrets. Never check out the pull
+# request here; only its number and head SHA leave this job.
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dispatch:
+    name: Dispatch acceptance tests
+    if: github.event.label.name == 'acceptance'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      HARNESS: megaport/terraform-provider-acceptance-ci
+      PR: ${{ github.event.pull_request.number }}
+    steps:
+      # Anyone with triage access can add a label. Only write access may
+      # spend a run on the shared stack.
+      - name: Require write access for whoever added the label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          permission=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$SENDER/permission" --jq .permission || echo none)
+          case "$permission" in
+            admin|write) ;;
+            *) echo "::error::$SENDER has '$permission' access to this repository; write access is required to run the acceptance tests"; exit 1 ;;
+          esac
+
+      - name: Mint a token for the acceptance harness
+        id: harness-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.ACCEPTANCE_APP_ID }}
+          private-key: ${{ secrets.ACCEPTANCE_APP_PRIVATE_KEY }}
+          owner: megaport
+          repositories: terraform-provider-acceptance-ci
+          permission-actions: write
+
+      # The harness names each run "PR #<n> at <sha>"; a newer push supersedes
+      # any run still queued or in progress for the same pull request.
+      - name: Cancel earlier runs for this pull request
+        env:
+          GH_TOKEN: ${{ steps.harness-token.outputs.token }}
+        run: |
+          gh api "repos/$HARNESS/actions/workflows/acceptance.yml/runs?event=workflow_dispatch&per_page=100" \
+            --jq ".workflow_runs[] | select(.status != \"completed\" and (.display_title | startswith(\"PR #$PR \"))) | .id" |
+          while read -r id; do
+            echo "cancelling run $id"
+            gh api -X POST "repos/$HARNESS/actions/runs/$id/cancel" || true
+          done
+
+      - name: Dispatch the acceptance run
+        env:
+          GH_TOKEN: ${{ steps.harness-token.outputs.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: gh workflow run acceptance.yml -R "$HARNESS" -f provider_ref="$HEAD_SHA" -f pr_number="$PR"
+
+      # Removing the label turns it back into a button for the next push.
+      - name: Remove the label
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api -X DELETE "repos/$GITHUB_REPOSITORY/issues/$PR/labels/acceptance"

--- a/.github/workflows/acceptance-label.yaml
+++ b/.github/workflows/acceptance-label.yaml
@@ -48,6 +48,8 @@ jobs:
             echo "::error::could not read $SENDER's access to $HARNESS"
             exit 1
           }
+          # The API answers the legacy roles, so maintain reads as write and
+          # triage reads as read.
           case "$permission" in
             admin|write) ;;
             *) echo "::error::$SENDER has '$permission' access to $HARNESS; write access is required to run the acceptance tests"; exit 1 ;;
@@ -59,9 +61,18 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.harness-token.outputs.token }}
         run: |
-          # shellcheck disable=SC2016  # $ENV.PR is jq's, not the shell's
-          ids=$(gh api "repos/$HARNESS/actions/workflows/acceptance.yml/runs?event=workflow_dispatch&per_page=100" \
-            --jq '.workflow_runs[] | select(.status != "completed" and (.display_title | startswith("PR #" + $ENV.PR + " "))) | .id')
+          # Filtering by status server side keeps an older run in view however
+          # many dispatches came after it. A run holds one status at a time.
+          ids=""
+          for status in queued pending in_progress; do
+            # shellcheck disable=SC2016  # $ENV.PR is jq's, not the shell's
+            page=$(gh api "repos/$HARNESS/actions/workflows/acceptance.yml/runs?event=workflow_dispatch&status=$status&per_page=100" \
+              --jq '.workflow_runs[] | select(.display_title | startswith("PR #" + $ENV.PR + " ")) | .id') || {
+              echo "::error::could not list $status runs on $HARNESS"
+              exit 1
+            }
+            ids="$ids $page"
+          done
           for id in $ids; do
             echo "cancelling run $id"
             gh api -X POST "repos/$HARNESS/actions/runs/$id/cancel" || echo "::warning::could not cancel run $id"
@@ -73,10 +84,16 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: gh workflow run acceptance.yml -R "$HARNESS" -f provider_ref="$HEAD_SHA" -f pr_number="$PR"
 
-      # Removing the label turns it back into a button for the next push. The
-      # label may already be gone by hand, and that answers 404.
+      # Removing the label turns it back into a button for the next push.
       - name: Remove the label
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh api -X DELETE "repos/$GITHUB_REPOSITORY/issues/$PR/labels/acceptance" || true
+        run: |
+          # A maintainer may have taken the label off by hand, which answers 404.
+          if ! out=$(gh api -X DELETE "repos/$GITHUB_REPOSITORY/issues/$PR/labels/acceptance" 2>&1); then
+            case "$out" in
+              *"HTTP 404"*) echo "the label was already removed" ;;
+              *) echo "::error::$out"; exit 1 ;;
+            esac
+          fi


### PR DESCRIPTION
### User-Facing Summary

Nothing user facing. Adding the `acceptance` label to a pull request runs the acceptance suite in `terraform-provider-acceptance-ci` against the pull request's head commit, and the result comes back as a check on that commit. The harness side is megaport/terraform-provider-acceptance-ci#17, and it merges first.

- Runs on `pull_request_target` for the `labeled` event only, and checks out nothing here, so the token in this job never meets pull request code.
- The harness does check the pull request out and runs it beside live credentials. The label is therefore gated on write access to the harness, not on write access here: labeling only needs triage.
- Labeling again cancels any harness run still queued or in progress for the same pull request. The label is removed afterwards so it works as a button.
- PLAT-3122 (the App and its two secrets) is now provisioned in both repos.

---

### Type of Change

- [ ] 🚀 New Feature
- [ ] ✨ Enhancement
- [ ] 🐛 Bug Fix
- [ ] 📚 Documentation Update
- [x] 🏗️ Chore / Other

---

### Related Issues

ENG-35346. Was blocked by PLAT-3122; now provisioned.

---

### How to Test

`pull_request_target` runs the copy of the workflow that is on the base branch, so the label cannot be tested from a pull request until this is on `main`. Until then, dispatch the harness by hand, with `--ref` set to the harness branch: a dispatch with no `--ref` runs the copy on the harness's own `main`, which has no `pr_number` input yet and rejects it.

```bash
gh workflow run acceptance.yml -R megaport/terraform-provider-acceptance-ci \
  --ref feature/ENG-35346-acceptance-on-provider-prs \
  -f provider_ref=$(gh pr view 456 --json headRefOid -q .headRefOid) -f pr_number=456
```

After both merges (the harness first): label a pull request, then watch for `Acceptance tests / <job>` on its head commit. Label it again while the first run is queued and the first run is cancelled. A label from an account without harness write access fails at the access check.

Scope of change: not customer facing. No automated coverage exists for workflow files.

Verified end to end via the manual dispatch above, against this PR's own head commit ([harness run 34495711201](https://github.com/megaport/terraform-provider-acceptance-ci/actions/runs/34495711201)): all eight check runs opened and closed with the correct result, one genuinely failing on an `api-ci.megaport.com` 500 and going green on re-run. Still unverified: the actual `labeled` event trigger, since the workflow file isn't on the harness's `main` yet for `pull_request_target` to pick up.
