### PR TITLE
ENG-35390: Deprecate the inert bfd block on VXC vrouter interfaces

### DIFF
--- a/docs/guides/vxc_vrouter.md
+++ b/docs/guides/vxc_vrouter.md
@@ -82,11 +82,6 @@ resource "megaport_vxc" "aws_vxc" {
         {
           ip_addresses     = ["10.0.0.1/30"]
           nat_ip_addresses = ["10.0.0.1"]
-          bfd = {
-            tx_interval = 500
-            rx_interval = 400
-            multiplier  = 5
-          }
           bgp_connections = [
             {
               peer_asn         = 64512

--- a/docs/resources/vxc.md
+++ b/docs/resources/vxc.md
@@ -484,7 +484,7 @@ Required:
 
 Optional:
 
-- `bfd` (Attributes, Deprecated) **DEPRECATED**: This block has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on. (see [below for nested schema](#nestedatt--a_end_partner_config--partner_a_end_config--interfaces--bfd))
+- `bfd` (Attributes, Deprecated) **DEPRECATED**: Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on. (see [below for nested schema](#nestedatt--a_end_partner_config--partner_a_end_config--interfaces--bfd))
 - `bgp_connections` (Attributes List) The BGP connections of the partner configuration interface. (see [below for nested schema](#nestedatt--a_end_partner_config--partner_a_end_config--interfaces--bgp_connections))
 - `ip_addresses` (List of String) The IP addresses of the partner configuration. Each entry must be in CIDR notation (e.g., "169.254.100.6/29").
 - `ip_routes` (Attributes List) The IP routes of the partner configuration. (see [below for nested schema](#nestedatt--a_end_partner_config--partner_a_end_config--interfaces--ip_routes))
@@ -495,9 +495,9 @@ Optional:
 
 Optional:
 
-- `multiplier` (Number) The multiplier of the BFD.
-- `rx_interval` (Number) The receive interval of the BFD.
-- `tx_interval` (Number) The transmit interval of the BFD.
+- `multiplier` (Number, Deprecated) The multiplier of the BFD. **DEPRECATED**: Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on.
+- `rx_interval` (Number, Deprecated) The receive interval of the BFD. **DEPRECATED**: Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on.
+- `tx_interval` (Number, Deprecated) The transmit interval of the BFD. **DEPRECATED**: Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on.
 
 
 <a id="nestedatt--a_end_partner_config--partner_a_end_config--interfaces--bgp_connections"></a>
@@ -550,7 +550,7 @@ Required:
 
 Optional:
 
-- `bfd` (Attributes, Deprecated) **DEPRECATED**: This block has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on. (see [below for nested schema](#nestedatt--a_end_partner_config--vrouter_config--interfaces--bfd))
+- `bfd` (Attributes, Deprecated) **DEPRECATED**: Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on. (see [below for nested schema](#nestedatt--a_end_partner_config--vrouter_config--interfaces--bfd))
 - `bgp_connections` (Attributes List) The BGP connections of the partner configuration interface. (see [below for nested schema](#nestedatt--a_end_partner_config--vrouter_config--interfaces--bgp_connections))
 - `description` (String) Optional human-readable description for the interface. Used by NAT Gateway A-End VXC interfaces.
 - `interface_type` (String) Type of the partner configuration interface. One of `subInterface` (default) or `ipSecTunnel`. Used by NAT Gateway A-End VXC interfaces.
@@ -568,9 +568,9 @@ Optional:
 
 Optional:
 
-- `multiplier` (Number) The multiplier of the BFD.
-- `rx_interval` (Number) The receive interval of the BFD.
-- `tx_interval` (Number) The transmit interval of the BFD.
+- `multiplier` (Number, Deprecated) The multiplier of the BFD. **DEPRECATED**: Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on.
+- `rx_interval` (Number, Deprecated) The receive interval of the BFD. **DEPRECATED**: Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on.
+- `tx_interval` (Number, Deprecated) The transmit interval of the BFD. **DEPRECATED**: Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on.
 
 
 <a id="nestedatt--a_end_partner_config--vrouter_config--interfaces--bgp_connections"></a>
@@ -741,7 +741,7 @@ Required:
 
 Optional:
 
-- `bfd` (Attributes, Deprecated) **DEPRECATED**: This block has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on. (see [below for nested schema](#nestedatt--b_end_partner_config--partner_a_end_config--interfaces--bfd))
+- `bfd` (Attributes, Deprecated) **DEPRECATED**: Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on. (see [below for nested schema](#nestedatt--b_end_partner_config--partner_a_end_config--interfaces--bfd))
 - `bgp_connections` (Attributes List) The BGP connections of the partner configuration interface. (see [below for nested schema](#nestedatt--b_end_partner_config--partner_a_end_config--interfaces--bgp_connections))
 - `ip_addresses` (List of String) The IP addresses of the partner configuration. Each entry must be in CIDR notation (e.g., "169.254.100.6/29").
 - `ip_routes` (Attributes List) The IP routes of the partner configuration. (see [below for nested schema](#nestedatt--b_end_partner_config--partner_a_end_config--interfaces--ip_routes))
@@ -752,9 +752,9 @@ Optional:
 
 Optional:
 
-- `multiplier` (Number) The multiplier of the BFD.
-- `rx_interval` (Number) The receive interval of the BFD.
-- `tx_interval` (Number) The transmit interval of the BFD.
+- `multiplier` (Number, Deprecated) The multiplier of the BFD. **DEPRECATED**: Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on.
+- `rx_interval` (Number, Deprecated) The receive interval of the BFD. **DEPRECATED**: Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on.
+- `tx_interval` (Number, Deprecated) The transmit interval of the BFD. **DEPRECATED**: Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on.
 
 
 <a id="nestedatt--b_end_partner_config--partner_a_end_config--interfaces--bgp_connections"></a>
@@ -807,7 +807,7 @@ Required:
 
 Optional:
 
-- `bfd` (Attributes, Deprecated) **DEPRECATED**: This block has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on. (see [below for nested schema](#nestedatt--b_end_partner_config--vrouter_config--interfaces--bfd))
+- `bfd` (Attributes, Deprecated) **DEPRECATED**: Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on. (see [below for nested schema](#nestedatt--b_end_partner_config--vrouter_config--interfaces--bfd))
 - `bgp_connections` (Attributes List) The BGP connections of the partner configuration interface. (see [below for nested schema](#nestedatt--b_end_partner_config--vrouter_config--interfaces--bgp_connections))
 - `description` (String) Optional human-readable description for the interface. Used by NAT Gateway A-End VXC interfaces.
 - `interface_type` (String) Type of the partner configuration interface. One of `subInterface` (default) or `ipSecTunnel`. Used by NAT Gateway A-End VXC interfaces.
@@ -825,9 +825,9 @@ Optional:
 
 Optional:
 
-- `multiplier` (Number) The multiplier of the BFD.
-- `rx_interval` (Number) The receive interval of the BFD.
-- `tx_interval` (Number) The transmit interval of the BFD.
+- `multiplier` (Number, Deprecated) The multiplier of the BFD. **DEPRECATED**: Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on.
+- `rx_interval` (Number, Deprecated) The receive interval of the BFD. **DEPRECATED**: Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on.
+- `tx_interval` (Number, Deprecated) The transmit interval of the BFD. **DEPRECATED**: Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on.
 
 
 <a id="nestedatt--b_end_partner_config--vrouter_config--interfaces--bgp_connections"></a>

--- a/docs/resources/vxc.md
+++ b/docs/resources/vxc.md
@@ -484,7 +484,7 @@ Required:
 
 Optional:
 
-- `bfd` (Attributes) The BFD of the partner configuration interface. (see [below for nested schema](#nestedatt--a_end_partner_config--partner_a_end_config--interfaces--bfd))
+- `bfd` (Attributes, Deprecated) **DEPRECATED**: This block has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on. (see [below for nested schema](#nestedatt--a_end_partner_config--partner_a_end_config--interfaces--bfd))
 - `bgp_connections` (Attributes List) The BGP connections of the partner configuration interface. (see [below for nested schema](#nestedatt--a_end_partner_config--partner_a_end_config--interfaces--bgp_connections))
 - `ip_addresses` (List of String) The IP addresses of the partner configuration. Each entry must be in CIDR notation (e.g., "169.254.100.6/29").
 - `ip_routes` (Attributes List) The IP routes of the partner configuration. (see [below for nested schema](#nestedatt--a_end_partner_config--partner_a_end_config--interfaces--ip_routes))
@@ -550,7 +550,7 @@ Required:
 
 Optional:
 
-- `bfd` (Attributes) The BFD of the partner configuration interface. (see [below for nested schema](#nestedatt--a_end_partner_config--vrouter_config--interfaces--bfd))
+- `bfd` (Attributes, Deprecated) **DEPRECATED**: This block has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on. (see [below for nested schema](#nestedatt--a_end_partner_config--vrouter_config--interfaces--bfd))
 - `bgp_connections` (Attributes List) The BGP connections of the partner configuration interface. (see [below for nested schema](#nestedatt--a_end_partner_config--vrouter_config--interfaces--bgp_connections))
 - `description` (String) Optional human-readable description for the interface. Used by NAT Gateway A-End VXC interfaces.
 - `interface_type` (String) Type of the partner configuration interface. One of `subInterface` (default) or `ipSecTunnel`. Used by NAT Gateway A-End VXC interfaces.
@@ -741,7 +741,7 @@ Required:
 
 Optional:
 
-- `bfd` (Attributes) The BFD of the partner configuration interface. (see [below for nested schema](#nestedatt--b_end_partner_config--partner_a_end_config--interfaces--bfd))
+- `bfd` (Attributes, Deprecated) **DEPRECATED**: This block has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on. (see [below for nested schema](#nestedatt--b_end_partner_config--partner_a_end_config--interfaces--bfd))
 - `bgp_connections` (Attributes List) The BGP connections of the partner configuration interface. (see [below for nested schema](#nestedatt--b_end_partner_config--partner_a_end_config--interfaces--bgp_connections))
 - `ip_addresses` (List of String) The IP addresses of the partner configuration. Each entry must be in CIDR notation (e.g., "169.254.100.6/29").
 - `ip_routes` (Attributes List) The IP routes of the partner configuration. (see [below for nested schema](#nestedatt--b_end_partner_config--partner_a_end_config--interfaces--ip_routes))
@@ -807,7 +807,7 @@ Required:
 
 Optional:
 
-- `bfd` (Attributes) The BFD of the partner configuration interface. (see [below for nested schema](#nestedatt--b_end_partner_config--vrouter_config--interfaces--bfd))
+- `bfd` (Attributes, Deprecated) **DEPRECATED**: This block has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on. (see [below for nested schema](#nestedatt--b_end_partner_config--vrouter_config--interfaces--bfd))
 - `bgp_connections` (Attributes List) The BGP connections of the partner configuration interface. (see [below for nested schema](#nestedatt--b_end_partner_config--vrouter_config--interfaces--bgp_connections))
 - `description` (String) Optional human-readable description for the interface. Used by NAT Gateway A-End VXC interfaces.
 - `interface_type` (String) Type of the partner configuration interface. One of `subInterface` (default) or `ipSecTunnel`. Used by NAT Gateway A-End VXC interfaces.

--- a/examples/vxc_mcr_bgp/vxc_mcr_bgp.tf
+++ b/examples/vxc_mcr_bgp/vxc_mcr_bgp.tf
@@ -67,11 +67,6 @@ resource "megaport_vxc" "aws_vxc" {
         {
           ip_addresses     = ["10.0.0.1/30"]
           nat_ip_addresses = ["10.0.0.1"]
-          bfd = {
-            tx_interval = 500
-            rx_interval = 400
-            multiplier  = 5
-          }
           bgp_connections = [
             {
               peer_asn         = 64512

--- a/internal/provider/vxc_schemas.go
+++ b/internal/provider/vxc_schemas.go
@@ -8,6 +8,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// The API dropped the interface-level BFD timers in 2024 because the MCR
+// platform cannot set them. Both partner config shapes repeat the block, so
+// both read the message from here.
+const bfdDeprecationMessage = "This block has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on."
+
 var (
 	awsPartnerConfigSchema = schema.SingleNestedAttribute{
 		Description: "The AWS partner configuration.",
@@ -230,8 +235,9 @@ var (
 							ElementType: types.StringType,
 						},
 						"bfd": schema.SingleNestedAttribute{
-							Description: "The BFD of the partner configuration interface.",
-							Optional:    true,
+							Description:        "**DEPRECATED**: " + bfdDeprecationMessage,
+							Optional:           true,
+							DeprecationMessage: bfdDeprecationMessage,
 							Attributes: map[string]schema.Attribute{
 								"tx_interval": schema.Int64Attribute{
 									Description: "The transmit interval of the BFD.",
@@ -441,8 +447,9 @@ var (
 							ElementType: types.StringType,
 						},
 						"bfd": schema.SingleNestedAttribute{
-							Description: "The BFD of the partner configuration interface.",
-							Optional:    true,
+							Description:        "**DEPRECATED**: " + bfdDeprecationMessage,
+							Optional:           true,
+							DeprecationMessage: bfdDeprecationMessage,
 							Attributes: map[string]schema.Attribute{
 								"tx_interval": schema.Int64Attribute{
 									Description: "The transmit interval of the BFD.",

--- a/internal/provider/vxc_schemas.go
+++ b/internal/provider/vxc_schemas.go
@@ -9,9 +9,9 @@ import (
 )
 
 // The API dropped the interface-level BFD timers in 2024 because the MCR
-// platform cannot set them. Both partner config shapes repeat the block, so
-// both read the message from here.
-const bfdDeprecationMessage = "This block has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on."
+// platform cannot set them. Both partner config shapes repeat the block, and
+// the block and each timer inside it read the message from here.
+const bfdDeprecationMessage = "Setting the BFD timers has no effect. MCR always runs BFD at a 300 ms transmit interval, a 300 ms receive interval, and a multiplier of 3. Set `bgp_connections[].bfd_enabled` to turn BFD on."
 
 var (
 	awsPartnerConfigSchema = schema.SingleNestedAttribute{
@@ -240,16 +240,19 @@ var (
 							DeprecationMessage: bfdDeprecationMessage,
 							Attributes: map[string]schema.Attribute{
 								"tx_interval": schema.Int64Attribute{
-									Description: "The transmit interval of the BFD.",
-									Optional:    true,
+									Description:        "The transmit interval of the BFD. **DEPRECATED**: " + bfdDeprecationMessage,
+									Optional:           true,
+									DeprecationMessage: bfdDeprecationMessage,
 								},
 								"rx_interval": schema.Int64Attribute{
-									Description: "The receive interval of the BFD.",
-									Optional:    true,
+									Description:        "The receive interval of the BFD. **DEPRECATED**: " + bfdDeprecationMessage,
+									Optional:           true,
+									DeprecationMessage: bfdDeprecationMessage,
 								},
 								"multiplier": schema.Int64Attribute{
-									Description: "The multiplier of the BFD.",
-									Optional:    true,
+									Description:        "The multiplier of the BFD. **DEPRECATED**: " + bfdDeprecationMessage,
+									Optional:           true,
+									DeprecationMessage: bfdDeprecationMessage,
 								},
 							},
 						},
@@ -452,16 +455,19 @@ var (
 							DeprecationMessage: bfdDeprecationMessage,
 							Attributes: map[string]schema.Attribute{
 								"tx_interval": schema.Int64Attribute{
-									Description: "The transmit interval of the BFD.",
-									Optional:    true,
+									Description:        "The transmit interval of the BFD. **DEPRECATED**: " + bfdDeprecationMessage,
+									Optional:           true,
+									DeprecationMessage: bfdDeprecationMessage,
 								},
 								"rx_interval": schema.Int64Attribute{
-									Description: "The receive interval of the BFD.",
-									Optional:    true,
+									Description:        "The receive interval of the BFD. **DEPRECATED**: " + bfdDeprecationMessage,
+									Optional:           true,
+									DeprecationMessage: bfdDeprecationMessage,
 								},
 								"multiplier": schema.Int64Attribute{
-									Description: "The multiplier of the BFD.",
-									Optional:    true,
+									Description:        "The multiplier of the BFD. **DEPRECATED**: " + bfdDeprecationMessage,
+									Optional:           true,
+									DeprecationMessage: bfdDeprecationMessage,
 								},
 							},
 						},

--- a/internal/provider/vxc_schemas_test.go
+++ b/internal/provider/vxc_schemas_test.go
@@ -35,6 +35,29 @@ func listNestedAttr(t *testing.T, attrs map[string]schema.Attribute, name string
 	return nested
 }
 
+// Every deprecated bfd attribute has to warn, and none of them may start
+// rejecting a config that already sets it.
+func assertBFDDeprecated(t *testing.T, name string, attr schema.Attribute) {
+	t.Helper()
+	if attr.GetDeprecationMessage() == "" {
+		t.Errorf("expected %s to carry a DeprecationMessage", name)
+	}
+	for _, want := range []string{"bgp_connections[].bfd_enabled", "300 ms", "multiplier of 3"} {
+		if !strings.Contains(attr.GetDeprecationMessage(), want) {
+			t.Errorf("expected %s DeprecationMessage to mention %q, got %q", name, want, attr.GetDeprecationMessage())
+		}
+		if !strings.Contains(attr.GetDescription(), want) {
+			t.Errorf("expected %s Description to mention %q, got %q", name, want, attr.GetDescription())
+		}
+	}
+	if !attr.IsOptional() {
+		t.Errorf("expected %s to stay optional", name)
+	}
+	if attr.IsRequired() {
+		t.Errorf("expected %s to stay not-required", name)
+	}
+}
+
 // The bfd timers are inert. Both partner config shapes, on both ends, must
 // warn and point at the switch that does work.
 func TestVXCSchema_InterfaceBFDIsDeprecated(t *testing.T) {
@@ -48,25 +71,16 @@ func TestVXCSchema_InterfaceBFDIsDeprecated(t *testing.T) {
 				interfaces := listNestedAttr(t, config.Attributes, "interfaces")
 				bfd := singleNestedAttr(t, interfaces.NestedObject.Attributes, "bfd")
 
-				if bfd.DeprecationMessage == "" {
-					t.Error("expected bfd to carry a DeprecationMessage")
-				}
-				for _, want := range []string{"bgp_connections[].bfd_enabled", "300 ms", "multiplier of 3"} {
-					if !strings.Contains(bfd.DeprecationMessage, want) {
-						t.Errorf("expected DeprecationMessage to mention %q, got %q", want, bfd.DeprecationMessage)
-					}
-					if !strings.Contains(bfd.Description, want) {
-						t.Errorf("expected Description to mention %q, got %q", want, bfd.Description)
-					}
-				}
+				assertBFDDeprecated(t, "bfd", bfd)
 
-				// Deprecating warns; it must not start rejecting configs that
-				// already set the block.
-				if !bfd.Optional {
-					t.Error("expected bfd to stay optional")
-				}
-				if bfd.Required {
-					t.Error("expected bfd to stay not-required")
+				// The timers carry the warning too. A reader who deep-links to
+				// the nested docs anchor never sees the parent block.
+				for _, timer := range []string{"tx_interval", "rx_interval", "multiplier"} {
+					child, ok := bfd.Attributes[timer]
+					if !ok {
+						t.Fatalf("expected a %q attribute inside bfd", timer)
+					}
+					assertBFDDeprecated(t, "bfd."+timer, child)
 				}
 			})
 		}

--- a/internal/provider/vxc_schemas_test.go
+++ b/internal/provider/vxc_schemas_test.go
@@ -1,0 +1,74 @@
+package provider
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+func singleNestedAttr(t *testing.T, attrs map[string]schema.Attribute, name string) schema.SingleNestedAttribute {
+	t.Helper()
+	attr, ok := attrs[name]
+	if !ok {
+		t.Fatalf("expected a %q attribute", name)
+	}
+	nested, ok := attr.(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatalf("expected %q to be a SingleNestedAttribute, got %T", name, attr)
+	}
+	return nested
+}
+
+func listNestedAttr(t *testing.T, attrs map[string]schema.Attribute, name string) schema.ListNestedAttribute {
+	t.Helper()
+	attr, ok := attrs[name]
+	if !ok {
+		t.Fatalf("expected a %q attribute", name)
+	}
+	nested, ok := attr.(schema.ListNestedAttribute)
+	if !ok {
+		t.Fatalf("expected %q to be a ListNestedAttribute, got %T", name, attr)
+	}
+	return nested
+}
+
+// The bfd timers are inert. Both partner config shapes, on both ends, must
+// warn and point at the switch that does work.
+func TestVXCSchema_InterfaceBFDIsDeprecated(t *testing.T) {
+	resp := &resource.SchemaResponse{}
+	(&vxcResource{}).Schema(context.Background(), resource.SchemaRequest{}, resp)
+
+	for _, end := range []string{"a_end_partner_config", "b_end_partner_config"} {
+		for _, partnerConfig := range []string{"vrouter_config", "partner_a_end_config"} {
+			t.Run(end+"."+partnerConfig, func(t *testing.T) {
+				config := singleNestedAttr(t, singleNestedAttr(t, resp.Schema.Attributes, end).Attributes, partnerConfig)
+				interfaces := listNestedAttr(t, config.Attributes, "interfaces")
+				bfd := singleNestedAttr(t, interfaces.NestedObject.Attributes, "bfd")
+
+				if bfd.DeprecationMessage == "" {
+					t.Error("expected bfd to carry a DeprecationMessage")
+				}
+				for _, want := range []string{"bgp_connections[].bfd_enabled", "300 ms", "multiplier of 3"} {
+					if !strings.Contains(bfd.DeprecationMessage, want) {
+						t.Errorf("expected DeprecationMessage to mention %q, got %q", want, bfd.DeprecationMessage)
+					}
+					if !strings.Contains(bfd.Description, want) {
+						t.Errorf("expected Description to mention %q, got %q", want, bfd.Description)
+					}
+				}
+
+				// Deprecating warns; it must not start rejecting configs that
+				// already set the block.
+				if !bfd.Optional {
+					t.Error("expected bfd to stay optional")
+				}
+				if bfd.Required {
+					t.Error("expected bfd to stay not-required")
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
### User-Facing Summary

The `bfd` block on VXC vrouter interfaces hasn't done anything since 2024. The API dropped the interface-level timers because MCR can't set them, and every MCR runs BFD at 300ms/300ms/multiplier 3. Only `bgp_connections[].bfd_enabled` has any effect.

- The block and its three timers now warn at plan time and point at `bfd_enabled`.
- The attributes stay, so existing configs keep applying.
- The `vxc_mcr_bgp` example no longer sets it. It used to set 500/400/5.

A customer read that example, then read the MCR docs saying the timers are fixed, and asked which was right.

**Scope of change:** customer-facing, it changes plan output and the published docs. `TestAccMegaportMCRVXCWithBGP_Basic` already applies a config with the block set, and is left alone on purpose to guard the apply path.

---

### Type of Change

- [ ] 🚀 New Feature
- [ ] ✨ Enhancement
- [x] 🐛 Bug Fix
- [ ] 📚 Documentation Update
- [ ] 🏗️ Chore / Other

---

### Related Issues

ENG-35390. Background in EIP-3346, which removed the timers from Portal, the API spec, the docs and NetAuto. Found during the vrouter import work in #452.

---

### How to Test

```
GOWORK=off go test -count=1 -run TestVXCSchema_InterfaceBFDIsDeprecated ./internal/provider/
```

The acceptance suite ran green against this head, including the BGP test that applies all three deprecated timers.

---

### What I could not verify

The timers carry `DeprecationMessage`, not just deprecation text in their descriptions. That's what renders `(Number, Deprecated)` on each timer row in the docs. Closing that gap was the point. The cost is four plan diagnostics instead of one, though Terraform collapses them on display to one warning plus `(and 3 more similar warnings elsewhere)`. Copilot argued for description text only and I declined on the thread. Reversing it is a line per timer if you disagree.
