### PR TITLE
ENG-35347: Prefix Dependabot commits with EIP-3148 and document the commit format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Every commit on main needs a Jira key. EIP-3148 is the standing key for Dependabot updates.
+    commit-message:
+      prefix: "EIP-3148"
     open-pull-requests-limit: 5
     groups:
       gomod:
@@ -20,6 +23,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Every commit on main needs a Jira key. EIP-3148 is the standing key for Dependabot updates.
+    commit-message:
+      prefix: "EIP-3148"
     open-pull-requests-limit: 5
     groups:
       github-actions:

--- a/README.md
+++ b/README.md
@@ -402,6 +402,8 @@ The CLA clarifies the terms of the [Mozilla Public Licence 2.0](LICENSE) used to
 When you open a Pull Request, all authors of the contributions are required to comment on the Pull Request confirming
 acceptance of the CLA terms. Pull Requests can not be merged until this is complete.
 
+Commit subjects start with a Jira key (`ESD-1234: <summary>`) and branches are named `feature/ESD-1234-<slug>`. GitHub enforces both. If you're contributing from a fork you don't need a key: write a clear subject and a maintainer will squash-merge your pull request under one. Dependabot commits use the standing key `EIP-3148`.
+
 Megaport users are also bound by the [Acceptable Use Policy](https://www.megaport.com/legal/acceptable-use-policy).
 
 ## 🚨 BREAKING CHANGE: Location Data Source Migration

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ The CLA clarifies the terms of the [Mozilla Public Licence 2.0](LICENSE) used to
 When you open a Pull Request, all authors of the contributions are required to comment on the Pull Request confirming
 acceptance of the CLA terms. Pull Requests can not be merged until this is complete.
 
-Commit subjects start with a Jira key (`ESD-1234: <summary>`) and branches are named `feature/ESD-1234-<slug>`. GitHub enforces both. If you're contributing from a fork you don't need a key: write a clear subject and a maintainer will squash-merge your pull request under one. Dependabot commits use the standing key `EIP-3148`.
+Commit subjects start with a Jira key (`ESD-1234: <summary>`) and branches are named `feature/ESD-1234-<slug>` (`fix/`, `hotfix/`, and `release/` prefixes also pass). GitHub enforces both. If you're contributing from a fork you don't need a key: write a clear subject and a maintainer will squash-merge your pull request under one. Dependabot commits use the standing key `EIP-3148`.
 
 Megaport users are also bound by the [Acceptable Use Policy](https://www.megaport.com/legal/acceptable-use-policy).
 

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ The CLA clarifies the terms of the [Mozilla Public Licence 2.0](LICENSE) used to
 When you open a Pull Request, all authors of the contributions are required to comment on the Pull Request confirming
 acceptance of the CLA terms. Pull Requests can not be merged until this is complete.
 
-Commit subjects start with a Jira key (`ESD-1234: <summary>`) and branches are named `feature/ESD-1234-<slug>` (`fix/`, `hotfix/`, and `release/` prefixes also pass). GitHub enforces both. If you're contributing from a fork you don't need a key: write a clear subject and a maintainer will squash-merge your pull request under one. Dependabot commits use the standing key `EIP-3148`.
+Commit subjects start with a Jira key (`ENG-1234: <summary>`) and branches are named `feature/ENG-1234-<slug>` (`fix/`, `hotfix/`, and `release/` prefixes also pass). GitHub enforces both. If you're contributing from a fork you don't need a key: write a clear subject and a maintainer will squash-merge your pull request under one. Dependabot commits use the standing key `EIP-3148`.
 
 Megaport users are also bound by the [Acceptable Use Policy](https://www.megaport.com/legal/acceptable-use-policy).
 


### PR DESCRIPTION
### User-Facing Summary

None. Prep for the SWEng commit and branch rulesets, which megaport/github-iac#190 switches on for this repo. Once they arm, every commit on `main` needs a Jira key and branches need a `feature/`, `fix/`, `hotfix/`, or `release/` prefix.

- Sets `commit-message.prefix: "EIP-3148"` for both Dependabot ecosystems. EIP-3148 is the org's standing key for Dependabot updates. Dependabot appends the colon itself, so subjects become `EIP-3148: Bump ...`.
- Adds a short paragraph to the README Contributing section on the commit and branch format, including the fork path (maintainer squash-merges under a key).

**Scope of change:** not customer-facing. Config and docs only, no automated coverage.

---

### Type of Change

- [ ] 🚀 New Feature
- [ ] ✨ Enhancement
- [ ] 🐛 Bug Fix
- [ ] 📚 Documentation Update
- [x] 🏗️ Chore / Other

---

### Related Issues

ENG-35347, megaport/github-iac#190

---

### How to Test

```
yq '.updates[].commit-message.prefix' .github/dependabot.yml
```

Both entries print `EIP-3148`. The README change is prose only.