### PR TITLE
ENG-35346: Pin the harness ref when dispatching acceptance runs

### DIFF
--- a/.github/workflows/acceptance-label.yaml
+++ b/.github/workflows/acceptance-label.yaml
@@ -82,7 +82,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.harness-token.outputs.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: gh workflow run acceptance.yml -R "$HARNESS" -f provider_ref="$HEAD_SHA" -f pr_number="$PR"
+        # Without --ref, gh resolves the harness default branch over GraphQL,
+        # which needs contents:read that this token deliberately lacks.
+        run: gh workflow run acceptance.yml -R "$HARNESS" --ref main -f provider_ref="$HEAD_SHA" -f pr_number="$PR"
 
       # Removing the label turns it back into a button for the next push.
       - name: Remove the label


### PR DESCRIPTION
The `acceptance` label on #387 failed at the dispatch step: `gh workflow run` with no `--ref` looks up the harness default branch over GraphQL, and that field needs `contents:read`. The App token deliberately carries only `actions:write` and `metadata:read`.

- Pass `--ref main` to `gh workflow run` so the lookup never happens.
- No token permission change. Every other call on the path (`ResolveWorkflow`, the dispatch POST) is REST under `actions`, which the earlier cancel step already proved works.

**Scope of change:** not customer-facing. No automated coverage; `pull_request_target` reads this workflow from `main`, so the check is to merge and re-label #387.

Failing run: https://github.com/megaport/terraform-provider-megaport/actions/runs/34541211482