### PR TITLE
ENG-35352: Treat an MVE read without vnics as incomplete

### DIFF
--- a/internal/provider/mve_resource.go
+++ b/internal/provider/mve_resource.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	megaport "github.com/megaport/megaportgo"
 )
 
@@ -195,6 +196,15 @@ func (orm *mveResourceModel) fromAPIMVE(ctx context.Context, p *megaport.MVE, ta
 		orm.ResourceTags = types.MapNull(types.StringType)
 	}
 
+	if len(p.NetworkInterfaces) == 0 {
+		apiDiags.AddError(
+			"MVE returned without vnics",
+			fmt.Sprintf("The Megaport API returned MVE %s with no vnics. Every MVE has at least one, so the response is incomplete, "+
+				"usually because the API could not reach its provisioning backend. Retry the operation.", p.UID),
+		)
+		return apiDiags
+	}
+
 	vnics := []types.Object{}
 	for _, n := range p.NetworkInterfaces {
 		model := &mveNetworkInterfaceModel{
@@ -210,6 +220,33 @@ func (orm *mveResourceModel) fromAPIMVE(ctx context.Context, p *megaport.MVE, ta
 	orm.NetworkInterfaces = networkInterfaceList
 
 	return apiDiags
+}
+
+// mveVnicRetries is how many extra reads getMVEWithVnics makes before it
+// returns an MVE that still has no vnics. The interval is a var so tests can
+// shorten it.
+const mveVnicRetries = 3
+
+var mveVnicRetryInterval = 2 * time.Second
+
+// getMVEWithVnics reads an MVE and re-reads it while the response has no vnics.
+// The API fills vnics from its provisioning backend on every read, so a
+// transient failure there returns a live MVE with an empty list.
+func getMVEWithVnics(ctx context.Context, svc megaport.MVEService, uid string) (*megaport.MVE, error) {
+	mve, err := svc.GetMVE(ctx, uid)
+	for attempt := 0; err == nil && len(mve.NetworkInterfaces) == 0 && attempt < mveVnicRetries; attempt++ {
+		tflog.Debug(ctx, "MVE returned without vnics, re-reading", map[string]interface{}{
+			"mve_id":  uid,
+			"attempt": attempt + 1,
+		})
+		select {
+		case <-time.After(mveVnicRetryInterval):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		mve, err = svc.GetMVE(ctx, uid)
+	}
+	return mve, err
 }
 
 func toAPIVendorConfig(v *vendorConfigModel) (megaport.VendorConfig, diag.Diagnostics) {
@@ -813,7 +850,7 @@ func (r *mveResource) Create(ctx context.Context, req resource.CreateRequest, re
 	createdID := createdMVE.TechnicalServiceUID
 
 	// get the created MVE
-	mve, err := r.client.MVEService.GetMVE(ctx, createdID)
+	mve, err := getMVEWithVnics(ctx, r.client.MVEService, createdID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading newly created MVE",

--- a/internal/provider/mve_vnics_test.go
+++ b/internal/provider/mve_vnics_test.go
@@ -1,0 +1,88 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	megaport "github.com/megaport/megaportgo"
+)
+
+func TestFromAPIMVE_NoVnicsIsAnError(t *testing.T) {
+	var model mveResourceModel
+	diags := model.fromAPIMVE(context.Background(), &megaport.MVE{UID: "mve-1"}, nil)
+
+	require.True(t, diags.HasError())
+	assert.Contains(t, diags.Errors()[0].Detail(), "mve-1")
+	assert.Equal(t, "mve-1", model.UID.ValueString(), "fields before the vnics check still land in state")
+}
+
+func TestFromAPIMVE_WithVnics(t *testing.T) {
+	var model mveResourceModel
+	mve := &megaport.MVE{
+		UID:               "mve-1",
+		NetworkInterfaces: []*megaport.MVENetworkInterface{{Description: "Data Plane", VLAN: 100}},
+	}
+	diags := model.fromAPIMVE(context.Background(), mve, nil)
+
+	require.False(t, diags.HasError(), diags)
+	assert.Len(t, model.NetworkInterfaces.Elements(), 1)
+}
+
+func shortenVnicRetryInterval(t *testing.T) {
+	t.Helper()
+	previous := mveVnicRetryInterval
+	mveVnicRetryInterval = time.Millisecond
+	t.Cleanup(func() { mveVnicRetryInterval = previous })
+}
+
+func TestGetMVEWithVnics_RereadsWhileVnicsAreMissing(t *testing.T) {
+	shortenVnicRetryInterval(t)
+	calls := 0
+	svc := &MockMVEService{GetMVEFunc: func(ctx context.Context, mveID string) (*megaport.MVE, error) {
+		calls++
+		if calls == 1 {
+			return &megaport.MVE{UID: mveID}, nil
+		}
+		return &megaport.MVE{UID: mveID, NetworkInterfaces: []*megaport.MVENetworkInterface{{Description: "Data Plane"}}}, nil
+	}}
+
+	mve, err := getMVEWithVnics(context.Background(), svc, "mve-1")
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+	assert.Len(t, mve.NetworkInterfaces, 1)
+}
+
+func TestGetMVEWithVnics_ReturnsTheLastReadAfterRetries(t *testing.T) {
+	shortenVnicRetryInterval(t)
+	calls := 0
+	svc := &MockMVEService{GetMVEFunc: func(ctx context.Context, mveID string) (*megaport.MVE, error) {
+		calls++
+		return &megaport.MVE{UID: mveID}, nil
+	}}
+
+	mve, err := getMVEWithVnics(context.Background(), svc, "mve-1")
+
+	require.NoError(t, err)
+	assert.Equal(t, 1+mveVnicRetries, calls)
+	assert.Empty(t, mve.NetworkInterfaces, "the caller's fromAPIMVE turns this into the error")
+}
+
+func TestGetMVEWithVnics_DoesNotRetryAReadError(t *testing.T) {
+	shortenVnicRetryInterval(t)
+	calls := 0
+	svc := &MockMVEService{GetMVEFunc: func(ctx context.Context, mveID string) (*megaport.MVE, error) {
+		calls++
+		return nil, errors.New("boom")
+	}}
+
+	_, err := getMVEWithVnics(context.Background(), svc, "mve-1")
+
+	require.EqualError(t, err, "boom")
+	assert.Equal(t, 1, calls)
+}

--- a/internal/provider/mves_data_source_test.go
+++ b/internal/provider/mves_data_source_test.go
@@ -19,6 +19,7 @@ import (
 type MockMVEService struct {
 	ListMVEsResult            []*megaport.MVE
 	ListMVEsErr               error
+	GetMVEFunc                func(ctx context.Context, mveID string) (*megaport.MVE, error)
 	GetMVEResult              *megaport.MVE
 	GetMVEErr                 error
 	ListMVEResourceTagsFunc   func(ctx context.Context, mveID string) (map[string]string, error)
@@ -38,6 +39,9 @@ func (m *MockMVEService) ListMVEs(ctx context.Context, req *megaport.ListMVEsReq
 }
 
 func (m *MockMVEService) GetMVE(ctx context.Context, mveId string) (*megaport.MVE, error) {
+	if m.GetMVEFunc != nil {
+		return m.GetMVEFunc(ctx, mveId)
+	}
 	if m.GetMVEErr != nil {
 		return nil, m.GetMVEErr
 	}


### PR DESCRIPTION
A transient failure between the API and NetAuto returns a live MVE as HTTP 200 with an empty `vnics` array. Acceptance run 34409398690 hit this right after create: the provider stored zero vnics and Terraform failed with "vnics: element 0 has vanished". On a refresh the same response would plan a destroy and re-create, because `vnics` is `RequiresReplace`.

- `fromAPIMVE` returns an error when the API sends no vnics instead of storing the empty list. Every MVE image has at least one vnic (spec: `MveRequest.vnics`).
- Create re-reads the MVE up to three times, two seconds apart, before it gives up.
- Unit tests for both, plus a `GetMVEFunc` hook on the existing MVE mock.

Scope of change: customer-facing yes. A refresh that hits the gap now errors and asks for a retry instead of planning a replace. Acceptance run 34413531437 against this branch passed on the ephemeral stack, all eight jobs on the first attempt.

What I could not verify: the transient cannot be reproduced on demand, so the retry path has unit coverage only.

