### PR TITLE
ENG-35426: Rename the off-convention provider acceptance tests

### DIFF
--- a/internal/provider/location_data_source_test.go
+++ b/internal/provider/location_data_source_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestDynamicLocation(t *testing.T) {
+func TestAccMegaportLocation_Dynamic(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()
 	locID := findAnyActiveLocationID(t)

--- a/internal/provider/vxc_resource_test.go
+++ b/internal/provider/vxc_resource_test.go
@@ -1474,7 +1474,7 @@ func TestAccMegaportMCRVXCWithBGP_Basic(t *testing.T) {
 	})
 }
 
-func TestGCPVXCWithProductUID(t *testing.T) {
+func TestAccMegaportVXC_GCPProductUID(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()
 	gcp := pickGCPPairingKey(t)
@@ -1531,7 +1531,7 @@ func TestGCPVXCWithProductUID(t *testing.T) {
 	})
 }
 
-func TestOracleVXCWithProductUID(t *testing.T) {
+func TestAccMegaportOracleVXCWithProductUID(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()
 	locs := findVXCPortAndMCRTestLocations(t, 1, 2500)
@@ -1598,7 +1598,7 @@ func TestOracleVXCWithProductUID(t *testing.T) {
 	})
 }
 
-func TestAzureVXCWithProductUID(t *testing.T) {
+func TestAccMegaportVXC_AzureProductUID(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()
 	azure := pickAzureServiceKey(t)
@@ -1780,7 +1780,7 @@ func TestAccMegaportMCRVXC_BEndIpMtu(t *testing.T) {
 	})
 }
 
-func TestFullEcosystem(t *testing.T) {
+func TestAccMegaportFullEcosystem_Basic(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()
 	// loc1 hosts the MCR (2500 Mbps) + LAG port; loc2 needs AWS partner ports; loc3 is unused.
@@ -2114,7 +2114,7 @@ func TestAccMegaportOracleVXC_Basic(t *testing.T) {
 	})
 }
 
-func TestMVE_TransitVXC(t *testing.T) {
+func TestAccMegaportMVETransit_VXC(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()
 	// The MVE and the TRANSIT partner port must share a region, so claim one
@@ -2212,7 +2212,7 @@ func TestMVE_TransitVXC(t *testing.T) {
 	})
 }
 
-func TestMVE_TransitVXCAWS(t *testing.T) {
+func TestAccMegaportMVETransit_VXCAWS(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()
 	// loc1 hosts the MVE (needs MVE capacity); loc2 needs both AWS and TRANSIT partner ports.
@@ -2582,7 +2582,7 @@ func TestMVE_TransitVXCAWS(t *testing.T) {
 	})
 }
 
-func TestMVE_AWS_VXC(t *testing.T) {
+func TestAccMegaportMVEAWS_VXC(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()
 	mveLocID, _ := findMVETestLocation(t, 0)


### PR DESCRIPTION
### User-Facing Summary

No user-facing change. Renames eight acceptance test functions in `internal/provider/` to the `TestAccMegaport` convention, so the matrix harness in `terraform-provider-acceptance-ci` can pattern-match them.

### Type of Change

- [x] 🏗️ Chore / Other

### Related Issues

ENG-35426. Unblocks ENG-35427 (adopt into the matrix).

### How to Test

```
GOWORK=off go build ./... && GOWORK=off go vet ./...
GOWORK=off go test -v -timeout=30m -cover ./internal/provider/
GOWORK=off golangci-lint run --timeout=10m
```

---

Eight tests carried names that missed the `TestAccMegaport` prefix, so no matrix pattern in the harness could reach them. Renamed per the table in ENG-35426. Nothing about what the tests assert changed.

**Scope of change:** not customer-facing. Existing build/vet/unit/lint coverage fully exercises this, a pure rename.

**What I could not verify:** the companion harness-repo edit (retiring these seven lines from `cmd/coverage/exclusions.txt` and rewording the Oracle one) is blocked. That file only exists on the still-open ENG-35413 branch (`terraform-provider-acceptance-ci` PR #21), not on its `main`. I'll open that companion PR once ENG-35413 merges.