### PR TITLE
ENG-35420: Converge the megaport_mve plan after vnics is removed

### DIFF
--- a/internal/provider/mcr_resource.go
+++ b/internal/provider/mcr_resource.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	megaport "github.com/megaport/megaportgo"
 )
 
@@ -1263,56 +1262,15 @@ func (r *mcrResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	}
 }
 
-// ModifyPlan converges a plan whose only content is unknowns. Removing the
-// deprecated prefix_filter_lists attribute makes the framework mark every
-// Computed attribute with a null config value as unknown, and it does that
-// before any plan modifier runs. Restoring prior state here is the only place
-// left. A real change anywhere skips the restore: Update rewrites those
-// attributes, so pinning them would fail the apply with an inconsistent result.
+// ModifyPlan converges a plan whose only content is the unknowns left behind
+// by removing the deprecated prefix_filter_lists attribute.
 func (r *mcrResource) ModifyPlan(_ context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	// Nothing to restore when creating (no prior state) or destroying (no plan).
-	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+	restored, err := restoreComputedOnNoOpPlan(req.Plan.Raw, req.State.Raw, req.Config.Raw)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Modifying MCR Plan", err.Error())
 		return
 	}
-
-	var plan, state, config map[string]tftypes.Value
-	if err := req.Plan.Raw.As(&plan); err != nil {
-		resp.Diagnostics.AddError("Error Modifying MCR Plan", "Could not read the planned values: "+err.Error())
-		return
-	}
-	if err := req.State.Raw.As(&state); err != nil {
-		resp.Diagnostics.AddError("Error Modifying MCR Plan", "Could not read the prior state values: "+err.Error())
-		return
-	}
-	if err := req.Config.Raw.As(&config); err != nil {
-		resp.Diagnostics.AddError("Error Modifying MCR Plan", "Could not read the configured values: "+err.Error())
-		return
-	}
-
-	restorable := map[string]tftypes.Value{}
-	for name, planValue := range plan {
-		if planValue.Equal(state[name]) {
-			continue
-		}
-		// Same test the framework used to mark it: unknown in the plan, null
-		// in the config. An attribute wired to another resource's unknown
-		// output fails this and stays unknown.
-		if !planValue.IsKnown() && config[name].IsNull() {
-			restorable[name] = state[name]
-			continue
-		}
-		// A real change. Leave the whole plan as it is.
-		return
-	}
-
-	if len(restorable) == 0 {
-		return
-	}
-
-	for name, stateValue := range restorable {
-		plan[name] = stateValue
-	}
-	resp.Plan.Raw = tftypes.NewValue(req.Plan.Raw.Type(), plan)
+	resp.Plan.Raw = restored
 }
 
 // Configure adds the provider configured client to the resource.

--- a/internal/provider/modify_plan_utils.go
+++ b/internal/provider/modify_plan_utils.go
@@ -1,0 +1,57 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// restoreComputedOnNoOpPlan converges a plan whose only content is unknowns.
+// Removing an Optional+Computed nested attribute from a configuration makes the
+// framework mark every Computed attribute with a null config value as unknown,
+// and it does that before any plan modifier runs. Restoring prior state here is
+// the only place left. A real change anywhere returns the plan untouched:
+// Update rewrites those attributes, so pinning them would fail the apply with
+// an inconsistent result.
+func restoreComputedOnNoOpPlan(plan, state, config tftypes.Value) (tftypes.Value, error) {
+	// Nothing to restore when creating (no prior state) or destroying (no plan).
+	if state.IsNull() || plan.IsNull() {
+		return plan, nil
+	}
+
+	var planAttrs, stateAttrs, configAttrs map[string]tftypes.Value
+	if err := plan.As(&planAttrs); err != nil {
+		return plan, fmt.Errorf("could not read the planned values: %w", err)
+	}
+	if err := state.As(&stateAttrs); err != nil {
+		return plan, fmt.Errorf("could not read the prior state values: %w", err)
+	}
+	if err := config.As(&configAttrs); err != nil {
+		return plan, fmt.Errorf("could not read the configured values: %w", err)
+	}
+
+	restorable := map[string]tftypes.Value{}
+	for name, planValue := range planAttrs {
+		if planValue.Equal(stateAttrs[name]) {
+			continue
+		}
+		// Same test the framework used to mark it: unknown in the plan, null
+		// in the config. An attribute wired to another resource's unknown
+		// output fails this and stays unknown.
+		if !planValue.IsKnown() && configAttrs[name].IsNull() {
+			restorable[name] = stateAttrs[name]
+			continue
+		}
+		// A real change. Leave the whole plan as it is.
+		return plan, nil
+	}
+
+	if len(restorable) == 0 {
+		return plan, nil
+	}
+
+	for name, stateValue := range restorable {
+		planAttrs[name] = stateValue
+	}
+	return tftypes.NewValue(plan.Type(), planAttrs), nil
+}

--- a/internal/provider/mve_resource.go
+++ b/internal/provider/mve_resource.go
@@ -32,6 +32,7 @@ var (
 	_ resource.Resource                = &mveResource{}
 	_ resource.ResourceWithConfigure   = &mveResource{}
 	_ resource.ResourceWithImportState = &mveResource{}
+	_ resource.ResourceWithModifyPlan  = &mveResource{}
 
 	vnicAttrs = map[string]attr.Type{
 		"description": types.StringType,
@@ -1092,6 +1093,10 @@ func (r *mveResource) ImportState(ctx context.Context, req resource.ImportStateR
 }
 
 func (r *mveResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// The vendor_config branch below writes back into req.State, so hold the
+	// real prior state for the restore at the end of this method.
+	priorState := req.State.Raw
+
 	// Get the plan and state
 	var plan, state mveResourceModel
 	if !req.Plan.Raw.IsNull() {
@@ -1175,4 +1180,13 @@ func (r *mveResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 			return
 		}
 	}
+
+	// Removing vnics from a configuration leaves the seven Computed attributes
+	// without a plan modifier marked unknown, which plans an update forever.
+	restored, err := restoreComputedOnNoOpPlan(req.Plan.Raw, priorState, req.Config.Raw)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Modifying MVE Plan", err.Error())
+		return
+	}
+	resp.Plan.Raw = restored
 }

--- a/internal/provider/mve_resource_modify_plan_test.go
+++ b/internal/provider/mve_resource_modify_plan_test.go
@@ -1,0 +1,288 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// mveComputedWithoutModifier lists the Computed attributes on megaport_mve that
+// carry no plan modifier, so the framework marks each one unknown whenever the
+// plan differs from prior state. Removing the vnics attribute from a
+// configuration is enough to trigger that.
+var mveComputedWithoutModifier = []string{
+	"contract_end_date",
+	"contract_start_date",
+	"cost_centre",
+	"last_updated",
+	"live_date",
+	"provisioning_status",
+	"terminate_date",
+}
+
+// mveSchemaObjectType returns the megaport_mve schema as a tftypes object.
+func mveSchemaObjectType(t *testing.T, ctx context.Context, r *mveResource) (tfsdk.State, tftypes.Object) {
+	t.Helper()
+
+	schemaResp := fwresource.SchemaResponse{}
+	r.Schema(ctx, fwresource.SchemaRequest{}, &schemaResp)
+
+	objType, ok := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema type is not tftypes.Object")
+	}
+	return tfsdk.State{Schema: schemaResp.Schema}, objType
+}
+
+// mveVendorConfig builds the Required vendor_config object. Every plan, state
+// and configuration in these tests carries one.
+func mveVendorConfig(t *testing.T, objType tftypes.Object, productSize string) tftypes.Value {
+	t.Helper()
+
+	vcType, ok := objType.AttributeTypes["vendor_config"].(tftypes.Object)
+	if !ok {
+		t.Fatal("vendor_config is not tftypes.Object")
+	}
+	attrs := nullValueMap(vcType)
+	attrs["vendor"] = tftypes.NewValue(tftypes.String, "cisco")
+	attrs["image_id"] = tftypes.NewValue(tftypes.Number, 42)
+	attrs["product_size"] = tftypes.NewValue(tftypes.String, productSize)
+	return tftypes.NewValue(vcType, attrs)
+}
+
+// mveVnics builds the two-element vnics list the removal case starts from.
+func mveVnics(t *testing.T, objType tftypes.Object) tftypes.Value {
+	t.Helper()
+
+	listType, ok := objType.AttributeTypes["vnics"].(tftypes.List)
+	if !ok {
+		t.Fatal("vnics is not tftypes.List")
+	}
+	elemType := listType.ElementType
+	return tftypes.NewValue(listType, []tftypes.Value{
+		tftypes.NewValue(elemType, map[string]tftypes.Value{
+			"description": tftypes.NewValue(tftypes.String, "Data Plane"),
+			"vlan":        tftypes.NewValue(tftypes.Number, 0),
+		}),
+		tftypes.NewValue(elemType, map[string]tftypes.Value{
+			"description": tftypes.NewValue(tftypes.String, "Control Plane"),
+			"vlan":        tftypes.NewValue(tftypes.Number, 0),
+		}),
+	})
+}
+
+// mvePriorStateAttrs builds a prior state holding a value for every attribute
+// the fix has to restore, plus the identifying attributes around them.
+func mvePriorStateAttrs(t *testing.T, objType tftypes.Object) map[string]tftypes.Value {
+	t.Helper()
+
+	attrs := nullValueMap(objType)
+	attrs["product_uid"] = tftypes.NewValue(tftypes.String, "mve-uid-1")
+	attrs["product_name"] = tftypes.NewValue(tftypes.String, "mve-one")
+	attrs["location_id"] = tftypes.NewValue(tftypes.Number, 5)
+	attrs["contract_term_months"] = tftypes.NewValue(tftypes.Number, 12)
+	// The API uppercases both, the configuration below sends them lowercase.
+	attrs["vendor"] = tftypes.NewValue(tftypes.String, "CISCO")
+	attrs["mve_size"] = tftypes.NewValue(tftypes.String, "SMALL")
+	attrs["vendor_config"] = mveVendorConfig(t, objType, "SMALL")
+	attrs["vnics"] = mveVnics(t, objType)
+	attrs["contract_end_date"] = tftypes.NewValue(tftypes.String, "2027-09-01")
+	attrs["contract_start_date"] = tftypes.NewValue(tftypes.String, "2026-09-01")
+	attrs["cost_centre"] = tftypes.NewValue(tftypes.String, "cc-1")
+	attrs["last_updated"] = tftypes.NewValue(tftypes.String, "Monday, 08-Sep-26 09:00:00 UTC")
+	attrs["live_date"] = tftypes.NewValue(tftypes.String, "2026-09-01")
+	attrs["provisioning_status"] = tftypes.NewValue(tftypes.String, "LIVE")
+	attrs["terminate_date"] = tftypes.NewValue(tftypes.String, "")
+	return attrs
+}
+
+// mveConfigAttrs builds the configuration left after vnics is deleted. The
+// seven restorable attributes are null here, which is what makes the framework
+// mark them unknown.
+func mveConfigAttrs(t *testing.T, objType tftypes.Object) map[string]tftypes.Value {
+	t.Helper()
+
+	attrs := nullValueMap(objType)
+	attrs["product_name"] = tftypes.NewValue(tftypes.String, "mve-one")
+	attrs["location_id"] = tftypes.NewValue(tftypes.Number, 5)
+	attrs["contract_term_months"] = tftypes.NewValue(tftypes.Number, 12)
+	attrs["vendor_config"] = mveVendorConfig(t, objType, "SMALL")
+	return attrs
+}
+
+// TestMVEResourceModifyPlan_ConvergesVnicsRemoval covers the reported bug. A
+// plan whose only content is the unknowns left by removing vnics has to come
+// back equal to prior state, so Terraform reports no changes.
+func TestMVEResourceModifyPlan_ConvergesVnicsRemoval(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &mveResource{}
+	base, objType := mveSchemaObjectType(t, ctx, r)
+
+	stateAttrs := mvePriorStateAttrs(t, objType)
+	stateVal := tftypes.NewValue(objType, stateAttrs)
+
+	// vnics carries UseStateForUnknown, so by the time the resource-level
+	// method runs it already holds prior state again. The seven below do not.
+	planAttrs := copyAttrs(stateAttrs)
+	markUnknown(planAttrs, objType, mveComputedWithoutModifier...)
+	planVal := tftypes.NewValue(objType, planAttrs)
+
+	configVal := tftypes.NewValue(objType, mveConfigAttrs(t, objType))
+
+	plan := tfsdk.Plan{Schema: base.Schema, Raw: planVal}
+	req := fwresource.ModifyPlanRequest{
+		Config: tfsdk.Config{Schema: base.Schema, Raw: configVal},
+		State:  tfsdk.State{Schema: base.Schema, Raw: stateVal},
+		Plan:   plan,
+	}
+	resp := fwresource.ModifyPlanResponse{Plan: plan}
+
+	r.ModifyPlan(ctx, req, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected no errors, got: %v", resp.Diagnostics.Errors())
+	}
+	if len(resp.RequiresReplace) != 0 {
+		t.Errorf("expected no replacement, got: %v", resp.RequiresReplace)
+	}
+	if !resp.Plan.Raw.Equal(stateVal) {
+		t.Errorf("expected the plan to converge to prior state, got: %v", resp.Plan.Raw)
+	}
+}
+
+// TestMVEResourceModifyPlan_KeepsUnknownsOnRealChange guards the other half.
+// Update writes a fresh last_updated and reads the rest back from the API, so a
+// plan that carries a real change has to leave every unknown alone.
+func TestMVEResourceModifyPlan_KeepsUnknownsOnRealChange(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &mveResource{}
+	base, objType := mveSchemaObjectType(t, ctx, r)
+
+	stateVal := tftypes.NewValue(objType, mvePriorStateAttrs(t, objType))
+	resizedVendorConfig := mveVendorConfig(t, objType, "MEDIUM")
+
+	tests := []struct {
+		name            string
+		mutate          func(planAttrs, configAttrs map[string]tftypes.Value)
+		requiresReplace bool
+	}{
+		{
+			// The AC case: renaming an MVE must still show last_updated and
+			// provisioning_status as changing.
+			name: "product_name changed",
+			mutate: func(planAttrs, configAttrs map[string]tftypes.Value) {
+				renamed := tftypes.NewValue(tftypes.String, "mve-renamed")
+				planAttrs["product_name"] = renamed
+				configAttrs["product_name"] = renamed
+			},
+		},
+		{
+			// cost_centre is Optional and Computed. Sourcing it from a resource
+			// that has not applied yet leaves it unknown in the configuration,
+			// which is not the framework's null-config marking.
+			name: "cost_centre unknown in config",
+			mutate: func(planAttrs, configAttrs map[string]tftypes.Value) {
+				planAttrs["cost_centre"] = tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+				configAttrs["cost_centre"] = tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+			},
+		},
+		{
+			// The size change still replaces the MVE, and the plan it replaces
+			// from keeps its unknowns.
+			name: "vendor_config size changed",
+			mutate: func(planAttrs, configAttrs map[string]tftypes.Value) {
+				planAttrs["vendor_config"] = resizedVendorConfig
+				configAttrs["vendor_config"] = resizedVendorConfig
+			},
+			requiresReplace: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			planAttrs := copyAttrs(mvePriorStateAttrs(t, objType))
+			markUnknown(planAttrs, objType, mveComputedWithoutModifier...)
+			configAttrs := mveConfigAttrs(t, objType)
+
+			tc.mutate(planAttrs, configAttrs)
+			planVal := tftypes.NewValue(objType, planAttrs)
+
+			plan := tfsdk.Plan{Schema: base.Schema, Raw: planVal}
+			req := fwresource.ModifyPlanRequest{
+				Config: tfsdk.Config{Schema: base.Schema, Raw: tftypes.NewValue(objType, configAttrs)},
+				State:  tfsdk.State{Schema: base.Schema, Raw: stateVal},
+				Plan:   plan,
+			}
+			resp := fwresource.ModifyPlanResponse{Plan: plan}
+
+			r.ModifyPlan(ctx, req, &resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("expected no errors, got: %v", resp.Diagnostics.Errors())
+			}
+			if !resp.Plan.Raw.Equal(planVal) {
+				t.Errorf("expected the plan to be left alone, got: %v", resp.Plan.Raw)
+			}
+
+			replaced := len(resp.RequiresReplace) != 0
+			if replaced != tc.requiresReplace {
+				t.Errorf("expected RequiresReplace %v, got: %v", tc.requiresReplace, resp.RequiresReplace)
+			}
+			if tc.requiresReplace && !resp.RequiresReplace.Contains(path.Root("vendor_config")) {
+				t.Errorf("expected vendor_config to require replacement, got: %v", resp.RequiresReplace)
+			}
+		})
+	}
+}
+
+// TestMVEResourceModifyPlan_SkipsCreateAndDestroy checks the two walks that
+// have nothing to restore.
+func TestMVEResourceModifyPlan_SkipsCreateAndDestroy(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &mveResource{}
+	base, objType := mveSchemaObjectType(t, ctx, r)
+
+	populated := tftypes.NewValue(objType, mvePriorStateAttrs(t, objType))
+	null := tftypes.NewValue(objType, nil)
+
+	tests := []struct {
+		name  string
+		state tftypes.Value
+		plan  tftypes.Value
+	}{
+		{"create has no prior state", null, populated},
+		{"destroy has no plan", populated, null},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			plan := tfsdk.Plan{Schema: base.Schema, Raw: tc.plan}
+			req := fwresource.ModifyPlanRequest{
+				Config: tfsdk.Config{Schema: base.Schema, Raw: tftypes.NewValue(objType, nullValueMap(objType))},
+				State:  tfsdk.State{Schema: base.Schema, Raw: tc.state},
+				Plan:   plan,
+			}
+			resp := fwresource.ModifyPlanResponse{Plan: plan}
+
+			r.ModifyPlan(ctx, req, &resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("expected no errors, got: %v", resp.Diagnostics.Errors())
+			}
+			if !resp.Plan.Raw.Equal(tc.plan) {
+				t.Errorf("expected the plan to be left alone, got: %v", resp.Plan.Raw)
+			}
+		})
+	}
+}

--- a/internal/provider/mve_resource_test.go
+++ b/internal/provider/mve_resource_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccMegaportMVEAruba_Basic(t *testing.T) {
@@ -1056,6 +1058,143 @@ func TestAccMegaportMVEPaloAlto_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("megaport_mve.mve", "product_name", mveNameNew),
 					resource.TestCheckResourceAttr("megaport_mve.mve", "cost_centre", costCentreNew),
 					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_uid"),
+				),
+			},
+		},
+	})
+}
+
+// checkMVEComputedPresent asserts every attribute in mveComputedWithoutModifier
+// is in state. An MVE with no live date reads back an empty one, so presence is
+// the check here, not a non-empty value. TestCheckResourceAttrSet rejects both.
+func checkMVEComputedPresent(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("%s not found in state", name)
+		}
+		for _, attribute := range mveComputedWithoutModifier {
+			if _, ok := rs.Primary.Attributes[attribute]; !ok {
+				return fmt.Errorf("%s: %s is missing from state", name, attribute)
+			}
+		}
+		return nil
+	}
+}
+
+// TestAccMegaportMVE_VnicsRemoval covers ENG-35420. An MVE that drops the vnics
+// attribute has to plan clean afterwards, with no lifecycle block in the
+// configuration. cost_centre is left unset throughout so it joins the six other
+// computed attributes the framework marks unknown.
+func TestAccMegaportMVE_VnicsRemoval(t *testing.T) {
+	t.Parallel()
+	defer acquireAccTestSlot(t)()
+	locationID, _ := findMVETestLocation(t, 2)
+	mveName := RandomTestName()
+	mveNameRenamed := RandomTestName()
+	mveKey := RandomTestName()
+
+	config := func(name, vnics string) string {
+		return providerConfig + fmt.Sprintf(`
+	data "megaport_location" "test_location" {
+		id = %d
+	}
+
+	data "megaport_mve_images" "aruba" {
+		vendor_filter = "Aruba"
+		id_filter     = %d
+	}
+
+	resource "megaport_mve" "mve" {
+		product_name         = "%s"
+		location_id          = data.megaport_location.test_location.id
+		contract_term_months = 1
+		diversity_zone       = "red"
+
+		vendor_config = {
+			vendor       = "aruba"
+			product_size = "SMALL"
+			mve_label    = "MVE 2/8"
+			image_id     = data.megaport_mve_images.aruba.mve_images.0.id
+			account_name = "%s"
+			account_key  = "%s"
+			system_tag   = "Preconfiguration-aruba-test-1"
+		}
+%s
+	}
+	`, locationID, MVEArubaImageID, name, mveName, mveKey, vnics)
+	}
+
+	withVnics := config(mveName, `
+		vnics = [
+			{
+				description = "Data Plane"
+			},
+			{
+				description = "Control Plane"
+			}
+		]`)
+
+	// The migrated configuration. No vnics, no lifecycle block, and no empty
+	// list either.
+	migrated := func(name string) string { return config(name, "") }
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// A create populates every computed attribute the removal plan
+			// later marks unknown.
+			{
+				Config: withVnics,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_mve.mve", "vnics.#", "2"),
+					resource.TestCheckResourceAttr("megaport_mve.mve", "vnics.0.description", "Data Plane"),
+					resource.TestCheckResourceAttr("megaport_mve.mve", "vnics.1.description", "Control Plane"),
+					resource.TestCheckResourceAttrSet("megaport_mve.mve", "product_uid"),
+					resource.TestCheckResourceAttrSet("megaport_mve.mve", "provisioning_status"),
+					resource.TestCheckResourceAttrSet("megaport_mve.mve", "last_updated"),
+					checkMVEComputedPresent("megaport_mve.mve"),
+				),
+			},
+			// Dropping vnics converges. The no-op action is what proves the MVE
+			// keeps its product_uid: a replacement would plan as Replace. The
+			// test framework then plans again after the apply and fails the
+			// step on a non-empty plan.
+			{
+				Config: migrated(mveName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("megaport_mve.mve", plancheck.ResourceActionNoop),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_mve.mve", "product_name", mveName),
+					resource.TestCheckResourceAttr("megaport_mve.mve", "vnics.#", "2"),
+					checkMVEComputedPresent("megaport_mve.mve"),
+				),
+			},
+			// The next two plans stay empty as well.
+			{
+				Config:   migrated(mveName),
+				PlanOnly: true,
+			},
+			{
+				Config:   migrated(mveName),
+				PlanOnly: true,
+			},
+			// A real change still refreshes the computed attributes. Pinning
+			// them here would fail the apply with an inconsistent result.
+			{
+				Config: migrated(mveNameRenamed),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectUnknownValue("megaport_mve.mve", tfjsonpath.New("last_updated")),
+						plancheck.ExpectUnknownValue("megaport_mve.mve", tfjsonpath.New("provisioning_status")),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("megaport_mve.mve", "product_name", mveNameRenamed),
+					checkMVEComputedPresent("megaport_mve.mve"),
 				),
 			},
 		},

--- a/internal/provider/mve_resource_test.go
+++ b/internal/provider/mve_resource_test.go
@@ -1082,11 +1082,10 @@ func checkMVEComputedPresent(name string) resource.TestCheckFunc {
 	}
 }
 
-// TestAccMegaportMVE_VnicsRemoval covers ENG-35420. An MVE that drops the vnics
-// attribute has to plan clean afterwards, with no lifecycle block in the
-// configuration. cost_centre is left unset throughout so it joins the six other
-// computed attributes the framework marks unknown.
-func TestAccMegaportMVE_VnicsRemoval(t *testing.T) {
+// An MVE that drops the vnics attribute has to plan clean afterwards, with no
+// lifecycle block in the configuration. cost_centre is left unset throughout so
+// it joins the six other computed attributes the framework marks unknown.
+func TestAccMegaportMVEAruba_VnicsRemoval(t *testing.T) {
 	t.Parallel()
 	defer acquireAccTestSlot(t)()
 	locationID, _ := findMVETestLocation(t, 2)


### PR DESCRIPTION
### User-Facing Summary

Deleting the `vnics` block from a `megaport_mve` left every plan proposing the same in-place update: `last_updated`, `provisioning_status`, `terminate_date`, `live_date`, `contract_start_date`, `contract_end_date` and `cost_centre`. Apply wrote the same values back and the next plan repeated it.

This is the ENG-35395 defect on a second resource, so it takes the same fix. The restore loop moves out of `mcrResource.ModifyPlan` into a shared helper, and `mveResource.ModifyPlan` now calls it too. A real change anywhere leaves every unknown alone, including a `vendor_config` change that already asked for a replace.

**Scope of change:** customer-facing. New unit and acceptance coverage; the existing MVE acceptance tests cover the paths this does not change.

**Caveat:** deleting the `cost_centre` line in the same edit as the `vnics` block now keeps the prior value. The drift used to overwrite it with `""`. Setting `cost_centre = ""` still clears it.

---

### Type of Change

- [ ] 🚀 New Feature
- [ ] ✨ Enhancement
- [x] 🐛 Bug Fix
- [ ] 📚 Documentation Update
- [ ] 🏗️ Chore / Other

---

### Related Issues

ENG-35420. Follows #461 (ENG-35395).

---

### How to Test

```
TF_ACC=1 go test -v -timeout=40m -run TestAccMegaportMVEAruba_VnicsRemoval ./internal/provider/
```

Or by hand: apply an MVE with two vNICs, delete the `vnics` block, then plan. The plan is empty and the MVE keeps its `product_uid`.

