### PR TITLE
ENG-35395: Converge the megaport_mcr plan after a prefix filter list migration

### DIFF
--- a/internal/provider/mcr_resource.go
+++ b/internal/provider/mcr_resource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	megaport "github.com/megaport/megaportgo"
 )
 
@@ -33,6 +34,7 @@ var (
 	_ resource.Resource                = &mcrResource{}
 	_ resource.ResourceWithConfigure   = &mcrResource{}
 	_ resource.ResourceWithImportState = &mcrResource{}
+	_ resource.ResourceWithModifyPlan  = &mcrResource{}
 
 	mcrPrefixFilterListModelAttributes = map[string]attr.Type{
 		"id":             types.Int64Type,
@@ -1259,6 +1261,58 @@ func (r *mcrResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		)
 		return
 	}
+}
+
+// ModifyPlan converges a plan whose only content is unknowns. Removing the
+// deprecated prefix_filter_lists attribute makes the framework mark every
+// Computed attribute with a null config value as unknown, and it does that
+// before any plan modifier runs. Restoring prior state here is the only place
+// left. A real change anywhere skips the restore: Update rewrites those
+// attributes, so pinning them would fail the apply with an inconsistent result.
+func (r *mcrResource) ModifyPlan(_ context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Nothing to restore when creating (no prior state) or destroying (no plan).
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan, state, config map[string]tftypes.Value
+	if err := req.Plan.Raw.As(&plan); err != nil {
+		resp.Diagnostics.AddError("Error Modifying MCR Plan", "Could not read the planned values: "+err.Error())
+		return
+	}
+	if err := req.State.Raw.As(&state); err != nil {
+		resp.Diagnostics.AddError("Error Modifying MCR Plan", "Could not read the prior state values: "+err.Error())
+		return
+	}
+	if err := req.Config.Raw.As(&config); err != nil {
+		resp.Diagnostics.AddError("Error Modifying MCR Plan", "Could not read the configured values: "+err.Error())
+		return
+	}
+
+	restorable := map[string]tftypes.Value{}
+	for name, planValue := range plan {
+		if planValue.Equal(state[name]) {
+			continue
+		}
+		// Same test the framework used to mark it: unknown in the plan, null
+		// in the config. An attribute wired to another resource's unknown
+		// output fails this and stays unknown.
+		if !planValue.IsKnown() && config[name].IsNull() {
+			restorable[name] = state[name]
+			continue
+		}
+		// A real change. Leave the whole plan as it is.
+		return
+	}
+
+	if len(restorable) == 0 {
+		return
+	}
+
+	for name, stateValue := range restorable {
+		plan[name] = stateValue
+	}
+	resp.Plan.Raw = tftypes.NewValue(req.Plan.Raw.Type(), plan)
 }
 
 // Configure adds the provider configured client to the resource.

--- a/internal/provider/mcr_resource_modify_plan_test.go
+++ b/internal/provider/mcr_resource_modify_plan_test.go
@@ -1,0 +1,243 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// mcrComputedWithoutModifier lists the Computed attributes on megaport_mcr that
+// carry no plan modifier, so the framework marks each one unknown whenever the
+// plan differs from prior state. Removing the deprecated prefix_filter_lists
+// attribute from a configuration is enough to trigger that.
+var mcrComputedWithoutModifier = []string{
+	"aggregation_id",
+	"attribute_tags",
+	"cancelable",
+	"company_name",
+	"contract_end_date",
+	"contract_start_date",
+	"lag_id",
+	"lag_primary",
+	"last_updated",
+	"live_date",
+	"provisioning_status",
+	"terminate_date",
+}
+
+// mcrSchemaObjectType returns the megaport_mcr schema as a tftypes object.
+func mcrSchemaObjectType(t *testing.T, ctx context.Context, r *mcrResource) (tfsdk.State, tftypes.Object) {
+	t.Helper()
+
+	schemaResp := fwresource.SchemaResponse{}
+	r.Schema(ctx, fwresource.SchemaRequest{}, &schemaResp)
+
+	objType, ok := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema type is not tftypes.Object")
+	}
+	return tfsdk.State{Schema: schemaResp.Schema}, objType
+}
+
+// mcrPriorStateAttrs builds a prior state holding a value for every attribute
+// the fix has to restore, plus the identifying attributes around them.
+func mcrPriorStateAttrs(objType tftypes.Object) map[string]tftypes.Value {
+	attrs := nullValueMap(objType)
+	attrs["product_uid"] = tftypes.NewValue(tftypes.String, "mcr-uid-1")
+	attrs["product_name"] = tftypes.NewValue(tftypes.String, "mcr-one")
+	attrs["cost_centre"] = tftypes.NewValue(tftypes.String, "cc-1")
+	attrs["aggregation_id"] = tftypes.NewValue(tftypes.Number, 7)
+	attrs["attribute_tags"] = tftypes.NewValue(objType.AttributeTypes["attribute_tags"], map[string]tftypes.Value{
+		"env": tftypes.NewValue(tftypes.String, "prod"),
+	})
+	attrs["cancelable"] = tftypes.NewValue(tftypes.Bool, true)
+	attrs["company_name"] = tftypes.NewValue(tftypes.String, "Test Company")
+	attrs["contract_end_date"] = tftypes.NewValue(tftypes.String, "2027-09-01")
+	attrs["contract_start_date"] = tftypes.NewValue(tftypes.String, "2026-09-01")
+	attrs["lag_id"] = tftypes.NewValue(tftypes.Number, 0)
+	attrs["lag_primary"] = tftypes.NewValue(tftypes.Bool, false)
+	attrs["last_updated"] = tftypes.NewValue(tftypes.String, "Monday, 08-Sep-26 09:00:00 UTC")
+	attrs["live_date"] = tftypes.NewValue(tftypes.String, "2026-09-01")
+	attrs["provisioning_status"] = tftypes.NewValue(tftypes.String, "LIVE")
+	attrs["terminate_date"] = tftypes.NewValue(tftypes.String, "")
+	return attrs
+}
+
+// copyAttrs returns a shallow copy so a case can diverge from prior state
+// without disturbing the others.
+func copyAttrs(src map[string]tftypes.Value) map[string]tftypes.Value {
+	dst := make(map[string]tftypes.Value, len(src))
+	for name, value := range src {
+		dst[name] = value
+	}
+	return dst
+}
+
+// markUnknown sets each named attribute to unknown, which is what the framework
+// does to a Computed attribute the configuration leaves null.
+func markUnknown(attrs map[string]tftypes.Value, objType tftypes.Object, names ...string) {
+	for _, name := range names {
+		attrs[name] = tftypes.NewValue(objType.AttributeTypes[name], tftypes.UnknownValue)
+	}
+}
+
+// TestMCRResourceModifyPlan_ConvergesMigrationDrift covers the reported bug.
+// A plan whose only content is the unknowns left behind by removing
+// prefix_filter_lists has to come back equal to prior state, so Terraform
+// reports no changes.
+func TestMCRResourceModifyPlan_ConvergesMigrationDrift(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &mcrResource{}
+	base, objType := mcrSchemaObjectType(t, ctx, r)
+
+	stateAttrs := mcrPriorStateAttrs(objType)
+	stateVal := tftypes.NewValue(objType, stateAttrs)
+
+	planAttrs := copyAttrs(stateAttrs)
+	markUnknown(planAttrs, objType, mcrComputedWithoutModifier...)
+	planVal := tftypes.NewValue(objType, planAttrs)
+
+	// The configuration no longer sets prefix_filter_lists, and never set any
+	// of the twelve, so all of them are null here.
+	configAttrs := nullValueMap(objType)
+	configAttrs["product_name"] = tftypes.NewValue(tftypes.String, "mcr-one")
+	configAttrs["cost_centre"] = tftypes.NewValue(tftypes.String, "cc-1")
+	configVal := tftypes.NewValue(objType, configAttrs)
+
+	plan := tfsdk.Plan{Schema: base.Schema, Raw: planVal}
+	req := fwresource.ModifyPlanRequest{
+		Config: tfsdk.Config{Schema: base.Schema, Raw: configVal},
+		State:  tfsdk.State{Schema: base.Schema, Raw: stateVal},
+		Plan:   plan,
+	}
+	resp := fwresource.ModifyPlanResponse{Plan: plan}
+
+	r.ModifyPlan(ctx, req, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected no errors, got: %v", resp.Diagnostics.Errors())
+	}
+	if !resp.Plan.Raw.Equal(stateVal) {
+		t.Errorf("expected the plan to converge to prior state, got: %v", resp.Plan.Raw)
+	}
+}
+
+// TestMCRResourceModifyPlan_KeepsUnknownsOnRealChange guards the other half.
+// Update writes a fresh last_updated and reads the rest back from the API, so a
+// plan that carries a real change has to leave every unknown alone.
+func TestMCRResourceModifyPlan_KeepsUnknownsOnRealChange(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &mcrResource{}
+	base, objType := mcrSchemaObjectType(t, ctx, r)
+
+	stateAttrs := mcrPriorStateAttrs(objType)
+	stateVal := tftypes.NewValue(objType, stateAttrs)
+
+	tests := []struct {
+		name   string
+		mutate func(planAttrs, configAttrs map[string]tftypes.Value)
+	}{
+		{
+			// The AC case: renaming an MCR must still show last_updated and
+			// provisioning_status as changing.
+			name: "product_name changed",
+			mutate: func(planAttrs, configAttrs map[string]tftypes.Value) {
+				renamed := tftypes.NewValue(tftypes.String, "mcr-renamed")
+				planAttrs["product_name"] = renamed
+				configAttrs["product_name"] = renamed
+			},
+		},
+		{
+			// cost_centre is Optional and Computed. Sourcing it from a resource
+			// that has not applied yet leaves it unknown in the configuration,
+			// which is not the framework's null-config marking.
+			name: "cost_centre unknown in config",
+			mutate: func(planAttrs, configAttrs map[string]tftypes.Value) {
+				planAttrs["cost_centre"] = tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+				configAttrs["cost_centre"] = tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			planAttrs := copyAttrs(stateAttrs)
+			markUnknown(planAttrs, objType, mcrComputedWithoutModifier...)
+
+			configAttrs := nullValueMap(objType)
+			configAttrs["product_name"] = tftypes.NewValue(tftypes.String, "mcr-one")
+			configAttrs["cost_centre"] = tftypes.NewValue(tftypes.String, "cc-1")
+
+			tc.mutate(planAttrs, configAttrs)
+			planVal := tftypes.NewValue(objType, planAttrs)
+
+			plan := tfsdk.Plan{Schema: base.Schema, Raw: planVal}
+			req := fwresource.ModifyPlanRequest{
+				Config: tfsdk.Config{Schema: base.Schema, Raw: tftypes.NewValue(objType, configAttrs)},
+				State:  tfsdk.State{Schema: base.Schema, Raw: stateVal},
+				Plan:   plan,
+			}
+			resp := fwresource.ModifyPlanResponse{Plan: plan}
+
+			r.ModifyPlan(ctx, req, &resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("expected no errors, got: %v", resp.Diagnostics.Errors())
+			}
+			if !resp.Plan.Raw.Equal(planVal) {
+				t.Errorf("expected the plan to be left alone, got: %v", resp.Plan.Raw)
+			}
+		})
+	}
+}
+
+// TestMCRResourceModifyPlan_SkipsCreateAndDestroy checks the two walks that
+// have nothing to restore.
+func TestMCRResourceModifyPlan_SkipsCreateAndDestroy(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &mcrResource{}
+	base, objType := mcrSchemaObjectType(t, ctx, r)
+
+	populated := tftypes.NewValue(objType, mcrPriorStateAttrs(objType))
+	null := tftypes.NewValue(objType, nil)
+
+	tests := []struct {
+		name  string
+		state tftypes.Value
+		plan  tftypes.Value
+	}{
+		{"create has no prior state", null, populated},
+		{"destroy has no plan", populated, null},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			plan := tfsdk.Plan{Schema: base.Schema, Raw: tc.plan}
+			req := fwresource.ModifyPlanRequest{
+				Config: tfsdk.Config{Schema: base.Schema, Raw: tftypes.NewValue(objType, nullValueMap(objType))},
+				State:  tfsdk.State{Schema: base.Schema, Raw: tc.state},
+				Plan:   plan,
+			}
+			resp := fwresource.ModifyPlanResponse{Plan: plan}
+
+			r.ModifyPlan(ctx, req, &resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("expected no errors, got: %v", resp.Diagnostics.Errors())
+			}
+			if !resp.Plan.Raw.Equal(tc.plan) {
+				t.Errorf("expected the plan to be left alone, got: %v", resp.Plan.Raw)
+			}
+		})
+	}
+}

--- a/internal/provider/mcr_resource_test.go
+++ b/internal/provider/mcr_resource_test.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccMegaportMCR_Basic(t *testing.T) {
@@ -769,6 +771,153 @@ func TestAccMegaportMCR_UpdateASN(t *testing.T) {
 				Config:             configNoASN,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// mcrComputedFromAPI lists the attributes fromAPIMCR rewrites from the API
+// response on every read. The migration plan marks all of them unknown, so a
+// converged plan has to leave each one populated. attribute_tags is left out:
+// fromAPIMCR leaves that map alone when the API sends no tags, so state can
+// hold a null there.
+var mcrComputedFromAPI = []string{
+	"aggregation_id",
+	"cancelable",
+	"company_name",
+	"contract_end_date",
+	"contract_start_date",
+	"lag_id",
+	"lag_primary",
+	"last_updated",
+	"live_date",
+	"provisioning_status",
+	"terminate_date",
+}
+
+// checkMCRComputedPresent asserts every attribute in mcrComputedFromAPI is in
+// state. An MCR with no live date reads back an empty one, so presence is the
+// check here, not a non-empty value. TestCheckResourceAttrSet rejects both.
+func checkMCRComputedPresent(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("%s not found in state", name)
+		}
+		for _, attribute := range mcrComputedFromAPI {
+			if _, ok := rs.Primary.Attributes[attribute]; !ok {
+				return fmt.Errorf("%s: %s is missing from state", name, attribute)
+			}
+		}
+		return nil
+	}
+}
+
+// TestAccMegaportMCR_InlinePrefixListMigration covers GitHub issue #450. An MCR
+// that drops the deprecated prefix_filter_lists attribute has to plan clean
+// afterwards, with no lifecycle block in the configuration.
+func TestAccMegaportMCR_InlinePrefixListMigration(t *testing.T) {
+	t.Parallel()
+	defer acquireAccTestSlot(t)()
+	locationID, _ := findMCRTestLocation(t, 1000)
+	mcrName := RandomTestName()
+	mcrNameRenamed := RandomTestName()
+	prefixFilterName := RandomTestName()
+	costCentreName := RandomTestName()
+
+	withInlineList := providerConfig + fmt.Sprintf(`
+	data "megaport_location" "test_location" {
+		id = %d
+	}
+
+	resource "megaport_mcr" "mcr" {
+		product_name         = "%s"
+		port_speed           = 1000
+		location_id          = data.megaport_location.test_location.id
+		contract_term_months = 12
+		cost_centre          = "%s"
+
+		prefix_filter_lists = [{
+			description    = "%s"
+			address_family = "IPv4"
+			entries = [{
+				action = "permit"
+				prefix = "10.0.1.0/24"
+				ge     = 25
+				le     = 32
+			}]
+		}]
+	}
+	`, locationID, mcrName, costCentreName, prefixFilterName)
+
+	// The migrated configuration. No prefix_filter_lists, no lifecycle block,
+	// and no empty list either.
+	migrated := func(name string) string {
+		return providerConfig + fmt.Sprintf(`
+	data "megaport_location" "test_location" {
+		id = %d
+	}
+
+	resource "megaport_mcr" "mcr" {
+		product_name         = "%s"
+		port_speed           = 1000
+		location_id          = data.megaport_location.test_location.id
+		contract_term_months = 12
+		cost_centre          = "%s"
+	}
+	`, locationID, name, costCentreName)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// The inline attribute still works, and a create populates every
+			// computed attribute the migration plan later marks unknown.
+			{
+				Config: withInlineList,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_mcr.mcr", "prefix_filter_lists.#", "1"),
+					resource.TestCheckResourceAttr("megaport_mcr.mcr", "prefix_filter_lists.0.description", prefixFilterName),
+					resource.TestCheckResourceAttrSet("megaport_mcr.mcr", "provisioning_status"),
+					resource.TestCheckResourceAttrSet("megaport_mcr.mcr", "company_name"),
+					resource.TestCheckResourceAttrSet("megaport_mcr.mcr", "last_updated"),
+					checkMCRComputedPresent("megaport_mcr.mcr"),
+				),
+			},
+			// Dropping the attribute converges. The test framework plans after
+			// every apply and fails the step on a non-empty plan, so this step
+			// is the regression guard for the reported bug.
+			{
+				Config: migrated(mcrName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_mcr.mcr", "product_name", mcrName),
+					resource.TestCheckResourceAttr("megaport_mcr.mcr", "prefix_filter_lists.#", "1"),
+					checkMCRComputedPresent("megaport_mcr.mcr"),
+				),
+			},
+			// The next two plans stay empty as well.
+			{
+				Config:   migrated(mcrName),
+				PlanOnly: true,
+			},
+			{
+				Config:   migrated(mcrName),
+				PlanOnly: true,
+			},
+			// A real change still refreshes the computed attributes. Pinning
+			// them here would fail the apply with an inconsistent result.
+			{
+				Config: migrated(mcrNameRenamed),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectUnknownValue("megaport_mcr.mcr", tfjsonpath.New("last_updated")),
+						plancheck.ExpectUnknownValue("megaport_mcr.mcr", tfjsonpath.New("provisioning_status")),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_mcr.mcr", "product_name", mcrNameRenamed),
+					checkMCRComputedPresent("megaport_mcr.mcr"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
### User-Facing Summary

Migrating an MCR off the deprecated inline `prefix_filter_lists` attribute left the plan churning forever. Once the attribute came out of the configuration, every `terraform plan` proposed an in-place update of the same twelve computed attributes, apply wrote the same values back, and the next plan repeated. The plan never named `prefix_filter_lists`, so there was nothing to point at.

Removing an Optional+Computed nested attribute makes Terraform core propose `null` for it. The framework reads that as a change and marks every Computed attribute with a null config value as unknown. It does that before any plan modifier runs, so no modifier on `prefix_filter_lists` can prevent it.

- Give `megaport_mcr` a `ModifyPlan` method that restores prior state for those attributes, but only when the plan holds no other change.
- A real change leaves every unknown alone, so an update still refreshes `last_updated` and the API-sourced fields.

The documented `lifecycle { ignore_changes = [prefix_filter_lists] }` workaround still works, and becomes optional.

**Scope of change:** customer-facing (plan behavior for every `megaport_mcr` user). Covered by three new unit tests and one new acceptance test; acceptance tests do not run in CI.

**What I could not verify:** the two guard unit tests (`KeepsUnknownsOnRealChange`, `SkipsCreateAndDestroy`) pass with or without the fix, since they assert the plan is left alone. Only `ConvergesMigrationDrift` and the acceptance test fail on `main`.

**Other resources:** `megaport_port` and `megaport_lag_port` don't have the trigger. Their only nested attribute, `resources`, is Computed-only, so it can't be removed from a configuration. `megaport_mve` does: `vnics` is Optional+Computed with a Required child, the same shape as `prefix_filter_lists`, and seven of its computed attributes carry no modifier. ENG-35420 covers it, and lifts this loop into a shared helper rather than copying it.

---

### Type of Change

- [ ] 🚀 New Feature
- [ ] ✨ Enhancement
- [x] 🐛 Bug Fix
- [ ] 📚 Documentation Update
- [ ] 🏗️ Chore / Other

---

### Related Issues

Fixes #450. Jira: ENG-35395.

---

### How to Test

Unit tests, no credentials needed:

```
go test -v -run TestMCRResourceModifyPlan ./internal/provider/
```

Acceptance test, needs credentials:

```
TF_ACC=1 go test -v -timeout=40m -run TestAccMegaportMCR_InlinePrefixListMigration ./internal/provider/
```

By hand: apply an MCR with an inline `prefix_filter_lists` block, remove the block, then plan. Before this change the plan proposes an update of twelve computed attributes and never settles. After it, the plan is empty.

---


